### PR TITLE
Add quest knowledge checks and completion tracking

### DIFF
--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -440,9 +440,11 @@ ${contextTranscript}
       timestamp: Date.now(),
       transcript,
       environmentImageUrl: environmentImageUrl || undefined,
+      questId: activeQuest?.id,
+      questTitle: activeQuest?.title,
     };
     saveConversationToLocalStorage(conversation);
-  }, [transcript, character, environmentImageUrl]);
+  }, [transcript, character, environmentImageUrl, activeQuest]);
 
   const handleReset = () => {
     if (transcript.length === 0 && !environmentImageUrl) return;

--- a/components/HistoryView.tsx
+++ b/components/HistoryView.tsx
@@ -64,7 +64,27 @@ const HistoryView: React.FC<HistoryViewProps> = ({ onBack }) => {
     let content = `Study Guide: Conversation with ${selectedConversation.characterName}\n`;
     content += `Date: ${new Date(selectedConversation.timestamp).toLocaleString()}\n`;
     content += `==================================================\n\n`;
-  
+
+    if (selectedConversation.questTitle || selectedConversation.questAssessment) {
+      content += `QUEST INFORMATION\n---------------------\n`;
+      if (selectedConversation.questTitle) {
+        content += `Quest: ${selectedConversation.questTitle}\n`;
+      }
+      if (selectedConversation.questAssessment) {
+        content += `Status: ${selectedConversation.questAssessment.passed ? 'Completed' : 'Needs Review'}\n`;
+        content += `Feedback: ${selectedConversation.questAssessment.feedback}\n`;
+        if (selectedConversation.questAssessment.evidence.length > 0) {
+          content += `Evidence:\n`;
+          selectedConversation.questAssessment.evidence.forEach(item => {
+            content += `- ${item}\n`;
+          });
+        }
+      } else {
+        content += 'Knowledge check not yet completed for this quest.\n';
+      }
+      content += `\n==================================================\n\n`;
+    }
+
     if (selectedConversation.summary) {
       content += `SUMMARY\n---------------------\n`;
       content += `${selectedConversation.summary.overview}\n\n`;
@@ -114,7 +134,45 @@ const HistoryView: React.FC<HistoryViewProps> = ({ onBack }) => {
               <p className="text-gray-400 text-sm">{new Date(selectedConversation.timestamp).toLocaleString()}</p>
             </div>
           </div>
-          
+
+          {(selectedConversation.questTitle || selectedConversation.questAssessment) && (
+            <div
+              className={`mb-4 p-4 rounded-lg border ${
+                selectedConversation.questAssessment
+                  ? selectedConversation.questAssessment.passed
+                    ? 'border-emerald-500/70 bg-emerald-900/30'
+                    : 'border-amber-500/70 bg-amber-900/30'
+                  : 'border-gray-600 bg-gray-800/40'
+              }`}
+            >
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-300">Learning Quest</p>
+              <h3 className="text-lg font-bold text-amber-100 mt-1">{selectedConversation.questTitle ?? 'Quest Session'}</h3>
+              {selectedConversation.questAssessment ? (
+                <>
+                  <p className="text-gray-200 mt-3 leading-relaxed">{selectedConversation.questAssessment.feedback}</p>
+                  {selectedConversation.questAssessment.evidence.length > 0 && (
+                    <ul className="list-disc list-inside mt-3 space-y-1 text-sm text-gray-200/90">
+                      {selectedConversation.questAssessment.evidence.map((item, index) => (
+                        <li key={`history-${selectedConversation.id}-evidence-${index}`}>{item}</li>
+                      ))}
+                    </ul>
+                  )}
+                  <p
+                    className={`mt-3 inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${
+                      selectedConversation.questAssessment.passed
+                        ? 'bg-emerald-500/20 text-emerald-200'
+                        : 'bg-amber-500/20 text-amber-200'
+                    }`}
+                  >
+                    {selectedConversation.questAssessment.passed ? 'Completed' : 'Needs Review'}
+                  </p>
+                </>
+              ) : (
+                <p className="text-gray-300 mt-3">Knowledge check has not been completed for this quest yet.</p>
+              )}
+            </div>
+          )}
+
           {selectedConversation.summary && (
             <div className="mb-4 bg-gray-900/70 p-4 rounded-lg border border-amber-800">
               <h3 className="text-lg font-bold text-amber-300 mb-2">Key Takeaways</h3>
@@ -164,9 +222,23 @@ const HistoryView: React.FC<HistoryViewProps> = ({ onBack }) => {
             <div key={conv.id} className="bg-gray-800/50 p-4 rounded-lg border border-gray-700 flex flex-col sm:flex-row items-center justify-between gap-4 hover:bg-gray-700/50 transition-colors">
               <div className="flex items-center self-start sm:self-center">
                 <img src={conv.portraitUrl} alt={conv.characterName} className="w-12 h-12 rounded-full mr-4" />
-                <div>
+                <div className="flex flex-col">
                   <p className="font-bold text-lg text-amber-300">{conv.characterName}</p>
                   <p className="text-sm text-gray-400">{new Date(conv.timestamp).toLocaleString()}</p>
+                  {conv.questTitle && (
+                    <p className="text-xs text-amber-200 mt-1">Quest: {conv.questTitle}</p>
+                  )}
+                  {conv.questAssessment && (
+                    <span
+                      className={`mt-2 inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${
+                        conv.questAssessment.passed
+                          ? 'bg-emerald-500/20 text-emerald-200'
+                          : 'bg-amber-500/20 text-amber-200'
+                      }`}
+                    >
+                      {conv.questAssessment.passed ? 'Completed' : 'Needs Review'}
+                    </span>
+                  )}
                 </div>
               </div>
               <div className="flex gap-2 self-end sm:self-center">

--- a/components/QuestsView.tsx
+++ b/components/QuestsView.tsx
@@ -1,6 +1,6 @@
 
-import React from 'react';
-import type { Quest, Character } from '../types';
+import React, { useMemo } from 'react';
+import type { Quest, Character, QuestAssessment } from '../types';
 import QuestIcon from './icons/QuestIcon';
 
 interface QuestsViewProps {
@@ -8,9 +8,17 @@ interface QuestsViewProps {
   characters: Character[];
   onSelectQuest: (quest: Quest) => void;
   onBack: () => void;
+  completedQuestIds: string[];
+  latestResult: QuestAssessment | null;
+  onDismissResult: () => void;
 }
 
-const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, onSelectQuest, onBack }) => {
+const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, onSelectQuest, onBack, completedQuestIds, latestResult, onDismissResult }) => {
+  const activeResult = useMemo(() => {
+    if (!latestResult) return null;
+    return quests.some(q => q.id === latestResult.questId) ? latestResult : null;
+  }, [latestResult, quests]);
+
   return (
     <div className="max-w-4xl mx-auto animate-fade-in">
       <div className="flex justify-between items-center mb-6">
@@ -23,6 +31,37 @@ const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, onSelectQue
         </button>
       </div>
 
+      {activeResult && (
+        <div
+          className={`mb-8 p-5 rounded-lg border text-left ${
+            activeResult.passed ? 'border-emerald-500/70 bg-emerald-900/30' : 'border-amber-500/70 bg-amber-900/30'
+          }`}
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-300">
+                {activeResult.passed ? 'Quest Completed' : 'Quest Review Needed'}
+              </p>
+              <h3 className="text-xl font-bold text-amber-100 mt-1">{activeResult.questTitle}</h3>
+            </div>
+            <button
+              onClick={onDismissResult}
+              className="text-xs font-semibold text-gray-300 hover:text-white bg-gray-800/60 border border-gray-700 px-3 py-1 rounded-md transition-colors"
+            >
+              Dismiss
+            </button>
+          </div>
+          <p className="text-gray-200 mt-3 leading-relaxed">{activeResult.feedback}</p>
+          {activeResult.evidence.length > 0 && (
+            <ul className="list-disc list-inside mt-3 space-y-1 text-sm text-gray-200/90">
+              {activeResult.evidence.map((item, index) => (
+                <li key={`${activeResult.questId}-quest-card-${index}`}>{item}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
       <p className="text-center text-gray-400 mb-8">
         Embark on a guided journey to explore a specific topic. Your mentor will steer the conversation towards a defined learning objective.
       </p>
@@ -34,12 +73,22 @@ const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, onSelectQue
           {quests.map((quest) => {
             const character = characters.find(c => c.id === quest.characterId);
             if (!character) return null;
+            const isCompleted = completedQuestIds.includes(quest.id);
 
             return (
               <div key={quest.id} className="bg-gray-800/50 p-5 rounded-lg border border-gray-700 flex flex-col text-center hover:border-amber-400 transition-colors duration-300">
                 <img src={character.portraitUrl} alt={character.name} className="w-24 h-24 rounded-full mx-auto mb-4 border-2 border-amber-300" />
-                <h3 className="font-bold text-xl text-amber-300">{quest.title}</h3>
-                <p className="text-sm text-gray-400 mt-1">with {character.name}</p>
+                <div className="flex items-start justify-between gap-2">
+                  <div className="text-left">
+                    <h3 className="font-bold text-xl text-amber-300 leading-snug">{quest.title}</h3>
+                    <p className="text-sm text-gray-400 mt-1">with {character.name}</p>
+                  </div>
+                  {isCompleted && (
+                    <span className="inline-flex items-center px-2 py-1 rounded-full bg-emerald-500/20 text-emerald-200 text-xs font-semibold uppercase tracking-wide">
+                      Completed
+                    </span>
+                  )}
+                </div>
                 <div className="mt-3 mb-4">
                   <span className="inline-flex items-center justify-center px-3 py-1 rounded-full bg-amber-500/20 text-amber-200 text-xs font-semibold uppercase tracking-wide">
                     {quest.duration}
@@ -64,7 +113,7 @@ const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, onSelectQue
                     onClick={() => onSelectQuest(quest)}
                     className="mt-6 bg-amber-600 hover:bg-amber-500 text-black font-bold py-2 px-4 rounded-lg transition-colors w-full"
                 >
-                    Begin Quest
+                    {isCompleted ? 'Retake Quest' : 'Begin Quest'}
                 </button>
               </div>
             );

--- a/types.ts
+++ b/types.ts
@@ -49,6 +49,14 @@ export interface Summary {
   takeaways: string[];
 }
 
+export interface QuestAssessment {
+  questId: string;
+  questTitle: string;
+  passed: boolean;
+  feedback: string;
+  evidence: string[];
+}
+
 export interface SavedConversation {
   id: string;
   characterId: string;
@@ -58,6 +66,9 @@ export interface SavedConversation {
   transcript: ConversationTurn[];
   environmentImageUrl?: string;
   summary?: Summary;
+  questId?: string;
+  questTitle?: string;
+  questAssessment?: QuestAssessment;
 }
 
 export interface Quest {


### PR DESCRIPTION
## Summary
- add persistent quest completion tracking along with AI-powered knowledge checks when ending quest conversations
- surface the latest quest result in the selector and quest list, including completion badges and retake messaging
- record quest metadata on saved conversations so history entries and exports reflect status and feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db150660f4832f9fe74ad32c73e100