### PR TITLE
Add quest knowledge checks and progress tracking

### DIFF
--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -432,6 +432,8 @@ ${contextTranscript}
   useEffect(() => {
     if (transcript.length === 0 && !environmentImageUrl) return;
 
+    const history = loadConversations();
+    const existingConversation = history.find(c => c.id === sessionIdRef.current);
     const conversation: SavedConversation = {
       id: sessionIdRef.current,
       characterId: character.id,
@@ -440,9 +442,11 @@ ${contextTranscript}
       timestamp: Date.now(),
       transcript,
       environmentImageUrl: environmentImageUrl || undefined,
+      questId: activeQuest?.id ?? existingConversation?.questId,
+      questEvaluation: existingConversation?.questEvaluation,
     };
     saveConversationToLocalStorage(conversation);
-  }, [transcript, character, environmentImageUrl]);
+  }, [transcript, character, environmentImageUrl, activeQuest]);
 
   const handleReset = () => {
     if (transcript.length === 0 && !environmentImageUrl) return;
@@ -455,10 +459,12 @@ ${contextTranscript}
         setTranscript([greetingTurn]);
         setDynamicSuggestions([]);
         onEnvironmentUpdate(null);
-        
+
         const initialSrc = AMBIENCE_LIBRARY.find(a => a.tag === character.ambienceTag)?.audioSrc ?? null;
         changeAmbienceTrack(initialSrc);
-        
+
+        const history = loadConversations();
+        const existingConversation = history.find(c => c.id === sessionIdRef.current);
         const clearedConversation: SavedConversation = {
             id: sessionIdRef.current,
             characterId: character.id,
@@ -467,6 +473,8 @@ ${contextTranscript}
             timestamp: Date.now(),
             transcript: [greetingTurn],
             environmentImageUrl: undefined,
+            questId: activeQuest?.id ?? existingConversation?.questId,
+            questEvaluation: existingConversation?.questEvaluation,
         };
         saveConversationToLocalStorage(clearedConversation);
     }

--- a/components/HistoryView.tsx
+++ b/components/HistoryView.tsx
@@ -2,6 +2,9 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import type { SavedConversation, ConversationTurn } from '../types';
 import DownloadIcon from './icons/DownloadIcon';
+import QuestIcon from './icons/QuestIcon';
+import CheckCircleIcon from './icons/CheckCircleIcon';
+import { QUESTS } from '../constants';
 
 const HISTORY_KEY = 'school-of-the-ancients-history';
 
