### PR TITLE
Improve mobile selector responsiveness

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -372,38 +372,42 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
       case 'selector':
       default:
         return (
-          <div className="text-center animate-fade-in">
-             <p className="max-w-3xl mx-auto mb-8 text-gray-400 text-lg">
+          <div className="animate-fade-in space-y-8 px-2 text-center sm:space-y-10 sm:px-0">
+            <div className="space-y-3">
+              <p className="mx-auto max-w-2xl text-base leading-relaxed text-gray-300 sm:max-w-3xl sm:text-lg">
                 Engage in real-time voice conversations with legendary minds from history, or embark on a guided Learning Quest to master a new subject.
-            </p>
-            <div className="max-w-3xl mx-auto mb-8 bg-gray-800/50 border border-gray-700 rounded-lg p-4 text-left">
-              <p className="text-sm text-gray-300 mb-2 font-semibold">Quest Progress</p>
-              <p className="text-xs uppercase tracking-wide text-gray-400 mb-3">{completedQuests.length} of {QUESTS.length} quests completed</p>
-              <div className="w-full h-2 bg-gray-700 rounded-full overflow-hidden">
+              </p>
+            </div>
+            <div className="mx-auto w-full max-w-3xl rounded-2xl border border-gray-700 bg-gray-800/60 p-4 text-left shadow-lg sm:p-6">
+              <p className="text-xs font-semibold uppercase tracking-wide text-amber-200/90 sm:text-sm">Quest Progress</p>
+              <p className="mt-1 text-xs uppercase tracking-wide text-gray-400 sm:text-sm">
+                {completedQuests.length} of {QUESTS.length} quests completed
+              </p>
+              <div className="mt-4 h-2 w-full overflow-hidden rounded-full bg-gray-700">
                 <div
-                  className="h-full bg-amber-500 transition-all duration-500"
+                  className="h-full rounded-full bg-amber-500 transition-all duration-500"
                   style={{ width: `${Math.min(100, Math.round((completedQuests.length / Math.max(QUESTS.length, 1)) * 100))}%` }}
                 />
               </div>
             </div>
             {lastQuestOutcome && (
               <div
-                className={`max-w-3xl mx-auto mb-8 rounded-lg border p-5 text-left shadow-lg ${lastQuestOutcome.passed ? 'bg-emerald-900/40 border-emerald-700' : 'bg-red-900/30 border-red-700'}`}
+                className={`mx-auto w-full max-w-3xl rounded-2xl border p-5 text-left shadow-xl sm:p-6 ${lastQuestOutcome.passed ? 'bg-emerald-900/40 border-emerald-700' : 'bg-red-900/30 border-red-700'}`}
               >
-                <div className="flex justify-between items-start gap-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                   <div>
-                    <p className="text-xs uppercase tracking-wide text-gray-300 font-semibold">Latest Quest Review</p>
-                    <h3 className="text-2xl font-bold text-amber-200 mt-1">{lastQuestOutcome.questTitle}</h3>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-gray-300">Latest Quest Review</p>
+                    <h3 className="mt-1 text-2xl font-bold text-amber-200 sm:text-3xl">{lastQuestOutcome.questTitle}</h3>
                   </div>
-                  <span className={`text-sm font-semibold px-3 py-1 rounded-full ${lastQuestOutcome.passed ? 'bg-emerald-600 text-emerald-50' : 'bg-red-600 text-red-50'}`}>
+                  <span className={`inline-flex items-center justify-center rounded-full px-3 py-1 text-sm font-semibold ${lastQuestOutcome.passed ? 'bg-emerald-600 text-emerald-50' : 'bg-red-600 text-red-50'}`}>
                     {lastQuestOutcome.passed ? 'Completed' : 'Needs Review'}
                   </span>
                 </div>
-                <p className="text-gray-200 mt-4 leading-relaxed">{lastQuestOutcome.summary}</p>
+                <p className="mt-4 text-sm leading-relaxed text-gray-100 sm:text-base">{lastQuestOutcome.summary}</p>
                 {lastQuestOutcome.evidence.length > 0 && (
-                  <div className="mt-4">
-                    <p className="text-sm font-semibold text-emerald-200 uppercase tracking-wide mb-1">Highlights</p>
-                    <ul className="list-disc list-inside text-gray-100 space-y-1 text-sm">
+                  <div className="mt-4 space-y-2">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-emerald-200 sm:text-sm">Highlights</p>
+                    <ul className="list-disc space-y-1 pl-4 text-sm text-gray-100">
                       {lastQuestOutcome.evidence.map(item => (
                         <li key={item}>{item}</li>
                       ))}
@@ -411,9 +415,9 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
                   </div>
                 )}
                 {!lastQuestOutcome.passed && lastQuestOutcome.improvements.length > 0 && (
-                  <div className="mt-4">
-                    <p className="text-sm font-semibold text-red-200 uppercase tracking-wide mb-1">Next Steps</p>
-                    <ul className="list-disc list-inside text-red-100 space-y-1 text-sm">
+                  <div className="mt-4 space-y-2">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-red-200 sm:text-sm">Next Steps</p>
+                    <ul className="list-disc space-y-1 pl-4 text-sm text-red-100">
                       {lastQuestOutcome.improvements.map(item => (
                         <li key={item}>{item}</li>
                       ))}
@@ -422,24 +426,24 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
                 )}
               </div>
             )}
-            <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mb-12">
-                <button
-                    onClick={() => setView('quests')}
-                    className="flex items-center gap-3 bg-amber-600 hover:bg-amber-500 text-black font-bold py-3 px-8 rounded-lg transition-colors duration-300 text-lg w-full sm:w-auto"
-                >
-                    <QuestIcon className="w-6 h-6" />
-                    <span>Learning Quests</span>
-                </button>
-                <button
-                    onClick={() => setView('history')}
-                    className="bg-gray-700 hover:bg-gray-600 text-amber-300 font-bold py-3 px-8 rounded-lg transition-colors duration-300 border border-gray-600 w-full sm:w-auto"
-                >
-                    View Conversation History
-                </button>
+            <div className="flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center sm:gap-4">
+              <button
+                onClick={() => setView('quests')}
+                className="flex w-full items-center justify-center gap-3 rounded-xl bg-amber-600 py-3 text-base font-bold text-black transition-colors duration-300 hover:bg-amber-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 sm:w-auto sm:px-8 sm:text-lg"
+              >
+                <QuestIcon className="h-6 w-6" />
+                <span>Learning Quests</span>
+              </button>
+              <button
+                onClick={() => setView('history')}
+                className="w-full rounded-xl border border-gray-600 bg-gray-700 py-3 text-base font-bold text-amber-300 transition-colors duration-300 hover:bg-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 sm:w-auto sm:px-8 sm:text-lg"
+              >
+                View Conversation History
+              </button>
             </div>
-
-            <Instructions />
-
+            <div className="mx-auto w-full max-w-5xl text-left">
+              <Instructions />
+            </div>
             <CharacterSelector
               characters={[...customCharacters, ...CHARACTERS]}
               onSelectCharacter={handleSelectCharacter}
@@ -459,17 +463,20 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
       />
       {environmentImageUrl && <div className="absolute inset-0 bg-black/50 z-0" />}
 
-      <div 
-        className="relative z-10 min-h-screen flex flex-col text-gray-200 font-serif p-4 sm:p-6 lg:p-8"
-        style={{ background: environmentImageUrl ? 'transparent' : 'linear-gradient(to bottom right, #1a1a1a, #2b2b2b)' }}
+      <div
+        className="relative z-10 min-h-screen flex flex-col text-gray-200 font-serif p-4 pb-16 sm:p-6 sm:pb-20 lg:p-8"
+        style={{
+          background: environmentImageUrl ? 'transparent' : 'linear-gradient(to bottom right, #1a1a1a, #2b2b2b)',
+          paddingBottom: 'calc(env(safe-area-inset-bottom) + 2rem)',
+        }}
       >
-        <header className="text-center mb-8">
-          <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold text-amber-300 tracking-wider" style={{ textShadow: '0 0 10px rgba(252, 211, 77, 0.5)' }}>
+        <header className="mb-8 text-center sm:mb-10">
+          <h1 className="text-4xl font-bold tracking-wider text-amber-300 sm:text-5xl md:text-6xl" style={{ textShadow: '0 0 10px rgba(252, 211, 77, 0.5)' }}>
             School of the Ancients
           </h1>
-          <p className="text-gray-400 mt-2 text-lg">Old world wisdom. New world classroom.</p>
+          <p className="mt-2 text-base text-gray-400 sm:text-lg">Old world wisdom. New world classroom.</p>
         </header>
-        <main className="max-w-7xl w-full mx-auto flex-grow flex flex-col">
+        <main className="mx-auto flex w-full max-w-7xl flex-grow flex-col gap-8 sm:gap-10">
           {renderContent()}
         </main>
       </div>

--- a/components/AddCharacterCard.tsx
+++ b/components/AddCharacterCard.tsx
@@ -6,16 +6,42 @@ interface AddCharacterCardProps {
 }
 
 const AddCharacterCard: React.FC<AddCharacterCardProps> = ({ onClick }) => {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClick();
+    }
+  };
+
   return (
     <div
-      className="w-72 h-96 cursor-pointer rounded-lg shadow-lg bg-gray-800/50 border-2 border-dashed border-gray-600 hover:border-amber-400 transition-all duration-300 transform hover:scale-105 flex flex-col items-center justify-center text-gray-400 hover:text-amber-300"
+      role="button"
+      tabIndex={0}
+      aria-label="Create a custom ancient"
       onClick={onClick}
+      onKeyDown={handleKeyDown}
+      className="group relative flex aspect-[3/4] w-full max-w-sm cursor-pointer select-none flex-col items-center justify-center rounded-2xl border-2 border-dashed border-gray-700 bg-gray-900/60 p-6 text-center text-gray-400 shadow-lg transition-all duration-300 focus-visible:border-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 sm:max-w-none sm:aspect-auto sm:h-[24rem] sm:p-8 md:h-[26rem]"
     >
-      <svg xmlns="http://www.w3.org/2000/svg" className="h-24 w-24 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
+      <div className="absolute inset-0 bg-gradient-to-b from-gray-900/40 via-gray-900/20 to-gray-900/60 opacity-90 transition-opacity duration-300 group-hover:opacity-100" />
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="relative h-16 w-16 text-amber-300 transition-transform duration-300 group-hover:scale-110 sm:h-20 sm:w-20"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={1.5}
+      >
         <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
       </svg>
-      <h3 className="text-2xl font-bold">Bring a new mind to the school.</h3>
-     
+      <div className="relative mt-4 space-y-2">
+        <h3 className="text-xl font-bold text-gray-200 sm:text-2xl">Bring a new mind to the school.</h3>
+        <p className="text-sm text-gray-400 sm:text-base">
+          Craft your own guide and tailor their knowledge to your next quest.
+        </p>
+      </div>
+      <span className="relative mt-6 inline-flex items-center gap-2 rounded-full border border-amber-400/40 bg-amber-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-amber-200 transition-all duration-300 group-hover:bg-amber-500/20">
+        Tap to begin
+      </span>
     </div>
   );
 };

