### PR TITLE
Improve mobile landing experience

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -372,25 +372,30 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
       case 'selector':
       default:
         return (
-          <div className="text-center animate-fade-in">
-             <p className="max-w-3xl mx-auto mb-8 text-gray-400 text-lg">
+          <div className="animate-fade-in text-center">
+            <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 rounded-2xl border border-gray-800/80 bg-gray-900/60 p-5 text-left shadow-lg backdrop-blur-sm sm:gap-8 sm:p-7">
+              <p className="text-sm font-semibold uppercase tracking-wide text-amber-300">Your Ancient Studies Hub</p>
+              <p className="text-base text-gray-300 sm:text-lg">
                 Engage in real-time voice conversations with legendary minds from history, or embark on a guided Learning Quest to master a new subject.
-            </p>
-            <div className="max-w-3xl mx-auto mb-8 bg-gray-800/50 border border-gray-700 rounded-lg p-4 text-left">
-              <p className="text-sm text-gray-300 mb-2 font-semibold">Quest Progress</p>
-              <p className="text-xs uppercase tracking-wide text-gray-400 mb-3">{completedQuests.length} of {QUESTS.length} quests completed</p>
-              <div className="w-full h-2 bg-gray-700 rounded-full overflow-hidden">
-                <div
-                  className="h-full bg-amber-500 transition-all duration-500"
-                  style={{ width: `${Math.min(100, Math.round((completedQuests.length / Math.max(QUESTS.length, 1)) * 100))}%` }}
-                />
+              </p>
+              <div>
+                <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-gray-300">
+                  <p className="font-semibold text-amber-200">Quest Progress</p>
+                  <p className="text-xs uppercase tracking-wide text-gray-400 sm:text-sm">{completedQuests.length} of {QUESTS.length} quests completed</p>
+                </div>
+                <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-gray-700">
+                  <div
+                    className="h-full rounded-full bg-amber-500 transition-all duration-500"
+                    style={{ width: `${Math.min(100, Math.round((completedQuests.length / Math.max(QUESTS.length, 1)) * 100))}%` }}
+                  />
+                </div>
               </div>
             </div>
             {lastQuestOutcome && (
               <div
-                className={`max-w-3xl mx-auto mb-8 rounded-lg border p-5 text-left shadow-lg ${lastQuestOutcome.passed ? 'bg-emerald-900/40 border-emerald-700' : 'bg-red-900/30 border-red-700'}`}
+                className={`mx-auto mt-8 w-full max-w-3xl rounded-2xl border p-5 text-left shadow-lg sm:p-6 ${lastQuestOutcome.passed ? 'bg-emerald-900/40 border-emerald-700/70' : 'bg-red-900/30 border-red-700/70'}`}
               >
-                <div className="flex justify-between items-start gap-4">
+                <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
                   <div>
                     <p className="text-xs uppercase tracking-wide text-gray-300 font-semibold">Latest Quest Review</p>
                     <h3 className="text-2xl font-bold text-amber-200 mt-1">{lastQuestOutcome.questTitle}</h3>
@@ -399,11 +404,11 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
                     {lastQuestOutcome.passed ? 'Completed' : 'Needs Review'}
                   </span>
                 </div>
-                <p className="text-gray-200 mt-4 leading-relaxed">{lastQuestOutcome.summary}</p>
+                <p className="mt-4 text-sm leading-relaxed text-gray-200 sm:text-base">{lastQuestOutcome.summary}</p>
                 {lastQuestOutcome.evidence.length > 0 && (
                   <div className="mt-4">
-                    <p className="text-sm font-semibold text-emerald-200 uppercase tracking-wide mb-1">Highlights</p>
-                    <ul className="list-disc list-inside text-gray-100 space-y-1 text-sm">
+                    <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-emerald-200 sm:text-sm">Highlights</p>
+                    <ul className="space-y-1 text-sm text-gray-100">
                       {lastQuestOutcome.evidence.map(item => (
                         <li key={item}>{item}</li>
                       ))}
@@ -412,8 +417,8 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
                 )}
                 {!lastQuestOutcome.passed && lastQuestOutcome.improvements.length > 0 && (
                   <div className="mt-4">
-                    <p className="text-sm font-semibold text-red-200 uppercase tracking-wide mb-1">Next Steps</p>
-                    <ul className="list-disc list-inside text-red-100 space-y-1 text-sm">
+                    <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-red-200 sm:text-sm">Next Steps</p>
+                    <ul className="space-y-1 text-sm text-red-100">
                       {lastQuestOutcome.improvements.map(item => (
                         <li key={item}>{item}</li>
                       ))}
@@ -422,17 +427,17 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
                 )}
               </div>
             )}
-            <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mb-12">
+            <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:mt-10 sm:flex-row sm:gap-4">
                 <button
                     onClick={() => setView('quests')}
-                    className="flex items-center gap-3 bg-amber-600 hover:bg-amber-500 text-black font-bold py-3 px-8 rounded-lg transition-colors duration-300 text-lg w-full sm:w-auto"
+                    className="flex w-full items-center justify-center gap-3 rounded-xl bg-amber-500 py-3 px-6 text-base font-bold text-black transition-colors duration-300 hover:bg-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-300 sm:w-auto sm:text-lg"
                 >
                     <QuestIcon className="w-6 h-6" />
                     <span>Learning Quests</span>
                 </button>
                 <button
                     onClick={() => setView('history')}
-                    className="bg-gray-700 hover:bg-gray-600 text-amber-300 font-bold py-3 px-8 rounded-lg transition-colors duration-300 border border-gray-600 w-full sm:w-auto"
+                    className="w-full rounded-xl border border-gray-600 bg-gray-800 py-3 px-6 text-base font-semibold text-amber-200 transition-colors duration-300 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-amber-300 sm:w-auto sm:text-lg"
                 >
                     View Conversation History
                 </button>
@@ -463,13 +468,13 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
         className="relative z-10 min-h-screen flex flex-col text-gray-200 font-serif p-4 sm:p-6 lg:p-8"
         style={{ background: environmentImageUrl ? 'transparent' : 'linear-gradient(to bottom right, #1a1a1a, #2b2b2b)' }}
       >
-        <header className="text-center mb-8">
-          <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold text-amber-300 tracking-wider" style={{ textShadow: '0 0 10px rgba(252, 211, 77, 0.5)' }}>
+        <header className="mb-8 space-y-3 text-center">
+          <h1 className="text-3xl font-bold tracking-wide text-amber-300 sm:text-5xl md:text-6xl" style={{ textShadow: '0 0 10px rgba(252, 211, 77, 0.5)' }}>
             School of the Ancients
           </h1>
-          <p className="text-gray-400 mt-2 text-lg">Old world wisdom. New world classroom.</p>
+          <p className="mx-auto max-w-xl text-base text-gray-400 sm:text-lg">Old world wisdom. New world classroom.</p>
         </header>
-        <main className="max-w-7xl w-full mx-auto flex-grow flex flex-col">
+        <main className="mx-auto flex w-full max-w-7xl flex-grow flex-col">
           {renderContent()}
         </main>
       </div>

--- a/components/AddCharacterCard.tsx
+++ b/components/AddCharacterCard.tsx
@@ -8,14 +8,24 @@ interface AddCharacterCardProps {
 const AddCharacterCard: React.FC<AddCharacterCardProps> = ({ onClick }) => {
   return (
     <div
-      className="w-72 h-96 cursor-pointer rounded-lg shadow-lg bg-gray-800/50 border-2 border-dashed border-gray-600 hover:border-amber-400 transition-all duration-300 transform hover:scale-105 flex flex-col items-center justify-center text-gray-400 hover:text-amber-300"
+      className="group flex min-h-[18rem] w-full cursor-pointer flex-col items-center justify-center rounded-2xl border-2 border-dashed border-gray-600 bg-gray-800/40 p-6 text-center text-gray-400 shadow-lg transition-all duration-300 hover:border-amber-400 hover:text-amber-300 focus:outline-none focus:ring-2 focus:ring-amber-400 sm:min-h-[20rem]"
       onClick={onClick}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onClick();
+        }
+      }}
+      role="button"
+      tabIndex={0}
     >
-      <svg xmlns="http://www.w3.org/2000/svg" className="h-24 w-24 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
+      <svg xmlns="http://www.w3.org/2000/svg" className="mb-4 h-20 w-20 transition-transform duration-300 group-hover:scale-110" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
       </svg>
-      <h3 className="text-2xl font-bold">Bring a new mind to the school.</h3>
-     
+      <h3 className="text-xl font-bold sm:text-2xl">Bring a new mind to the school.</h3>
+      <p className="mt-3 max-w-xs text-sm text-gray-400 sm:text-base">
+        Craft a custom mentor with your own portrait, voice, and expertise.
+      </p>
     </div>
   );
 };

