### PR TITLE
Add detailed guidance to quests

### DIFF
--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -507,9 +507,24 @@ ${contextTranscript}
             <p className="text-gray-400 italic">{character.title}</p>
 
             {activeQuest && (
-                <div className="mt-4 p-3 w-full max-w-xs bg-amber-900/50 border border-amber-800 rounded-lg text-center animate-fade-in">
-                    <p className="font-bold text-amber-300 text-sm">Active Quest</p>
-                    <p className="text-amber-200">{activeQuest.title}</p>
+                <div className="mt-4 p-4 w-full max-w-xs bg-amber-900/40 border border-amber-800/80 rounded-lg text-left animate-fade-in space-y-3">
+                    <div>
+                        <p className="font-bold text-amber-300 text-xs uppercase tracking-wide">Active Quest</p>
+                        <p className="text-amber-100 text-lg font-semibold leading-snug">{activeQuest.title}</p>
+                        <p className="text-amber-200/80 text-xs mt-1">Estimated {activeQuest.duration}</p>
+                    </div>
+                    <div>
+                        <p className="text-amber-200 text-xs font-semibold uppercase tracking-wide mb-1">Objective</p>
+                        <p className="text-amber-50/90 text-sm leading-relaxed">{activeQuest.objective}</p>
+                    </div>
+                    <div>
+                        <p className="text-amber-200 text-xs font-semibold uppercase tracking-wide mb-1">Focus Points</p>
+                        <ul className="list-disc list-inside space-y-1 text-amber-50/80 text-sm">
+                            {activeQuest.focusPoints.map((point) => (
+                                <li key={point}>{point}</li>
+                            ))}
+                        </ul>
+                    </div>
                 </div>
             )}
             

--- a/components/QuestsView.tsx
+++ b/components/QuestsView.tsx
@@ -39,11 +39,30 @@ const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, onSelectQue
               <div key={quest.id} className="bg-gray-800/50 p-5 rounded-lg border border-gray-700 flex flex-col text-center hover:border-amber-400 transition-colors duration-300">
                 <img src={character.portraitUrl} alt={character.name} className="w-24 h-24 rounded-full mx-auto mb-4 border-2 border-amber-300" />
                 <h3 className="font-bold text-xl text-amber-300">{quest.title}</h3>
-                <p className="text-sm text-gray-400 mt-1 mb-4">with {character.name}</p>
-                <p className="text-gray-300 flex-grow text-sm mb-6">{quest.description}</p>
-                <button 
-                    onClick={() => onSelectQuest(quest)} 
-                    className="mt-auto bg-amber-600 hover:bg-amber-500 text-black font-bold py-2 px-4 rounded-lg transition-colors w-full"
+                <p className="text-sm text-gray-400 mt-1">with {character.name}</p>
+                <div className="mt-3 mb-4">
+                  <span className="inline-flex items-center justify-center px-3 py-1 rounded-full bg-amber-500/20 text-amber-200 text-xs font-semibold uppercase tracking-wide">
+                    {quest.duration}
+                  </span>
+                </div>
+                <p className="text-gray-300 text-sm mb-4">{quest.description}</p>
+                <div className="text-left text-sm text-gray-300 space-y-3 flex-grow">
+                  <div>
+                    <p className="font-semibold text-amber-200 uppercase tracking-wide text-xs mb-1">Objective</p>
+                    <p className="text-gray-300 leading-relaxed">{quest.objective}</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-amber-200 uppercase tracking-wide text-xs mb-1">Focus Points</p>
+                    <ul className="list-disc list-inside space-y-1 text-gray-300/90">
+                      {quest.focusPoints.map((point) => (
+                        <li key={point}>{point}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+                <button
+                    onClick={() => onSelectQuest(quest)}
+                    className="mt-6 bg-amber-600 hover:bg-amber-500 text-black font-bold py-2 px-4 rounded-lg transition-colors w-full"
                 >
                     Begin Quest
                 </button>

--- a/constants.ts
+++ b/constants.ts
@@ -37,6 +37,12 @@ export const QUESTS: Quest[] = [
     description: "Explore the core tenets of Stoicism, learning how to find tranquility and resilience in the face of modern-day challenges.",
     objective: "The student should understand the Stoic concepts of the dichotomy of control, living in accordance with nature, and viewing obstacles as opportunities for virtue.",
     characterId: 'marcus_aurelius',
+    duration: '20-30 minutes',
+    focusPoints: [
+      'Define the dichotomy of control with modern examples',
+      'Reflect on practical Stoic exercises for daily life',
+      'Discuss how to reframe obstacles as opportunities',
+    ],
   },
   {
     id: 'socratic_method_101',
@@ -44,6 +50,12 @@ export const QUESTS: Quest[] = [
     description: "Engage in a classic dialogue to understand the art of questioning. Learn how to examine your own beliefs and pursue truth through rigorous inquiry.",
     objective: "The student should experience the Socratic method firsthand and understand its purpose: to reveal contradictions in one's own beliefs and stimulate critical thinking, rather than to receive direct answers.",
     characterId: 'socrates',
+    duration: '25-35 minutes',
+    focusPoints: [
+      'Experience a guided Socratic dialogue',
+      'Identify assumptions hidden in personal beliefs',
+      'Practice formulating follow-up questions',
+    ],
   },
   {
     id: 'renaissance_art_101',
@@ -51,6 +63,12 @@ export const QUESTS: Quest[] = [
     description: "Journey with the master himself to understand the techniques and philosophies that defined Renaissance art, from human anatomy to the science of perspective.",
     objective: "The student should learn about the connection between art and science during the Renaissance, understand the importance of humanism, and be able to identify key principles in Leonardo's work.",
     characterId: 'davinci',
+    duration: '30-40 minutes',
+    focusPoints: [
+      'Examine the role of humanism in Renaissance art',
+      'Explore Leonardo’s approach to anatomy and observation',
+      'Understand the fundamentals of perspective drawing',
+    ],
   },
 ];
 

--- a/types.ts
+++ b/types.ts
@@ -66,4 +66,6 @@ export interface Quest {
   description: string;
   objective: string;
   characterId: string;
+  duration: string;
+  focusPoints: string[];
 }


### PR DESCRIPTION
## Summary
- extend quest data with duration and focus points to better set learner expectations
- surface duration, objectives, and focus points in the quest list and active quest sidebar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db0f169d94832fbcb909a03bc1b6e2