--- a/components/CharacterSelector.tsx
+++ b/components/CharacterSelector.tsx
@@ -11,63 +11,87 @@ interface CharacterSelectorProps {
   onDeleteCharacter: (characterId: string) => void;
 }
 
-const CharacterSelector: React.FC<CharacterSelectorProps> = ({ characters, onSelectCharacter, onStartCreation, onDeleteCharacter }) => {
-  const handleDelete = (e: React.MouseEvent, characterId: string) => {
-    e.stopPropagation(); // Prevent card click
+const CharacterSelector: React.FC<CharacterSelectorProps> = ({
+  characters,
+  onSelectCharacter,
+  onStartCreation,
+  onDeleteCharacter,
+}) => {
+  const handleDelete = (event: React.MouseEvent, characterId: string) => {
+    event.stopPropagation();
     onDeleteCharacter(characterId);
   };
-  
+
+  const handleCardKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, character: Character) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onSelectCharacter(character);
+    }
+  };
+
   return (
-    <div className="flex flex-wrap justify-center gap-4 md:gap-8">
-      <AddCharacterCard onClick={onStartCreation} />
-      {characters.map((character) => {
-        const isCustom = character.id.startsWith('custom_');
-        return (
-          <div
-            key={character.id}
-            className="group relative w-full max-w-sm sm:w-72 h-96 cursor-pointer overflow-hidden rounded-lg shadow-lg bg-gray-800 border-2 border-transparent hover:border-amber-400 transition-all duration-300 transform hover:scale-105"
-            onClick={() => onSelectCharacter(character)}
-          >
-            {isCustom && (
-              <button
-                onClick={(e) => handleDelete(e, character.id)}
-                className="absolute top-2 left-2 z-10 p-2 rounded-full bg-red-800/60 hover:bg-red-700 text-white opacity-0 group-hover:opacity-100 transition-all duration-300 -translate-x-2 group-hover:translate-x-0"
-                aria-label={`Delete ${character.name}`}
-              >
-                <TrashIcon className="w-5 h-5" />
-              </button>
-            )}
-            <img 
-              src={character.portraitUrl} 
-              alt={character.name}
-              className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110 filter grayscale group-hover:grayscale-0"
-            />
-            <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent transition-colors duration-300 group-hover:bg-black/70" />
-            <div className="absolute bottom-0 left-0 p-3 sm:p-4 text-white w-full">
-              <h3 className="text-xl sm:text-2xl font-bold text-amber-200">{character.name}</h3>
-              <p className="text-sm text-gray-300 italic mb-2">{character.title}</p>
-              
-              <div className="overflow-hidden transition-all duration-500 ease-in-out max-h-0 group-hover:max-h-64">
-                <div className="overflow-y-auto max-h-64 pr-2">
-                  <p className="text-sm text-gray-400 pt-2 border-t border-gray-700/50 mb-3">
+    <section aria-label="Select an ancient to converse with" className="mx-auto w-full max-w-6xl">
+      <div className="grid grid-cols-1 gap-4 px-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 sm:gap-6 md:gap-8 sm:px-0">
+        <AddCharacterCard onClick={onStartCreation} />
+        {characters.map(character => {
+          const isCustom = character.id.startsWith('custom_');
+          return (
+            <div
+              key={character.id}
+              role="button"
+              tabIndex={0}
+              aria-label={`Speak with ${character.name}`}
+              onClick={() => onSelectCharacter(character)}
+              onKeyDown={event => handleCardKeyDown(event, character)}
+              className="group relative flex aspect-[3/4] w-full cursor-pointer select-none flex-col overflow-hidden rounded-2xl border border-gray-700/70 bg-gray-900/70 shadow-lg transition-all duration-300 hover:-translate-y-1 hover:border-amber-400 focus-visible:border-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 sm:aspect-[3/4]"
+            >
+              {isCustom && (
+                <button
+                  onClick={event => handleDelete(event, character.id)}
+                  className="absolute left-3 top-3 z-20 rounded-full bg-red-800/70 p-2 text-white opacity-100 transition-all duration-300 hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 sm:opacity-0 sm:-translate-x-2 sm:group-hover:translate-x-0 sm:group-hover:opacity-100"
+                  aria-label={`Delete ${character.name}`}
+                >
+                  <TrashIcon className="h-5 w-5" />
+                </button>
+              )}
+              <img
+                src={character.portraitUrl}
+                alt={character.name}
+                className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-110"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/40 to-black/70" />
+              <div className="relative mt-auto flex h-full flex-col justify-end p-4 text-left text-white sm:p-5">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h3 className="text-2xl font-bold text-amber-200 sm:text-3xl">{character.name}</h3>
+                    <p className="mt-1 text-sm italic text-gray-200/90 sm:text-base">{character.title}</p>
+                  </div>
+                  <div className="hidden sm:inline-flex items-center rounded-full bg-amber-400 px-3 py-1 text-sm font-bold text-black shadow-md transition-opacity duration-300 sm:opacity-0 sm:group-hover:opacity-100">
+                    Speak
+                  </div>
+                </div>
+                <div className="mt-4 space-y-3 text-xs text-gray-200 sm:max-h-0 sm:overflow-hidden sm:pr-2 sm:text-sm sm:transition-[max-height] sm:duration-500 sm:ease-in-out sm:group-hover:max-h-64">
+                  <p className="leading-relaxed text-gray-200/90">
                     {character.bio}
                   </p>
-
-                  <div className="text-xs text-gray-400 space-y-1 mb-3">
-                    <p><strong className="font-semibold text-gray-300">Timeframe:</strong> {character.timeframe}</p>
-                    <p><strong className="font-semibold text-gray-300">Expertise:</strong> {character.expertise}</p>
-                    <p><strong className="font-semibold text-gray-300">Passion:</strong> {character.passion}</p>
+                  <div className="grid grid-cols-1 gap-2 text-[0.7rem] uppercase tracking-wide text-gray-300/80 sm:text-xs">
+                    <p>
+                      <span className="font-semibold text-gray-100">Timeframe:</span> {character.timeframe}
+                    </p>
+                    <p>
+                      <span className="font-semibold text-gray-100">Expertise:</span> {character.expertise}
+                    </p>
+                    <p>
+                      <span className="font-semibold text-gray-100">Passion:</span> {character.passion}
+                    </p>
                   </div>
                 </div>
               </div>
             </div>
-            <div className="absolute top-4 right-4 bg-amber-400 text-black px-3 py-1 rounded-full text-sm font-bold opacity-0 group-hover:opacity-100 transition-opacity duration-300 -translate-y-2 group-hover:translate-y-0">
-              Speak
-            </div>
-          </div>
-        );
-      })}
-    </div>
+          );
+        })}
+      </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
## Summary
- smooth out the landing experience on small screens with mobile-first spacing, quest progress styling, and safe-area padding
- restyle the character selector into a responsive grid with accessible keyboard/touch interactions
- refresh the add-character card with clearer copy and visual affordances for mobile users

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc10338450832fa1916ed50ae5b629