### PR TITLE
Add quest knowledge check and completion tracking

### DIFF
--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -440,9 +440,15 @@ ${contextTranscript}
       timestamp: Date.now(),
       transcript,
       environmentImageUrl: environmentImageUrl || undefined,
+      ...(activeQuest
+        ? {
+            questId: activeQuest.id,
+            questTitle: activeQuest.title,
+          }
+        : {}),
     };
     saveConversationToLocalStorage(conversation);
-  }, [transcript, character, environmentImageUrl]);
+  }, [transcript, character, environmentImageUrl, activeQuest]);
 
   const handleReset = () => {
     if (transcript.length === 0 && !environmentImageUrl) return;
@@ -467,6 +473,12 @@ ${contextTranscript}
             timestamp: Date.now(),
             transcript: [greetingTurn],
             environmentImageUrl: undefined,
+            ...(activeQuest
+              ? {
+                  questId: activeQuest.id,
+                  questTitle: activeQuest.title,
+                }
+              : {}),
         };
         saveConversationToLocalStorage(clearedConversation);
     }

--- a/components/HistoryView.tsx
+++ b/components/HistoryView.tsx
@@ -115,6 +115,44 @@ const HistoryView: React.FC<HistoryViewProps> = ({ onBack }) => {
             </div>
           </div>
           
+          {selectedConversation.questTitle && (
+            <div
+              className={`mb-4 p-4 rounded-lg border ${selectedConversation.questAssessment?.passed ? 'bg-emerald-900/30 border-emerald-700' : 'bg-amber-900/30 border-amber-700'}`}
+            >
+              <p className="text-xs uppercase tracking-wide text-gray-300 font-semibold mb-1">Quest Review</p>
+              <h3 className="text-lg font-bold text-amber-200">{selectedConversation.questTitle}</h3>
+              {selectedConversation.questAssessment ? (
+                <>
+                  <p className="mt-2 text-gray-200">{selectedConversation.questAssessment.summary}</p>
+                  <div className="mt-3 grid gap-3 md:grid-cols-2">
+                    {selectedConversation.questAssessment.evidence.length > 0 && (
+                      <div>
+                        <p className="text-sm font-semibold text-emerald-200 uppercase tracking-wide mb-1">Highlights</p>
+                        <ul className="list-disc list-inside text-sm text-gray-100 space-y-1">
+                          {selectedConversation.questAssessment.evidence.map(item => (
+                            <li key={item}>{item}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                    {selectedConversation.questAssessment.improvements.length > 0 && (
+                      <div>
+                        <p className="text-sm font-semibold text-amber-200 uppercase tracking-wide mb-1">Next Steps</p>
+                        <ul className="list-disc list-inside text-sm text-amber-100 space-y-1">
+                          {selectedConversation.questAssessment.improvements.map(item => (
+                            <li key={item}>{item}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </div>
+                </>
+              ) : (
+                <p className="mt-2 text-gray-300 text-sm">Quest selected, awaiting knowledge check results.</p>
+              )}
+            </div>
+          )}
+
           {selectedConversation.summary && (
             <div className="mb-4 bg-gray-900/70 p-4 rounded-lg border border-amber-800">
               <h3 className="text-lg font-bold text-amber-300 mb-2">Key Takeaways</h3>
@@ -167,6 +205,16 @@ const HistoryView: React.FC<HistoryViewProps> = ({ onBack }) => {
                 <div>
                   <p className="font-bold text-lg text-amber-300">{conv.characterName}</p>
                   <p className="text-sm text-gray-400">{new Date(conv.timestamp).toLocaleString()}</p>
+                  {conv.questTitle && (
+                    <p className="text-xs text-gray-400 mt-1">
+                      Quest: <span className="text-gray-200">{conv.questTitle}</span>{' '}
+                      {conv.questAssessment && (
+                        <span className={`ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide ${conv.questAssessment.passed ? 'bg-emerald-700/40 text-emerald-200' : 'bg-red-700/40 text-red-200'}`}>
+                          {conv.questAssessment.passed ? 'Completed' : 'Needs Review'}
+                        </span>
+                      )}
+                    </p>
+                  )}
                 </div>
               </div>
               <div className="flex gap-2 self-end sm:self-center">

--- a/components/QuestsView.tsx
+++ b/components/QuestsView.tsx
@@ -6,11 +6,12 @@ import QuestIcon from './icons/QuestIcon';
 interface QuestsViewProps {
   quests: Quest[];
   characters: Character[];
+  completedQuestIds: string[];
   onSelectQuest: (quest: Quest) => void;
   onBack: () => void;
 }
 
-const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, onSelectQuest, onBack }) => {
+const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, completedQuestIds, onSelectQuest, onBack }) => {
   return (
     <div className="max-w-4xl mx-auto animate-fade-in">
       <div className="flex justify-between items-center mb-6">
@@ -34,12 +35,24 @@ const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, onSelectQue
           {quests.map((quest) => {
             const character = characters.find(c => c.id === quest.characterId);
             if (!character) return null;
+            const isCompleted = completedQuestIds.includes(quest.id);
 
             return (
-              <div key={quest.id} className="bg-gray-800/50 p-5 rounded-lg border border-gray-700 flex flex-col text-center hover:border-amber-400 transition-colors duration-300">
+              <div
+                key={quest.id}
+                className={`bg-gray-800/50 p-5 rounded-lg border flex flex-col text-center transition-colors duration-300 ${isCompleted ? 'border-emerald-600/80 shadow-lg shadow-emerald-900/40' : 'border-gray-700 hover:border-amber-400'}`}
+              >
                 <img src={character.portraitUrl} alt={character.name} className="w-24 h-24 rounded-full mx-auto mb-4 border-2 border-amber-300" />
                 <h3 className="font-bold text-xl text-amber-300">{quest.title}</h3>
                 <p className="text-sm text-gray-400 mt-1">with {character.name}</p>
+                {isCompleted && (
+                  <div className="mt-2">
+                    <span className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-emerald-700/30 text-emerald-200 text-xs font-semibold uppercase tracking-wide">
+                      <span className="w-2 h-2 rounded-full bg-emerald-300" />
+                      Completed
+                    </span>
+                  </div>
+                )}
                 <div className="mt-3 mb-4">
                   <span className="inline-flex items-center justify-center px-3 py-1 rounded-full bg-amber-500/20 text-amber-200 text-xs font-semibold uppercase tracking-wide">
                     {quest.duration}
@@ -62,9 +75,9 @@ const QuestsView: React.FC<QuestsViewProps> = ({ quests, characters, onSelectQue
                 </div>
                 <button
                     onClick={() => onSelectQuest(quest)}
-                    className="mt-6 bg-amber-600 hover:bg-amber-500 text-black font-bold py-2 px-4 rounded-lg transition-colors w-full"
+                    className={`mt-6 font-bold py-2 px-4 rounded-lg transition-colors w-full ${isCompleted ? 'bg-emerald-600 hover:bg-emerald-500 text-black' : 'bg-amber-600 hover:bg-amber-500 text-black'}`}
                 >
-                    Begin Quest
+                    {isCompleted ? 'Review Quest' : 'Begin Quest'}
                 </button>
               </div>
             );

--- a/types.ts
+++ b/types.ts
@@ -49,6 +49,15 @@ export interface Summary {
   takeaways: string[];
 }
 
+export interface QuestAssessment {
+  questId: string;
+  questTitle: string;
+  passed: boolean;
+  summary: string;
+  evidence: string[];
+  improvements: string[];
+}
+
 export interface SavedConversation {
   id: string;
   characterId: string;
@@ -58,6 +67,9 @@ export interface SavedConversation {
   transcript: ConversationTurn[];
   environmentImageUrl?: string;
   summary?: Summary;
+  questId?: string;
+  questTitle?: string;
+  questAssessment?: QuestAssessment;
 }
 
 export interface Quest {


### PR DESCRIPTION
## Summary
- add AI-powered knowledge checks to quest conversations and store completion results
- surface quest progress and recent evaluation feedback in the selector and history views
- persist quest metadata in saved conversations and highlight completed quests in the quest browser

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db150660f4832f9fe74ad32c73e100