@@ -101,6 +104,7 @@ const HistoryView: React.FC<HistoryViewProps> = ({ onBack }) => {
   }, [history]);
 
   if (selectedConversation) {
+    const questDetails = selectedConversation.questId ? QUESTS.find(q => q.id === selectedConversation.questId) : null;
     return (
       <div className="max-w-4xl mx-auto bg-cover bg-center bg-[#202020] p-4 md:p-6 rounded-2xl shadow-2xl border border-gray-700 animate-fade-in relative"
         style={{ backgroundImage: selectedConversation.environmentImageUrl ? `url(${selectedConversation.environmentImageUrl})` : 'none' }}
@@ -122,6 +126,33 @@ const HistoryView: React.FC<HistoryViewProps> = ({ onBack }) => {
               <ul className="list-disc list-inside space-y-1 text-gray-300">
                 {selectedConversation.summary.takeaways.map((item, i) => <li key={i}>{item}</li>)}
               </ul>
+            </div>
+          )}
+
+          {selectedConversation.questEvaluation && (
+            <div className={`mb-4 p-4 rounded-lg border ${selectedConversation.questEvaluation.status === 'completed' ? 'border-emerald-500/50 bg-emerald-500/10 text-emerald-100' : 'border-amber-500/60 bg-amber-500/10 text-amber-100'}`}>
+              <div className="flex items-start justify-between gap-3 mb-3">
+                <div className="flex items-center gap-2">
+                  {selectedConversation.questEvaluation.status === 'completed' ? (
+                    <CheckCircleIcon className="w-5 h-5" />
+                  ) : (
+                    <QuestIcon className="w-5 h-5" />
+                  )}
+                  <div>
+                    <p className="text-sm font-semibold uppercase tracking-wide">Knowledge Check</p>
+                    {questDetails && <p className="text-lg font-bold">{questDetails.title}</p>}
+                  </div>
+                </div>
+                <span className="text-xs text-white/70">{new Date(selectedConversation.questEvaluation.lastChecked).toLocaleString()}</span>
+              </div>
+              <p className="text-sm leading-relaxed opacity-90">{selectedConversation.questEvaluation.rationale}</p>
+              {selectedConversation.questEvaluation.demonstratedPoints.length > 0 && (
+                <ul className="mt-3 list-disc list-inside space-y-1 text-sm opacity-80">
+                  {selectedConversation.questEvaluation.demonstratedPoints.map((point, i) => (
+                    <li key={i}>{point}</li>
+                  ))}
+                </ul>
+              )}
             </div>
           )}
 
@@ -167,6 +198,12 @@ const HistoryView: React.FC<HistoryViewProps> = ({ onBack }) => {
                 <div>
                   <p className="font-bold text-lg text-amber-300">{conv.characterName}</p>
                   <p className="text-sm text-gray-400">{new Date(conv.timestamp).toLocaleString()}</p>
+                  {conv.questEvaluation && (
+                    <span className={`mt-1 inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide px-2 py-1 rounded-full ${conv.questEvaluation.status === 'completed' ? 'bg-emerald-500/20 text-emerald-200' : 'bg-amber-500/20 text-amber-200'}`}>
+                      {conv.questEvaluation.status === 'completed' ? <CheckCircleIcon className="w-3 h-3" /> : <QuestIcon className="w-3 h-3" />}
+                      {conv.questEvaluation.status === 'completed' ? 'Quest Completed' : 'Needs Review'}
+                    </span>
+                  )}
                 </div>
               </div>
               <div className="flex gap-2 self-end sm:self-center">

--- a/components/QuestsView.tsx
+++ b/components/QuestsView.tsx
@@ -1,16 +1,18 @@
 
 import React from 'react';
-import type { Quest, Character } from '../types';
+import type { Quest, Character, QuestProgressRecord } from '../types';
 import QuestIcon from './icons/QuestIcon';
+import CheckCircleIcon from './icons/CheckCircleIcon';
 
 interface QuestsViewProps {
   quests: Quest[];
   characters: Character[];
   onSelectQuest: (quest: Quest) => void;
   onBack: () => void;
+  questProgress: Record<string, QuestProgressRecord>;
 }
 
-const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, onSelectQuest, onBack }) => {
+const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, onSelectQuest, onBack, questProgress }) => {
   return (
     <div className="max-w-4xl mx-auto animate-fade-in">
       <div className="flex justify-between items-center mb-6">
@@ -34,9 +36,16 @@ const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, onSelectQue
           {quests.map((quest) => {
             const character = characters.find(c => c.id === quest.characterId);
             if (!character) return null;
+            const progress = questProgress[quest.id];
+            const isCompleted = progress?.status === 'completed';
+            const demonstratedPoints = progress?.demonstratedPoints?.filter(point => point.trim()) ?? [];
+            const previewPoints = demonstratedPoints.slice(0, 3);
 
             return (
-              <div key={quest.id} className="bg-gray-800/50 p-5 rounded-lg border border-gray-700 flex flex-col text-center hover:border-amber-400 transition-colors duration-300">
+              <div
+                key={quest.id}
+                className={`relative bg-gray-800/50 p-5 rounded-lg border ${isCompleted ? 'border-emerald-500/40 hover:border-emerald-400/80' : 'border-gray-700 hover:border-amber-400'} flex flex-col text-center transition-colors duration-300`}
+              >
                 <img src={character.portraitUrl} alt={character.name} className="w-24 h-24 rounded-full mx-auto mb-4 border-2 border-amber-300" />
                 <h3 className="font-bold text-xl text-amber-300">{quest.title}</h3>
                 <p className="text-sm text-gray-400 mt-1">with {character.name}</p>
@@ -60,11 +69,41 @@ const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, onSelectQue
                     </ul>
                   </div>
                 </div>
+                {progress && (
+                  <div className={`mt-4 text-left text-sm rounded-lg border ${isCompleted ? 'border-emerald-500/50 bg-emerald-500/10 text-emerald-100' : 'border-amber-500/50 bg-amber-500/10 text-amber-100'} p-3 space-y-2`}>
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="flex items-center gap-2">
+                        {isCompleted ? (
+                          <CheckCircleIcon className="w-4 h-4" />
+                        ) : (
+                          <QuestIcon className="w-4 h-4" />
+                        )}
+                        <span className="font-semibold uppercase tracking-wide text-xs">
+                          {isCompleted ? 'Completed' : 'Needs Review'}
+                        </span>
+                      </div>
+                      {progress.lastChecked && (
+                        <span className="text-[11px] text-white/70">{new Date(progress.lastChecked).toLocaleDateString()}</span>
+                      )}
+                    </div>
+                    <p className="opacity-90 leading-snug">{progress.rationale}</p>
+                    {previewPoints.length > 0 && (
+                      <ul className="list-disc list-inside space-y-1 opacity-80">
+                        {previewPoints.map(point => (
+                          <li key={point}>{point}</li>
+                        ))}
+                        {demonstratedPoints.length > previewPoints.length && (
+                          <li className="italic">…and more</li>
+                        )}
+                      </ul>
+                    )}
+                  </div>
+                )}
                 <button
-                    onClick={() => onSelectQuest(quest)}
-                    className="mt-6 bg-amber-600 hover:bg-amber-500 text-black font-bold py-2 px-4 rounded-lg transition-colors w-full"
+                  onClick={() => onSelectQuest(quest)}
+                  className={`mt-6 font-bold py-2 px-4 rounded-lg transition-colors w-full ${isCompleted ? 'bg-emerald-500 hover:bg-emerald-400 text-black' : 'bg-amber-600 hover:bg-amber-500 text-black'}`}
                 >
-                    Begin Quest
+                  {isCompleted ? 'Revisit Quest' : 'Begin Quest'}
                 </button>
               </div>
             );

--- a/components/icons/CheckCircleIcon.tsx
+++ b/components/icons/CheckCircleIcon.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const CheckCircleIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <circle cx="12" cy="12" r="9" />
+    <path d="M9 12.5l2 2 4-4.5" />
+  </svg>
+);
+
+export default CheckCircleIcon;

--- a/types.ts
+++ b/types.ts
@@ -49,6 +49,13 @@ export interface Summary {
   takeaways: string[];
 }
 
+export interface QuestProgressRecord {
+  status: 'completed' | 'incomplete';
+  rationale: string;
+  demonstratedPoints: string[];
+  lastChecked: number;
+}
+
 export interface SavedConversation {
   id: string;
   characterId: string;
@@ -58,6 +65,8 @@ export interface SavedConversation {
   transcript: ConversationTurn[];
   environmentImageUrl?: string;
   summary?: Summary;
+  questId?: string;
+  questEvaluation?: QuestProgressRecord;
 }
 
 export interface Quest {


### PR DESCRIPTION
## Summary
- add AI-powered knowledge checks when ending quest conversations and persist quest progress in local storage
- surface quest completion status and feedback in the quests grid and conversation history views
- show recent knowledge check results on the home screen and add a reusable check icon for completion badges

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db150660f4832f9fe74ad32c73e100