### PR TITLE
Improve mobile layout for the character selector

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -372,11 +372,11 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
       case 'selector':
       default:
         return (
-          <div className="text-center animate-fade-in">
-             <p className="max-w-3xl mx-auto mb-8 text-gray-400 text-lg">
+          <div className="text-center animate-fade-in space-y-8 sm:space-y-10">
+             <p className="max-w-3xl mx-auto text-gray-400 text-base sm:text-lg px-4">
                 Engage in real-time voice conversations with legendary minds from history, or embark on a guided Learning Quest to master a new subject.
             </p>
-            <div className="max-w-3xl mx-auto mb-8 bg-gray-800/50 border border-gray-700 rounded-lg p-4 text-left">
+            <div className="max-w-3xl mx-auto bg-gray-800/50 border border-gray-700 rounded-xl p-4 sm:p-5 text-left px-4 sm:px-6">
               <p className="text-sm text-gray-300 mb-2 font-semibold">Quest Progress</p>
               <p className="text-xs uppercase tracking-wide text-gray-400 mb-3">{completedQuests.length} of {QUESTS.length} quests completed</p>
               <div className="w-full h-2 bg-gray-700 rounded-full overflow-hidden">
@@ -388,7 +388,7 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
             </div>
             {lastQuestOutcome && (
               <div
-                className={`max-w-3xl mx-auto mb-8 rounded-lg border p-5 text-left shadow-lg ${lastQuestOutcome.passed ? 'bg-emerald-900/40 border-emerald-700' : 'bg-red-900/30 border-red-700'}`}
+                className={`max-w-3xl mx-auto rounded-xl border p-5 text-left shadow-lg px-4 sm:px-6 ${lastQuestOutcome.passed ? 'bg-emerald-900/40 border-emerald-700' : 'bg-red-900/30 border-red-700'}`}
               >
                 <div className="flex justify-between items-start gap-4">
                   <div>
@@ -422,7 +422,7 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
                 )}
               </div>
             )}
-            <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mb-12">
+            <div className="flex flex-col sm:flex-row justify-center items-center gap-4 px-4">
                 <button
                     onClick={() => setView('quests')}
                     className="flex items-center gap-3 bg-amber-600 hover:bg-amber-500 text-black font-bold py-3 px-8 rounded-lg transition-colors duration-300 text-lg w-full sm:w-auto"

