### PR TITLE
Improve mobile responsiveness of primary views

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -372,11 +372,11 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
       case 'selector':
       default:
         return (
-          <div className="text-center animate-fade-in">
-             <p className="max-w-3xl mx-auto mb-8 text-gray-400 text-lg">
+          <div className="text-center animate-fade-in space-y-8 sm:space-y-12">
+             <p className="max-w-3xl mx-auto text-gray-300 text-base sm:text-lg leading-relaxed px-2">
                 Engage in real-time voice conversations with legendary minds from history, or embark on a guided Learning Quest to master a new subject.
             </p>
-            <div className="max-w-3xl mx-auto mb-8 bg-gray-800/50 border border-gray-700 rounded-lg p-4 text-left">
+            <div className="max-w-3xl mx-auto bg-gray-800/60 border border-gray-700/70 rounded-2xl p-5 sm:p-6 text-left shadow-xl">
               <p className="text-sm text-gray-300 mb-2 font-semibold">Quest Progress</p>
               <p className="text-xs uppercase tracking-wide text-gray-400 mb-3">{completedQuests.length} of {QUESTS.length} quests completed</p>
               <div className="w-full h-2 bg-gray-700 rounded-full overflow-hidden">
@@ -388,7 +388,7 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
             </div>
             {lastQuestOutcome && (
               <div
-                className={`max-w-3xl mx-auto mb-8 rounded-lg border p-5 text-left shadow-lg ${lastQuestOutcome.passed ? 'bg-emerald-900/40 border-emerald-700' : 'bg-red-900/30 border-red-700'}`}
+                className={`max-w-3xl mx-auto rounded-2xl border p-5 sm:p-6 text-left shadow-2xl space-y-4 ${lastQuestOutcome.passed ? 'bg-emerald-900/40 border-emerald-700/80' : 'bg-red-900/30 border-red-700/80'}`}
               >
                 <div className="flex justify-between items-start gap-4">
                   <div>
@@ -399,7 +399,7 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
                     {lastQuestOutcome.passed ? 'Completed' : 'Needs Review'}
                   </span>
                 </div>
-                <p className="text-gray-200 mt-4 leading-relaxed">{lastQuestOutcome.summary}</p>
+                <p className="text-gray-100 leading-relaxed text-sm sm:text-base">{lastQuestOutcome.summary}</p>
                 {lastQuestOutcome.evidence.length > 0 && (
                   <div className="mt-4">
                     <p className="text-sm font-semibold text-emerald-200 uppercase tracking-wide mb-1">Highlights</p>
@@ -422,17 +422,17 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
                 )}
               </div>
             )}
-            <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mb-12">
+            <div className="flex flex-col sm:flex-row justify-center items-stretch sm:items-center gap-4 sm:gap-6">
                 <button
                     onClick={() => setView('quests')}
-                    className="flex items-center gap-3 bg-amber-600 hover:bg-amber-500 text-black font-bold py-3 px-8 rounded-lg transition-colors duration-300 text-lg w-full sm:w-auto"
+                    className="flex items-center justify-center gap-3 bg-amber-600 hover:bg-amber-500 text-black font-semibold py-3 px-6 rounded-xl transition-colors duration-300 text-base sm:text-lg w-full sm:w-auto shadow-lg"
                 >
                     <QuestIcon className="w-6 h-6" />
                     <span>Learning Quests</span>
                 </button>
                 <button
                     onClick={() => setView('history')}
-                    className="bg-gray-700 hover:bg-gray-600 text-amber-300 font-bold py-3 px-8 rounded-lg transition-colors duration-300 border border-gray-600 w-full sm:w-auto"
+                    className="bg-gray-800 hover:bg-gray-700 text-amber-300 font-semibold py-3 px-6 rounded-xl transition-colors duration-300 border border-gray-600/80 w-full sm:w-auto shadow-lg"
                 >
                     View Conversation History
                 </button>
@@ -463,11 +463,11 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
         className="relative z-10 min-h-screen flex flex-col text-gray-200 font-serif p-4 sm:p-6 lg:p-8"
         style={{ background: environmentImageUrl ? 'transparent' : 'linear-gradient(to bottom right, #1a1a1a, #2b2b2b)' }}
       >
-        <header className="text-center mb-8">
-          <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold text-amber-300 tracking-wider" style={{ textShadow: '0 0 10px rgba(252, 211, 77, 0.5)' }}>
+        <header className="text-center mb-8 space-y-2">
+          <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold text-amber-300 tracking-wider leading-tight px-2" style={{ textShadow: '0 0 10px rgba(252, 211, 77, 0.5)' }}>
             School of the Ancients
           </h1>
-          <p className="text-gray-400 mt-2 text-lg">Old world wisdom. New world classroom.</p>
+          <p className="text-gray-400 text-base sm:text-lg px-4">Old world wisdom. New world classroom.</p>
         </header>
         <main className="max-w-7xl w-full mx-auto flex-grow flex flex-col">
           {renderContent()}

--- a/components/AddCharacterCard.tsx
+++ b/components/AddCharacterCard.tsx
@@ -3,20 +3,33 @@ import React from 'react';
 
 interface AddCharacterCardProps {
   onClick: () => void;
+  className?: string;
 }
 
-const AddCharacterCard: React.FC<AddCharacterCardProps> = ({ onClick }) => {
+const AddCharacterCard: React.FC<AddCharacterCardProps> = ({ onClick, className = '' }) => {
   return (
-    <div
-      className="w-72 h-96 cursor-pointer rounded-lg shadow-lg bg-gray-800/50 border-2 border-dashed border-gray-600 hover:border-amber-400 transition-all duration-300 transform hover:scale-105 flex flex-col items-center justify-center text-gray-400 hover:text-amber-300"
+    <button
+      type="button"
       onClick={onClick}
+      className={`group flex flex-col items-center justify-center text-center text-gray-300 hover:text-amber-200 transition-all duration-300 border-2 border-dashed border-gray-600 hover:border-amber-400 bg-gray-800/60 hover:bg-gray-800/80 rounded-2xl shadow-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 w-[85vw] sm:w-72 md:w-80 h-[22rem] sm:h-96 px-6 ${className}`}
     >
-      <svg xmlns="http://www.w3.org/2000/svg" className="h-24 w-24 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="h-20 w-20 sm:h-24 sm:w-24 mb-4 text-amber-300 group-hover:scale-110 transition-transform"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={1}
+      >
         <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
       </svg>
-      <h3 className="text-2xl font-bold">Bring a new mind to the school.</h3>
-     
-    </div>
+      <h3 className="text-xl sm:text-2xl font-bold leading-relaxed">
+        Bring a new mind to the school.
+      </h3>
+      <p className="mt-3 text-sm text-gray-400">
+        Craft a persona with its own expertise, passions, and voice.
+      </p>
+    </button>
   );
 };
 

--- a/components/CharacterSelector.tsx
+++ b/components/CharacterSelector.tsx
@@ -18,55 +18,61 @@ const CharacterSelector: React.FC<CharacterSelectorProps> = ({ characters, onSel
   };
   
   return (
-    <div className="flex flex-wrap justify-center gap-4 md:gap-8">
-      <AddCharacterCard onClick={onStartCreation} />
-      {characters.map((character) => {
-        const isCustom = character.id.startsWith('custom_');
-        return (
-          <div
-            key={character.id}
-            className="group relative w-full max-w-sm sm:w-72 h-96 cursor-pointer overflow-hidden rounded-lg shadow-lg bg-gray-800 border-2 border-transparent hover:border-amber-400 transition-all duration-300 transform hover:scale-105"
-            onClick={() => onSelectCharacter(character)}
-          >
-            {isCustom && (
-              <button
-                onClick={(e) => handleDelete(e, character.id)}
-                className="absolute top-2 left-2 z-10 p-2 rounded-full bg-red-800/60 hover:bg-red-700 text-white opacity-0 group-hover:opacity-100 transition-all duration-300 -translate-x-2 group-hover:translate-x-0"
-                aria-label={`Delete ${character.name}`}
-              >
-                <TrashIcon className="w-5 h-5" />
-              </button>
-            )}
-            <img 
-              src={character.portraitUrl} 
-              alt={character.name}
-              className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110 filter grayscale group-hover:grayscale-0"
-            />
-            <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent transition-colors duration-300 group-hover:bg-black/70" />
-            <div className="absolute bottom-0 left-0 p-3 sm:p-4 text-white w-full">
-              <h3 className="text-xl sm:text-2xl font-bold text-amber-200">{character.name}</h3>
-              <p className="text-sm text-gray-300 italic mb-2">{character.title}</p>
-              
-              <div className="overflow-hidden transition-all duration-500 ease-in-out max-h-0 group-hover:max-h-64">
-                <div className="overflow-y-auto max-h-64 pr-2">
-                  <p className="text-sm text-gray-400 pt-2 border-t border-gray-700/50 mb-3">
-                    {character.bio}
-                  </p>
+    <div className="w-full">
+      <div className="flex flex-nowrap sm:flex-wrap justify-start sm:justify-center gap-4 md:gap-8 overflow-x-auto sm:overflow-visible pb-6 sm:pb-0 -mx-4 sm:mx-0 px-4 sm:px-0 snap-x snap-mandatory">
+        <AddCharacterCard onClick={onStartCreation} className="flex-shrink-0 snap-center" />
+        {characters.map((character) => {
+          const isCustom = character.id.startsWith('custom_');
+          return (
+            <div
+              key={character.id}
+              className="group relative flex-shrink-0 snap-center w-[82vw] sm:w-72 md:w-80 h-[24rem] sm:h-96 cursor-pointer overflow-hidden rounded-2xl shadow-2xl bg-gray-900/70 border border-gray-700 hover:border-amber-400 transition-all duration-300 hover:-translate-y-1 backdrop-blur"
+              onClick={() => onSelectCharacter(character)}
+            >
+              {isCustom && (
+                <button
+                  onClick={(e) => handleDelete(e, character.id)}
+                  className="absolute top-2 left-2 z-10 p-2 rounded-full bg-red-800/70 hover:bg-red-700 text-white opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-all duration-300 md:-translate-x-2 md:group-hover:translate-x-0 shadow-lg"
+                  aria-label={`Delete ${character.name}`}
+                >
+                  <TrashIcon className="w-5 h-5" />
+                </button>
+              )}
+              <img
+                src={character.portraitUrl}
+                alt={character.name}
+                className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110 filter grayscale group-hover:grayscale-0"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/50 to-black/20 transition-opacity duration-300 group-hover:opacity-90" />
+              <div className="absolute bottom-0 left-0 p-4 sm:p-5 text-white w-full space-y-2">
+                <div className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1">
+                  <h3 className="text-2xl font-bold text-amber-200">{character.name}</h3>
+                  <span className="text-xs uppercase tracking-wide text-amber-300/80 bg-black/40 px-2 py-1 rounded-full w-max">
+                    {character.timeframe}
+                  </span>
+                </div>
+                <p className="text-sm text-gray-300 italic">{character.title}</p>
 
-                  <div className="text-xs text-gray-400 space-y-1 mb-3">
-                    <p><strong className="font-semibold text-gray-300">Timeframe:</strong> {character.timeframe}</p>
-                    <p><strong className="font-semibold text-gray-300">Expertise:</strong> {character.expertise}</p>
-                    <p><strong className="font-semibold text-gray-300">Passion:</strong> {character.passion}</p>
+                <div className="overflow-hidden transition-all duration-500 ease-in-out max-h-32 md:max-h-0 md:group-hover:max-h-64">
+                  <div className="overflow-y-auto max-h-48 pr-1 md:pr-2">
+                    <p className="text-sm text-gray-300/90 border-t border-gray-700/50 pt-3 mt-3 leading-relaxed">
+                      {character.bio}
+                    </p>
+
+                    <div className="text-xs text-gray-400 space-y-1 mt-3">
+                      <p><strong className="font-semibold text-gray-200">Expertise:</strong> {character.expertise}</p>
+                      <p><strong className="font-semibold text-gray-200">Passion:</strong> {character.passion}</p>
+                    </div>
                   </div>
                 </div>
               </div>
+              <div className="absolute top-4 right-4 bg-amber-400 text-black px-3 py-1 rounded-full text-sm font-bold shadow-lg opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity duration-300 md:-translate-y-2 md:group-hover:translate-y-0">
+                Speak
+              </div>
             </div>
-            <div className="absolute top-4 right-4 bg-amber-400 text-black px-3 py-1 rounded-full text-sm font-bold opacity-0 group-hover:opacity-100 transition-opacity duration-300 -translate-y-2 group-hover:translate-y-0">
-              Speak
-            </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
     </div>
   );
 };

--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -493,8 +493,8 @@ ${contextTranscript}
   };
 
   return (
-    <div 
-        className="relative flex flex-col md:flex-row gap-4 md:gap-8 max-w-6xl mx-auto w-full flex-grow rounded-lg md:rounded-2xl shadow-2xl border border-gray-700 overflow-hidden bg-gray-900/60 backdrop-blur-lg transition-all duration-1000"
+    <div
+        className="relative flex flex-col md:flex-row gap-4 md:gap-6 max-w-6xl mx-auto w-full flex-grow rounded-2xl shadow-2xl border border-gray-700/80 overflow-hidden bg-gray-900/70 backdrop-blur-xl transition-all duration-1000"
     >
       {isGeneratingVisual && (
          <div className="absolute inset-0 bg-black/80 flex flex-col items-center justify-center z-30 rounded-lg md:rounded-2xl">
@@ -503,23 +503,36 @@ ${contextTranscript}
         </div>
       )}
       
-      <div className="relative z-10 flex flex-col md:flex-row gap-4 md:gap-8 w-full p-2 sm:p-4 md:p-6">
-        <div className="w-full md:w-1/3 md:max-w-sm flex flex-col items-center text-center">
-            <div className="relative w-40 h-40 sm:w-48 sm:h-48 md:w-64 md:h-64 flex-shrink-0">
-                <img
-                    src={character.portraitUrl}
-                    alt={character.name}
-                    className={`w-full h-full object-cover rounded-full border-4 ${connectionState === ConnectionState.SPEAKING ? 'border-teal-400' : 'border-amber-400'} shadow-lg filter grayscale sepia-[0.2] transition-all duration-300`}
-                />
-                <div className="absolute -bottom-4 left-1/2 -translate-x-1/2">
+      <div className="relative z-10 flex flex-col md:flex-row items-stretch gap-4 md:gap-6 w-full p-4 sm:p-6">
+        <div className="w-full md:w-1/3 md:max-w-sm flex flex-col gap-6 bg-gray-900/60 border border-gray-700/70 rounded-xl p-4 sm:p-6 text-center md:text-left">
+            <div className="flex flex-col items-center gap-4 text-center">
+                <div className="relative w-32 h-32 sm:w-40 sm:h-40 md:w-48 md:h-48 mx-auto">
+                    <img
+                        src={character.portraitUrl}
+                        alt={character.name}
+                        className={`w-full h-full object-cover rounded-full border-4 ${connectionState === ConnectionState.SPEAKING ? 'border-teal-400' : 'border-amber-400'} shadow-lg filter grayscale sepia-[0.2] transition-all duration-300`}
+                    />
+                </div>
+                <div className="w-full flex justify-center">
                     <StatusIndicator state={connectionState} isMicActive={isMicActive} />
                 </div>
+                <div className="space-y-1">
+                    <h2 className="text-2xl sm:text-3xl font-bold text-amber-200">{character.name}</h2>
+                    <p className="text-gray-400 italic text-sm sm:text-base">{character.title}</p>
+                    <p className="text-xs uppercase tracking-[0.3em] text-amber-300/80">{character.timeframe}</p>
+                </div>
             </div>
-            <h2 className="text-2xl sm:text-3xl font-bold text-amber-200 mt-8">{character.name}</h2>
-            <p className="text-gray-400 italic">{character.title}</p>
+
+            <div className="bg-black/30 border border-gray-700/60 rounded-lg p-4 text-left text-sm text-gray-300 leading-relaxed max-h-48 overflow-y-auto">
+                <p>{character.bio}</p>
+                <div className="grid grid-cols-1 gap-2 mt-4 text-xs uppercase tracking-wide text-gray-400">
+                    <p><span className="text-gray-200 font-semibold">Expertise:</span> {character.expertise}</p>
+                    <p><span className="text-gray-200 font-semibold">Passion:</span> {character.passion}</p>
+                </div>
+            </div>
 
             {activeQuest && (
-                <div className="mt-4 p-4 w-full max-w-xs bg-amber-900/40 border border-amber-800/80 rounded-lg text-left animate-fade-in space-y-3">
+                <div className="bg-amber-900/40 border border-amber-800/70 rounded-lg text-left animate-fade-in space-y-3 p-4 shadow-inner">
                     <div>
                         <p className="font-bold text-amber-300 text-xs uppercase tracking-wide">Active Quest</p>
                         <p className="text-amber-100 text-lg font-semibold leading-snug">{activeQuest.title}</p>
@@ -539,89 +552,89 @@ ${contextTranscript}
                     </div>
                 </div>
             )}
-            
-            <div className="mt-6 text-left w-full max-w-xs">
-            {transcript.length <= 1 ? (
-                <div className="animate-fade-in">
-                <h4 className="text-md font-bold text-amber-200 mb-2 text-center">Conversation Starters</h4>
-                <div className="space-y-2">
-                    {character.suggestedPrompts.map((prompt, i) => (
-                    <button
-                        key={i}
-                        onClick={() => sendTextMessage(prompt)}
-                        className="w-full text-sm text-left bg-gray-800/60 hover:bg-gray-700/80 p-3 rounded-lg transition-colors duration-200 border border-gray-700 text-gray-300 disabled:opacity-50"
-                        disabled={connectionState !== ConnectionState.LISTENING && connectionState !== ConnectionState.CONNECTED}
-                    >
-                        <span className="text-amber-300 mr-2">»</span>
-                        {prompt}
-                    </button>
-                    ))}
-                </div>
-                </div>
-            ) : (
-                <div className="animate-fade-in">
-                <h4 className="text-md font-bold text-amber-200 mb-2 text-center">Topics to Explore</h4>
-                {isFetchingSuggestions ? (
-                    <div className="space-y-2">
-                    <div className="w-full bg-gray-800/60 p-3 rounded-lg h-[44px] animate-pulse"></div>
-                    <div className="w-full bg-gray-800/60 p-3 rounded-lg h-[44px] animate-pulse" style={{ animationDelay: '75ms' }}></div>
-                    <div className="w-full bg-gray-800/60 p-3 rounded-lg h-[44px] animate-pulse" style={{ animationDelay: '150ms' }}></div>
+
+            <div className="text-left w-full">
+                {transcript.length <= 1 ? (
+                    <div className="animate-fade-in">
+                        <h4 className="text-sm font-bold text-amber-200 mb-2 text-center md:text-left">Conversation Starters</h4>
+                        <div className="space-y-2">
+                            {character.suggestedPrompts.map((prompt, i) => (
+                                <button
+                                    key={i}
+                                    onClick={() => sendTextMessage(prompt)}
+                                    className="w-full text-sm text-left bg-gray-800/60 hover:bg-gray-700/80 p-3 rounded-lg transition-colors duration-200 border border-gray-700 text-gray-300 disabled:opacity-50"
+                                    disabled={connectionState !== ConnectionState.LISTENING && connectionState !== ConnectionState.CONNECTED}
+                                >
+                                    <span className="text-amber-300 mr-2">»</span>
+                                    {prompt}
+                                </button>
+                            ))}
+                        </div>
                     </div>
                 ) : (
-                    <div className="space-y-2">
-                    {(dynamicSuggestions.length > 0 ? dynamicSuggestions : character.suggestedPrompts).map((prompt, i) => (
-                        <button
-                        key={i}
-                        onClick={() => sendTextMessage(prompt)}
-                        className="w-full text-sm text-left bg-gray-800/60 hover:bg-gray-700/80 p-3 rounded-lg transition-colors duration-200 border border-gray-700 text-gray-300 disabled:opacity-50"
-                        disabled={connectionState !== ConnectionState.LISTENING && connectionState !== ConnectionState.CONNECTED}
-                        >
-                        <span className="text-amber-300 mr-2">»</span>
-                        {prompt}
-                        </button>
-                    ))}
+                    <div className="animate-fade-in">
+                        <h4 className="text-sm font-bold text-amber-200 mb-2 text-center md:text-left">Topics to Explore</h4>
+                        {isFetchingSuggestions ? (
+                            <div className="space-y-2">
+                                <div className="w-full bg-gray-800/60 p-3 rounded-lg h-[44px] animate-pulse"></div>
+                                <div className="w-full bg-gray-800/60 p-3 rounded-lg h-[44px] animate-pulse" style={{ animationDelay: '75ms' }}></div>
+                                <div className="w-full bg-gray-800/60 p-3 rounded-lg h-[44px] animate-pulse" style={{ animationDelay: '150ms' }}></div>
+                            </div>
+                        ) : (
+                            <div className="space-y-2">
+                                {(dynamicSuggestions.length > 0 ? dynamicSuggestions : character.suggestedPrompts).map((prompt, i) => (
+                                    <button
+                                        key={i}
+                                        onClick={() => sendTextMessage(prompt)}
+                                        className="w-full text-sm text-left bg-gray-800/60 hover:bg-gray-700/80 p-3 rounded-lg transition-colors duration-200 border border-gray-700 text-gray-300 disabled:opacity-50"
+                                        disabled={connectionState !== ConnectionState.LISTENING && connectionState !== ConnectionState.CONNECTED}
+                                    >
+                                        <span className="text-amber-300 mr-2">»</span>
+                                        {prompt}
+                                    </button>
+                                ))}
+                            </div>
+                        )}
                     </div>
                 )}
-                </div>
-            )}
             </div>
 
-            <div className="flex items-center justify-center gap-4 mt-auto pt-6 flex-wrap">
-              <button
-                  onClick={() => onEndConversation(transcript, sessionIdRef.current)}
-                  disabled={isSaving}
-                  className="bg-red-800/70 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-300 border border-red-700 disabled:opacity-50 disabled:cursor-wait"
-              >
-                  {isSaving ? 'Saving...' : 'End'}
-              </button>
-              <button
-                  onClick={handleReset}
-                  disabled={transcript.length === 0 && !environmentImageUrl}
-                  className="bg-amber-800/70 hover:bg-amber-700 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-300 border border-amber-700 disabled:opacity-50"
-              >
-                  Reset
-              </button>
-              <div className="flex items-center gap-2">
+            <div className="flex flex-col sm:flex-row sm:flex-wrap sm:justify-center gap-3 mt-auto pt-2">
                 <button
-                    onClick={() => toggleMicrophone()}
-                    aria-label={isMicActive ? "Mute microphone" : "Unmute microphone"}
-                    className={`p-2 rounded-full transition-colors duration-300 border ${isMicActive ? 'bg-blue-800/70 hover:bg-blue-700 border-blue-700' : 'bg-gray-700 hover:bg-gray-600 border-gray-600'}`}
+                    onClick={() => onEndConversation(transcript, sessionIdRef.current)}
+                    disabled={isSaving}
+                    className="bg-red-800/80 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded-lg transition-colors duration-300 border border-red-700 disabled:opacity-50 disabled:cursor-wait w-full sm:w-auto"
                 >
-                    {isMicActive ? <MicrophoneIcon className="w-6 h-6 text-white" /> : <MicrophoneOffIcon className="w-6 h-6 text-white" />}
+                    {isSaving ? 'Saving...' : 'End Session'}
                 </button>
                 <button
-                    onClick={toggleAmbienceMute}
-                    aria-label={isAmbienceMuted ? "Unmute ambient sound" : "Mute ambient sound"}
-                    className={`p-2 rounded-full transition-colors duration-300 border ${!isAmbienceMuted ? 'bg-green-800/70 hover:bg-green-700 border-green-700' : 'bg-gray-700 hover:bg-gray-600 border-gray-600'}`}
+                    onClick={handleReset}
+                    disabled={transcript.length === 0 && !environmentImageUrl}
+                    className="bg-amber-800/80 hover:bg-amber-700 text-white font-semibold py-2 px-4 rounded-lg transition-colors duration-300 border border-amber-700 disabled:opacity-50 w-full sm:w-auto"
                 >
-                    {isAmbienceMuted ? <MuteIcon className="w-6 h-6 text-white" /> : <UnmuteIcon className="w-6 h-6 text-white" />}
+                    Reset Conversation
                 </button>
-              </div>
+                <div className="flex items-center justify-center gap-2 w-full sm:w-auto">
+                    <button
+                        onClick={() => toggleMicrophone()}
+                        aria-label={isMicActive ? "Mute microphone" : "Unmute microphone"}
+                        className={`p-2 rounded-full transition-colors duration-300 border ${isMicActive ? 'bg-blue-800/70 hover:bg-blue-700 border-blue-700' : 'bg-gray-700 hover:bg-gray-600 border-gray-600'} w-12 h-12 flex items-center justify-center`}
+                    >
+                        {isMicActive ? <MicrophoneIcon className="w-6 h-6 text-white" /> : <MicrophoneOffIcon className="w-6 h-6 text-white" />}
+                    </button>
+                    <button
+                        onClick={toggleAmbienceMute}
+                        aria-label={isAmbienceMuted ? "Unmute ambient sound" : "Mute ambient sound"}
+                        className={`p-2 rounded-full transition-colors duration-300 border ${!isAmbienceMuted ? 'bg-green-800/70 hover:bg-green-700 border-green-700' : 'bg-gray-700 hover:bg-gray-600 border-gray-600'} w-12 h-12 flex items-center justify-center`}
+                    >
+                        {isAmbienceMuted ? <MuteIcon className="w-6 h-6 text-white" /> : <UnmuteIcon className="w-6 h-6 text-white" />}
+                    </button>
+                </div>
             </div>
         </div>
-        <div className="w-full md:w-2/3 bg-gray-900/50 p-4 rounded-lg border border-gray-700 h-[60vh] md:h-auto flex flex-col">
-            <h3 className="text-xl font-semibold mb-4 text-gray-300 border-b border-gray-700 pb-2 flex-shrink-0">Conversation Transcript</h3>
-            <div className="flex-grow space-y-4 overflow-y-auto pr-2">
+        <div className="w-full md:w-2/3 bg-gray-900/60 p-4 sm:p-6 rounded-xl border border-gray-700/70 h-[65vh] sm:h-[70vh] md:h-auto flex flex-col">
+            <h3 className="text-xl font-semibold mb-4 text-gray-300 border-b border-gray-700/70 pb-2 flex-shrink-0">Conversation Transcript</h3>
+            <div className="flex-grow space-y-4 overflow-y-auto pr-2 sm:pr-3">
                 {transcript.map((turn, index) => {
                     const isUser = turn.speaker === 'user';
                     const isOperator = turn.speakerName === 'Matrix Operator';
@@ -663,7 +676,7 @@ ${contextTranscript}
                 </>
                 )}
             </div>
-            <form onSubmit={handleSendText} className="mt-4 flex gap-2 flex-shrink-0">
+            <form onSubmit={handleSendText} className="mt-4 flex gap-2 flex-col sm:flex-row flex-shrink-0">
                 <input
                     type="text"
                     value={textInput}
@@ -674,7 +687,7 @@ ${contextTranscript}
                 />
                 <button
                     type="submit"
-                    className="bg-amber-600 hover:bg-amber-500 text-black font-bold p-3 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="bg-amber-600 hover:bg-amber-500 text-black font-bold p-3 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
                     disabled={!textInput.trim() || connectionState === ConnectionState.CONNECTING || connectionState === ConnectionState.SPEAKING || connectionState === ConnectionState.THINKING }
                     aria-label="Send message"
                 >

--- a/components/Instructions.tsx
+++ b/components/Instructions.tsx
@@ -3,24 +3,24 @@ import React from 'react';
 
 const Instructions: React.FC = () => {
   return (
-    <div className="max-w-4xl mx-auto mb-12 bg-gray-800/50 p-6 rounded-lg border border-gray-700 text-left animate-fade-in">
-      <h2 className="text-2xl font-bold text-amber-200 mb-2">Welcome to the School of the Ancients</h2>
-      <p className="text-gray-400 mb-6">
+    <div className="max-w-4xl mx-auto w-full bg-gray-800/60 p-5 sm:p-6 rounded-2xl border border-gray-700/70 text-left animate-fade-in shadow-xl">
+      <h2 className="text-2xl sm:text-3xl font-bold text-amber-200 mb-3 text-center sm:text-left">Welcome to the School of the Ancients</h2>
+      <p className="text-gray-300 mb-6 text-sm sm:text-base leading-relaxed text-center sm:text-left">
         Engage in real-time voice conversations with legendary minds from history. Here's how to begin your journey:
       </p>
-      <div className="grid md:grid-cols-3 gap-6">
-        <div className="bg-gray-900/50 p-4 rounded-lg border border-gray-600">
+      <div className="grid gap-4 sm:gap-6 sm:grid-cols-2 md:grid-cols-3">
+        <div className="bg-gray-900/50 p-4 rounded-xl border border-gray-600/70 shadow-inner">
           <h3 className="font-bold text-lg text-amber-300 mb-2">1. Start a Conversation</h3>
-          <p className="text-gray-300">
+          <p className="text-gray-200 text-sm leading-relaxed">
             Select an ancient from the gallery below or create your own. Grant microphone access when prompted to begin speaking. You can also type messages if you prefer.
           </p>
         </div>
-        <div className="bg-gray-900/50 p-4 rounded-lg border border-gray-600">
+        <div className="bg-gray-900/50 p-4 rounded-xl border border-gray-600/70 shadow-inner">
           <h3 className="font-bold text-lg text-amber-300 mb-2">2. Command Your World</h3>
-          <p className="text-gray-300 mb-3">
+          <p className="text-gray-200 mb-3 text-sm leading-relaxed">
             This is more than a chat. You can command the environment like a "Matrix Operator":
           </p>
-          <ul className="list-disc list-inside space-y-2 text-gray-300">
+          <ul className="list-disc list-inside space-y-2 text-gray-200 text-sm leading-relaxed">
             <li>
               <strong className="text-teal-300">Change Scenery:</strong> Say <span className="italic text-teal-200">"Operator, Take me to the Roman Forum"</span> to transport yourself to a new location.
             </li>
@@ -29,14 +29,14 @@ const Instructions: React.FC = () => {
             </li>
           </ul>
         </div>
-        <div className="bg-gray-900/50 p-4 rounded-lg border border-gray-600">
+        <div className="bg-gray-900/50 p-4 rounded-xl border border-gray-600/70 shadow-inner">
           <h3 className="font-bold text-lg text-amber-300 mb-2">3. Review & Study</h3>
-          <p className="text-gray-300">
+          <p className="text-gray-200 text-sm leading-relaxed">
             Every conversation is automatically saved. Visit your <strong className="text-amber-200">Conversation History</strong> to review transcripts, see AI-generated summaries, and download a complete Study Guide.
           </p>
         </div>
       </div>
-      <p className="text-center text-amber-200 font-semibold mt-6">
+      <p className="text-center text-amber-200 font-semibold mt-6 text-sm sm:text-base">
         Select an ancient below to begin your lesson.
       </p>
     </div>


### PR DESCRIPTION
## Summary
- refine the landing selector layout with mobile-friendly spacing, button sizing, and quest summary styling
- modernize the character gallery cards with responsive widths, horizontal scrolling on small screens, and accessible controls
- reorganize the conversation view and instructions panel to improve readability and controls on phones

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc10338450832fa1916ed50ae5b629