--- a/components/CharacterSelector.tsx
+++ b/components/CharacterSelector.tsx
@@ -16,53 +16,68 @@ const CharacterSelector: React.FC<CharacterSelectorProps> = ({ characters, onSel
     e.stopPropagation(); // Prevent card click
     onDeleteCharacter(characterId);
   };
-  
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, character: Character) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onSelectCharacter(character);
+    }
+  };
+
   return (
-    <div className="flex flex-wrap justify-center gap-4 md:gap-8">
+    <div className="grid w-full max-w-6xl mx-auto grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 sm:gap-6 px-2 sm:px-0">
       <AddCharacterCard onClick={onStartCreation} />
       {characters.map((character) => {
         const isCustom = character.id.startsWith('custom_');
         return (
           <div
             key={character.id}
-            className="group relative w-full max-w-sm sm:w-72 h-96 cursor-pointer overflow-hidden rounded-lg shadow-lg bg-gray-800 border-2 border-transparent hover:border-amber-400 transition-all duration-300 transform hover:scale-105"
+            className="group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl bg-gray-800/70 border border-gray-700/50 shadow-lg transition-transform duration-300 hover:-translate-y-1 focus:outline-none focus:ring-2 focus:ring-amber-400"
             onClick={() => onSelectCharacter(character)}
+            onKeyDown={(event) => handleKeyDown(event, character)}
+            role="button"
+            tabIndex={0}
           >
             {isCustom && (
               <button
                 onClick={(e) => handleDelete(e, character.id)}
-                className="absolute top-2 left-2 z-10 p-2 rounded-full bg-red-800/60 hover:bg-red-700 text-white opacity-0 group-hover:opacity-100 transition-all duration-300 -translate-x-2 group-hover:translate-x-0"
+                className="absolute left-3 top-3 z-10 rounded-full bg-red-800/70 p-2 text-white opacity-0 transition-all duration-300 focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-red-400 group-hover:translate-x-0 group-hover:opacity-100 group-focus-within:opacity-100"
                 aria-label={`Delete ${character.name}`}
               >
                 <TrashIcon className="w-5 h-5" />
               </button>
             )}
-            <img 
-              src={character.portraitUrl} 
-              alt={character.name}
-              className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110 filter grayscale group-hover:grayscale-0"
-            />
-            <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent transition-colors duration-300 group-hover:bg-black/70" />
-            <div className="absolute bottom-0 left-0 p-3 sm:p-4 text-white w-full">
-              <h3 className="text-xl sm:text-2xl font-bold text-amber-200">{character.name}</h3>
-              <p className="text-sm text-gray-300 italic mb-2">{character.title}</p>
-              
-              <div className="overflow-hidden transition-all duration-500 ease-in-out max-h-0 group-hover:max-h-64">
-                <div className="overflow-y-auto max-h-64 pr-2">
-                  <p className="text-sm text-gray-400 pt-2 border-t border-gray-700/50 mb-3">
-                    {character.bio}
-                  </p>
-
-                  <div className="text-xs text-gray-400 space-y-1 mb-3">
-                    <p><strong className="font-semibold text-gray-300">Timeframe:</strong> {character.timeframe}</p>
-                    <p><strong className="font-semibold text-gray-300">Expertise:</strong> {character.expertise}</p>
-                    <p><strong className="font-semibold text-gray-300">Passion:</strong> {character.passion}</p>
+            <div className="relative h-56 w-full overflow-hidden sm:h-64">
+              <img
+                src={character.portraitUrl}
+                alt={character.name}
+                className="absolute inset-0 h-full w-full object-cover transition-transform duration-300 filter grayscale group-hover:scale-105 group-hover:grayscale-0 group-focus-within:scale-105 group-focus-within:grayscale-0"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent transition-opacity duration-300 group-hover:opacity-90 group-focus-within:opacity-90" />
+              <div className="absolute right-3 top-3 rounded-full bg-amber-400 px-3 py-1 text-sm font-semibold text-black shadow-lg opacity-90 transition duration-300 group-hover:-translate-y-1 group-hover:opacity-100 group-focus-within:-translate-y-1 group-focus-within:opacity-100">
+                Speak
+              </div>
+            </div>
+            <div className="flex flex-1 flex-col justify-between gap-3 p-4 text-left text-white">
+              <div>
+                <h3 className="text-2xl font-bold text-amber-200">{character.name}</h3>
+                <p className="text-sm text-gray-300 italic">{character.title}</p>
+                <p className="mt-3 text-sm text-gray-300 md:hidden" style={{ maxHeight: '4.5rem', overflow: 'hidden' }}>
+                  {character.bio}
+                </p>
+              </div>
+              <div className="hidden text-sm text-gray-300 md:block">
+                <div className="overflow-hidden border-t border-gray-700/40 pt-3 transition-all duration-500 ease-in-out max-h-0 group-hover:max-h-64 group-focus-within:max-h-64">
+                  <div className="max-h-48 space-y-3 overflow-y-auto pr-1">
+                    <p className="text-gray-400">{character.bio}</p>
+                    <div className="space-y-1 text-xs text-gray-400">
+                      <p><strong className="font-semibold text-gray-200">Timeframe:</strong> {character.timeframe}</p>
+                      <p><strong className="font-semibold text-gray-200">Expertise:</strong> {character.expertise}</p>
+                      <p><strong className="font-semibold text-gray-200">Passion:</strong> {character.passion}</p>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div className="absolute top-4 right-4 bg-amber-400 text-black px-3 py-1 rounded-full text-sm font-bold opacity-0 group-hover:opacity-100 transition-opacity duration-300 -translate-y-2 group-hover:translate-y-0">
-              Speak
             </div>
           </div>
         );

--- a/components/Instructions.tsx
+++ b/components/Instructions.tsx
@@ -3,40 +3,40 @@ import React from 'react';
 
 const Instructions: React.FC = () => {
   return (
-    <div className="max-w-4xl mx-auto mb-12 bg-gray-800/50 p-6 rounded-lg border border-gray-700 text-left animate-fade-in">
-      <h2 className="text-2xl font-bold text-amber-200 mb-2">Welcome to the School of the Ancients</h2>
-      <p className="text-gray-400 mb-6">
+    <div className="mx-auto mb-12 w-full max-w-4xl rounded-2xl border border-gray-700 bg-gray-800/60 p-5 text-left shadow-lg backdrop-blur-sm animate-fade-in sm:p-8">
+      <h2 className="text-xl font-bold text-amber-200 sm:text-2xl">Welcome to the School of the Ancients</h2>
+      <p className="mt-3 text-sm text-gray-400 sm:text-base">
         Engage in real-time voice conversations with legendary minds from history. Here's how to begin your journey:
       </p>
-      <div className="grid md:grid-cols-3 gap-6">
-        <div className="bg-gray-900/50 p-4 rounded-lg border border-gray-600">
-          <h3 className="font-bold text-lg text-amber-300 mb-2">1. Start a Conversation</h3>
-          <p className="text-gray-300">
+      <div className="mt-6 grid gap-4 sm:gap-6 md:grid-cols-3">
+        <div className="rounded-xl border border-gray-600 bg-gray-900/60 p-4">
+          <h3 className="mb-2 text-lg font-semibold text-amber-300">1. Start a Conversation</h3>
+          <p className="text-sm text-gray-300 sm:text-base">
             Select an ancient from the gallery below or create your own. Grant microphone access when prompted to begin speaking. You can also type messages if you prefer.
           </p>
         </div>
-        <div className="bg-gray-900/50 p-4 rounded-lg border border-gray-600">
-          <h3 className="font-bold text-lg text-amber-300 mb-2">2. Command Your World</h3>
-          <p className="text-gray-300 mb-3">
+        <div className="rounded-xl border border-gray-600 bg-gray-900/60 p-4">
+          <h3 className="mb-2 text-lg font-semibold text-amber-300">2. Command Your World</h3>
+          <p className="mb-3 text-sm text-gray-300 sm:text-base">
             This is more than a chat. You can command the environment like a "Matrix Operator":
           </p>
-          <ul className="list-disc list-inside space-y-2 text-gray-300">
-            <li>
+          <ul className="space-y-2 text-sm text-gray-300 sm:text-base">
+            <li className="rounded-lg bg-gray-800/60 p-3">
               <strong className="text-teal-300">Change Scenery:</strong> Say <span className="italic text-teal-200">"Operator, Take me to the Roman Forum"</span> to transport yourself to a new location.
             </li>
-            <li>
+            <li className="rounded-lg bg-gray-800/60 p-3">
               <strong className="text-teal-300">Display Artifacts:</strong> Say <span className="italic text-teal-200">"Operator, Show me a diagram of a flying machine"</span> to see a visual aid.
             </li>
           </ul>
         </div>
-        <div className="bg-gray-900/50 p-4 rounded-lg border border-gray-600">
-          <h3 className="font-bold text-lg text-amber-300 mb-2">3. Review & Study</h3>
-          <p className="text-gray-300">
+        <div className="rounded-xl border border-gray-600 bg-gray-900/60 p-4">
+          <h3 className="mb-2 text-lg font-semibold text-amber-300">3. Review & Study</h3>
+          <p className="text-sm text-gray-300 sm:text-base">
             Every conversation is automatically saved. Visit your <strong className="text-amber-200">Conversation History</strong> to review transcripts, see AI-generated summaries, and download a complete Study Guide.
           </p>
         </div>
       </div>
-      <p className="text-center text-amber-200 font-semibold mt-6">
+      <p className="mt-6 text-center text-sm font-semibold text-amber-200 sm:text-base">
         Select an ancient below to begin your lesson.
       </p>
     </div>


### PR DESCRIPTION
## Summary
- refactor the landing hero and quest progress callouts for better spacing on small screens
- restyle the instructions section with responsive typography and cards that read well on mobile
- redesign character gallery cards to support mobile-first layout and keyboard access

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc10338450832fa1916ed50ae5b629