--- a/components/AddCharacterCard.tsx
+++ b/components/AddCharacterCard.tsx
@@ -8,14 +8,16 @@ interface AddCharacterCardProps {
 const AddCharacterCard: React.FC<AddCharacterCardProps> = ({ onClick }) => {
   return (
     <div
-      className="w-72 h-96 cursor-pointer rounded-lg shadow-lg bg-gray-800/50 border-2 border-dashed border-gray-600 hover:border-amber-400 transition-all duration-300 transform hover:scale-105 flex flex-col items-center justify-center text-gray-400 hover:text-amber-300"
+      className="w-full sm:w-72 h-60 sm:h-96 cursor-pointer rounded-xl shadow-lg bg-gray-800/60 border-2 border-dashed border-gray-600 hover:border-amber-400 transition-all duration-300 hover:-translate-y-1 flex flex-col items-center justify-center text-gray-300 hover:text-amber-300 p-6 text-center"
       onClick={onClick}
     >
-      <svg xmlns="http://www.w3.org/2000/svg" className="h-24 w-24 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
+      <svg xmlns="http://www.w3.org/2000/svg" className="h-16 w-16 sm:h-24 sm:w-24 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
       </svg>
-      <h3 className="text-2xl font-bold">Bring a new mind to the school.</h3>
-     
+      <h3 className="text-xl sm:text-2xl font-bold leading-snug">
+        Bring a new mind to the school.
+      </h3>
+
     </div>
   );
 };

--- a/components/CharacterSelector.tsx
+++ b/components/CharacterSelector.tsx
@@ -18,42 +18,42 @@ const CharacterSelector: React.FC<CharacterSelectorProps> = ({ characters, onSel
   };
   
   return (
-    <div className="flex flex-wrap justify-center gap-4 md:gap-8">
+    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 md:gap-6 xl:gap-8 w-full px-1 sm:px-0">
       <AddCharacterCard onClick={onStartCreation} />
       {characters.map((character) => {
         const isCustom = character.id.startsWith('custom_');
         return (
           <div
             key={character.id}
-            className="group relative w-full max-w-sm sm:w-72 h-96 cursor-pointer overflow-hidden rounded-lg shadow-lg bg-gray-800 border-2 border-transparent hover:border-amber-400 transition-all duration-300 transform hover:scale-105"
+            className="group relative w-full h-[26rem] sm:h-96 cursor-pointer overflow-hidden rounded-xl shadow-lg bg-gray-800/80 border border-gray-700 hover:border-amber-400 transition-all duration-300 hover:-translate-y-1"
             onClick={() => onSelectCharacter(character)}
           >
             {isCustom && (
               <button
                 onClick={(e) => handleDelete(e, character.id)}
-                className="absolute top-2 left-2 z-10 p-2 rounded-full bg-red-800/60 hover:bg-red-700 text-white opacity-0 group-hover:opacity-100 transition-all duration-300 -translate-x-2 group-hover:translate-x-0"
+                className="absolute top-2 left-2 z-10 p-2 rounded-full bg-red-800/60 hover:bg-red-700 text-white opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-all duration-300 -translate-x-1 md:-translate-x-2 md:group-hover:translate-x-0"
                 aria-label={`Delete ${character.name}`}
               >
                 <TrashIcon className="w-5 h-5" />
               </button>
             )}
-            <img 
-              src={character.portraitUrl} 
+            <img
+              src={character.portraitUrl}
               alt={character.name}
-              className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110 filter grayscale group-hover:grayscale-0"
+              className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105 filter grayscale md:group-hover:grayscale-0"
             />
-            <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent transition-colors duration-300 group-hover:bg-black/70" />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/50 to-transparent transition-colors duration-300 md:group-hover:from-black/80" />
             <div className="absolute bottom-0 left-0 p-3 sm:p-4 text-white w-full">
-              <h3 className="text-xl sm:text-2xl font-bold text-amber-200">{character.name}</h3>
-              <p className="text-sm text-gray-300 italic mb-2">{character.title}</p>
-              
-              <div className="overflow-hidden transition-all duration-500 ease-in-out max-h-0 group-hover:max-h-64">
-                <div className="overflow-y-auto max-h-64 pr-2">
-                  <p className="text-sm text-gray-400 pt-2 border-t border-gray-700/50 mb-3">
+              <h3 className="text-lg sm:text-2xl font-bold text-amber-200">{character.name}</h3>
+              <p className="text-xs sm:text-sm text-gray-300 italic mb-2">{character.title}</p>
+
+              <div className="overflow-hidden transition-all duration-500 ease-in-out max-h-40 md:max-h-0 md:group-hover:max-h-64">
+                <div className="overflow-y-auto max-h-32 md:max-h-64 pr-1 sm:pr-2">
+                  <p className="text-xs sm:text-sm text-gray-300/90 pt-2 border-t border-gray-700/50 mb-3 leading-relaxed">
                     {character.bio}
                   </p>
 
-                  <div className="text-xs text-gray-400 space-y-1 mb-3">
+                  <div className="text-[0.7rem] sm:text-xs text-gray-300 space-y-1 mb-3">
                     <p><strong className="font-semibold text-gray-300">Timeframe:</strong> {character.timeframe}</p>
                     <p><strong className="font-semibold text-gray-300">Expertise:</strong> {character.expertise}</p>
                     <p><strong className="font-semibold text-gray-300">Passion:</strong> {character.passion}</p>
@@ -61,7 +61,7 @@ const CharacterSelector: React.FC<CharacterSelectorProps> = ({ characters, onSel
                 </div>
               </div>
             </div>
-            <div className="absolute top-4 right-4 bg-amber-400 text-black px-3 py-1 rounded-full text-sm font-bold opacity-0 group-hover:opacity-100 transition-opacity duration-300 -translate-y-2 group-hover:translate-y-0">
+            <div className="hidden md:flex absolute top-4 right-4 bg-amber-400 text-black px-3 py-1 rounded-full text-sm font-bold opacity-0 group-hover:opacity-100 transition-opacity duration-300 -translate-y-2 group-hover:translate-y-0">
               Speak
             </div>
           </div>

--- a/components/Instructions.tsx
+++ b/components/Instructions.tsx
@@ -3,24 +3,24 @@ import React from 'react';
 
 const Instructions: React.FC = () => {
   return (
-    <div className="max-w-4xl mx-auto mb-12 bg-gray-800/50 p-6 rounded-lg border border-gray-700 text-left animate-fade-in">
-      <h2 className="text-2xl font-bold text-amber-200 mb-2">Welcome to the School of the Ancients</h2>
-      <p className="text-gray-400 mb-6">
+    <div className="max-w-4xl mx-auto mb-10 sm:mb-12 bg-gray-800/60 p-4 sm:p-6 rounded-xl border border-gray-700 text-left animate-fade-in space-y-4">
+      <h2 className="text-xl sm:text-2xl font-bold text-amber-200">Welcome to the School of the Ancients</h2>
+      <p className="text-sm sm:text-base text-gray-400">
         Engage in real-time voice conversations with legendary minds from history. Here's how to begin your journey:
       </p>
-      <div className="grid md:grid-cols-3 gap-6">
-        <div className="bg-gray-900/50 p-4 rounded-lg border border-gray-600">
+      <div className="grid gap-4 sm:gap-6 sm:grid-cols-2 xl:grid-cols-3">
+        <div className="bg-gray-900/60 p-4 sm:p-5 rounded-lg border border-gray-600 shadow-sm">
           <h3 className="font-bold text-lg text-amber-300 mb-2">1. Start a Conversation</h3>
-          <p className="text-gray-300">
+          <p className="text-sm sm:text-base text-gray-300">
             Select an ancient from the gallery below or create your own. Grant microphone access when prompted to begin speaking. You can also type messages if you prefer.
           </p>
         </div>
-        <div className="bg-gray-900/50 p-4 rounded-lg border border-gray-600">
+        <div className="bg-gray-900/60 p-4 sm:p-5 rounded-lg border border-gray-600 shadow-sm">
           <h3 className="font-bold text-lg text-amber-300 mb-2">2. Command Your World</h3>
-          <p className="text-gray-300 mb-3">
+          <p className="text-sm sm:text-base text-gray-300 mb-3">
             This is more than a chat. You can command the environment like a "Matrix Operator":
           </p>
-          <ul className="list-disc list-inside space-y-2 text-gray-300">
+          <ul className="list-disc list-inside space-y-2 text-sm sm:text-base text-gray-300">
             <li>
               <strong className="text-teal-300">Change Scenery:</strong> Say <span className="italic text-teal-200">"Operator, Take me to the Roman Forum"</span> to transport yourself to a new location.
             </li>
@@ -29,14 +29,14 @@ const Instructions: React.FC = () => {
             </li>
           </ul>
         </div>
-        <div className="bg-gray-900/50 p-4 rounded-lg border border-gray-600">
+        <div className="bg-gray-900/60 p-4 sm:p-5 rounded-lg border border-gray-600 shadow-sm">
           <h3 className="font-bold text-lg text-amber-300 mb-2">3. Review & Study</h3>
-          <p className="text-gray-300">
+          <p className="text-sm sm:text-base text-gray-300">
             Every conversation is automatically saved. Visit your <strong className="text-amber-200">Conversation History</strong> to review transcripts, see AI-generated summaries, and download a complete Study Guide.
           </p>
         </div>
       </div>
-      <p className="text-center text-amber-200 font-semibold mt-6">
+      <p className="text-center text-amber-200 font-semibold text-sm sm:text-base pt-2">
         Select an ancient below to begin your lesson.
       </p>
     </div>


### PR DESCRIPTION
## Summary
- refresh the landing selector layout with tighter spacing and rounded containers for smaller screens
- make the character gallery responsive with grid-based cards, mobile-friendly details, and accessible custom delete controls
- tune the instructions panel and add-character card so typography and spacing scale down gracefully on phones

## Testing
- `npm run build`

## Screenshots
- ![Mobile selector view](browser:/invocations/ptinobev/artifacts/artifacts/mobile-home.png)


------
https://chatgpt.com/codex/tasks/task_e_68dc10338450832fa1916ed50ae5b629