### PR TITLE
feat: track and display quest progress

### DIFF
--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -12,6 +12,7 @@ import ThinkingIcon from './icons/ThinkingIcon';
 import SendIcon from './icons/SendIcon';
 import MuteIcon from './icons/MuteIcon';
 import UnmuteIcon from './icons/UnmuteIcon';
+import QuestProgressCard from './QuestProgressCard';
 
 const HISTORY_KEY = 'school-of-the-ancients-history';
 
@@ -21,6 +22,8 @@ interface ConversationViewProps {
   environmentImageUrl: string | null;
   onEnvironmentUpdate: (url: string | null) => void;
   activeQuest: Quest | null;
+  completedQuestIds: string[];
+  onCompleteQuest: (questId: string) => void;
   isSaving: boolean;
 }
 
@@ -99,13 +102,30 @@ const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifa
     );
   };
 
-const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndConversation, environmentImageUrl, onEnvironmentUpdate, activeQuest, isSaving }) => {
+const ConversationView: React.FC<ConversationViewProps> = ({
+  character,
+  onEndConversation,
+  environmentImageUrl,
+  onEnvironmentUpdate,
+  activeQuest,
+  completedQuestIds,
+  onCompleteQuest,
+  isSaving,
+}) => {
   const [transcript, setTranscript] = useState<ConversationTurn[]>([]);
   const [textInput, setTextInput] = useState('');
   const [dynamicSuggestions, setDynamicSuggestions] = useState<string[]>([]);
   const [isFetchingSuggestions, setIsFetchingSuggestions] = useState(false);
   const [isGeneratingVisual, setIsGeneratingVisual] = useState(false);
   const [generationMessage, setGenerationMessage] = useState('');
+
+  const isQuestCompleted = activeQuest ? completedQuestIds.includes(activeQuest.id) : false;
+
+  const handleQuestComplete = useCallback(() => {
+    if (activeQuest && !isQuestCompleted) {
+      onCompleteQuest(activeQuest.id);
+    }
+  }, [activeQuest, isQuestCompleted, onCompleteQuest]);
 
   const initialAudioSrc = AMBIENCE_LIBRARY.find(a => a.tag === character.ambienceTag)?.audioSrc ?? null;
   const { isMuted: isAmbienceMuted, toggleMute: toggleAmbienceMute, changeTrack: changeAmbienceTrack } = useAmbientAudio(initialAudioSrc);
@@ -507,10 +527,13 @@ ${contextTranscript}
             <p className="text-gray-400 italic">{character.title}</p>
 
             {activeQuest && (
-                <div className="mt-4 p-3 w-full max-w-xs bg-amber-900/50 border border-amber-800 rounded-lg text-center animate-fade-in">
-                    <p className="font-bold text-amber-300 text-sm">Active Quest</p>
-                    <p className="text-amber-200">{activeQuest.title}</p>
-                </div>
+              <div className="mt-4 w-full max-w-xs">
+                <QuestProgressCard
+                  quest={activeQuest}
+                  completed={isQuestCompleted}
+                  onComplete={handleQuestComplete}
+                />
+              </div>
             )}
             
             <div className="mt-6 text-left w-full max-w-xs">

--- a/components/QuestProgressCard.tsx
+++ b/components/QuestProgressCard.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import type { Quest } from '../types';
+
+interface QuestProgressCardProps {
+  quest: Quest;
+  completed: boolean;
+  onComplete: () => void;
+}
+
+const QuestProgressCard: React.FC<QuestProgressCardProps> = ({ quest, completed, onComplete }) => {
+  return (
+    <div className="animate-fade-in bg-amber-900/40 border border-amber-800/80 rounded-xl p-4 text-left shadow-lg">
+      <p className="text-xs font-semibold uppercase tracking-widest text-amber-300/80">Active Quest</p>
+      <h3 className="mt-1 text-lg font-bold text-amber-100">{quest.title}</h3>
+      <p className="mt-3 text-sm text-amber-100/80 leading-relaxed">{quest.objective}</p>
+
+      {completed ? (
+        <div className="mt-4 flex items-center gap-2 rounded-lg border border-emerald-500/60 bg-emerald-500/10 px-3 py-2 text-emerald-300 text-sm font-semibold">
+          <svg
+            className="h-4 w-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+          <span>Quest Completed</span>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={onComplete}
+          className="mt-4 w-full rounded-lg bg-amber-500/90 py-2 text-sm font-semibold text-black transition-colors duration-200 hover:bg-amber-400"
+        >
+          Mark Quest Complete
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default QuestProgressCard;

--- a/components/QuestsView.tsx
+++ b/components/QuestsView.tsx
@@ -6,11 +6,12 @@ import QuestIcon from './icons/QuestIcon';
 interface QuestsViewProps {
   quests: Quest[];
   characters: Character[];
+  completedQuestIds: string[];
   onSelectQuest: (quest: Quest) => void;
   onBack: () => void;
 }
 
-const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, onSelectQuest, onBack }) => {
+const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, completedQuestIds, onSelectQuest, onBack }) => {
   return (
     <div className="max-w-4xl mx-auto animate-fade-in">
       <div className="flex justify-between items-center mb-6">
@@ -34,18 +35,43 @@ const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, onSelectQue
           {quests.map((quest) => {
             const character = characters.find(c => c.id === quest.characterId);
             if (!character) return null;
+            const isCompleted = completedQuestIds.includes(quest.id);
 
             return (
-              <div key={quest.id} className="bg-gray-800/50 p-5 rounded-lg border border-gray-700 flex flex-col text-center hover:border-amber-400 transition-colors duration-300">
+              <div
+                key={quest.id}
+                className={`bg-gray-800/50 p-5 rounded-lg border flex flex-col text-center transition-colors duration-300 hover:border-amber-400 ${isCompleted ? 'border-emerald-500/60' : 'border-gray-700'}`}
+              >
                 <img src={character.portraitUrl} alt={character.name} className="w-24 h-24 rounded-full mx-auto mb-4 border-2 border-amber-300" />
                 <h3 className="font-bold text-xl text-amber-300">{quest.title}</h3>
                 <p className="text-sm text-gray-400 mt-1 mb-4">with {character.name}</p>
-                <p className="text-gray-300 flex-grow text-sm mb-6">{quest.description}</p>
-                <button 
-                    onClick={() => onSelectQuest(quest)} 
-                    className="mt-auto bg-amber-600 hover:bg-amber-500 text-black font-bold py-2 px-4 rounded-lg transition-colors w-full"
+                <p className="text-gray-300 flex-grow text-sm mb-3">{quest.description}</p>
+                <p className="text-xs text-amber-200/80 bg-amber-900/40 border border-amber-800/60 rounded-lg px-3 py-2 mb-4">
+                  <span className="block text-amber-300 font-semibold uppercase tracking-wide mb-1">Objective</span>
+                  <span className="block text-left text-amber-100/90">{quest.objective}</span>
+                </p>
+                {isCompleted && (
+                  <span className="mb-3 inline-flex items-center justify-center gap-2 rounded-full border border-emerald-500/60 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-300">
+                    <svg
+                      className="h-3.5 w-3.5"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                    Completed
+                  </span>
+                )}
+                <button
+                    onClick={() => onSelectQuest(quest)}
+                    className={`mt-auto font-bold py-2 px-4 rounded-lg transition-colors w-full ${isCompleted ? 'bg-amber-500/80 hover:bg-amber-400 text-black' : 'bg-amber-600 hover:bg-amber-500 text-black'}`}
                 >
-                    Begin Quest
+                    {isCompleted ? 'Revisit Quest' : 'Begin Quest'}
                 </button>
               </div>
             );


### PR DESCRIPTION
## Summary
- persist completed quest ids so finished learning quests stay highlighted across sessions
- add a quest progress card in the conversation view that exposes the objective and allows marking a quest complete
- surface quest objectives and completion badges directly on the quests grid to make status clear before joining a mentor

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db0f169d94832fbcb909a03bc1b6e2