### PR TITLE
Add Supabase SSO authentication

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,6 +18,7 @@ import QuestsView from './components/QuestsView';
 import Instructions from './components/Instructions';
 import { CHARACTERS, QUESTS } from './constants';
 import QuestIcon from './components/icons/QuestIcon';
+import { useSupabaseAuth } from '@/hooks/useSupabaseAuth';
 
 const CUSTOM_CHARACTERS_KEY = 'school-of-the-ancients-custom-characters';
 // Fix: Add history key constant for conversation management.
@@ -69,6 +70,14 @@ const saveCompletedQuests = (questIds: string[]) => {
 };
 
 const App: React.FC = () => {
+  const {
+    user,
+    profile,
+    loading: authLoading,
+    error: authError,
+    signInWithGoogle,
+    signOut,
+  } = useSupabaseAuth();
   const [selectedCharacter, setSelectedCharacter] = useState<Character | null>(null);
   const [view, setView] = useState<'selector' | 'conversation' | 'history' | 'creator' | 'quests'>('selector');
   const [customCharacters, setCustomCharacters] = useState<Character[]>([]);
@@ -78,6 +87,37 @@ const App: React.FC = () => {
   const [isSaving, setIsSaving] = useState(false);
   const [completedQuests, setCompletedQuests] = useState<string[]>([]);
   const [lastQuestOutcome, setLastQuestOutcome] = useState<QuestAssessment | null>(null);
+  const accountName = profile?.displayName ?? profile?.email ?? user?.email ?? 'Adventurer';
+
+  if (authLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#0f172a] text-gray-100">
+        <p className="text-lg font-semibold tracking-wide">Preparing your classroom...</p>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#0f172a] text-gray-100 p-6">
+        <div className="max-w-md w-full text-center space-y-6 bg-gray-900/60 border border-gray-700 rounded-2xl p-8 shadow-xl">
+          <h1 className="text-3xl font-bold text-amber-300 tracking-wide">School of the Ancients</h1>
+          <p className="text-gray-300">Sign in to unlock saved conversations, quests, and progress tracking.</p>
+          {authError && (
+            <p className="text-sm text-red-400 bg-red-900/40 border border-red-700 rounded-lg px-3 py-2">
+              {authError}
+            </p>
+          )}
+          <button
+            onClick={signInWithGoogle}
+            className="w-full flex items-center justify-center gap-3 bg-amber-500 hover:bg-amber-400 text-black font-semibold py-3 px-6 rounded-lg transition-colors duration-200"
+          >
+            <span className="text-lg">Continue with Google</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   useEffect(() => {
     // Load custom characters from local storage
@@ -463,7 +503,32 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
         className="relative z-10 min-h-screen flex flex-col text-gray-200 font-serif p-4 sm:p-6 lg:p-8"
         style={{ background: environmentImageUrl ? 'transparent' : 'linear-gradient(to bottom right, #1a1a1a, #2b2b2b)' }}
       >
-        <header className="text-center mb-8">
+        <header className="relative text-center mb-8">
+          <div className="absolute top-0 right-0 flex items-center gap-3 bg-gray-900/50 border border-gray-700 rounded-full pl-3 pr-4 py-2 shadow-lg">
+            {profile?.avatarUrl ? (
+              <img
+                src={profile.avatarUrl}
+                alt={`${accountName}'s avatar`}
+                className="w-10 h-10 rounded-full border border-amber-300 object-cover"
+              />
+            ) : (
+              <div className="w-10 h-10 rounded-full border border-amber-300 bg-amber-500/20 flex items-center justify-center text-amber-200 font-semibold">
+                {accountName.charAt(0).toUpperCase()}
+              </div>
+            )}
+            <div className="flex flex-col items-end leading-tight">
+              <span className="text-sm font-semibold text-amber-200">{accountName}</span>
+              {profile?.email && (
+                <span className="text-xs text-gray-300">{profile.email}</span>
+              )}
+              <button
+                onClick={signOut}
+                className="text-xs text-gray-400 hover:text-amber-300 transition-colors"
+              >
+                Sign out
+              </button>
+            </div>
+          </div>
           <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold text-amber-300 tracking-wider" style={{ textShadow: '0 0 10px rgba(252, 211, 77, 0.5)' }}>
             School of the Ancients
           </h1>

--- a/hooks/useSupabaseAuth.tsx
+++ b/hooks/useSupabaseAuth.tsx
@@ -1,0 +1,166 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import type { User } from '@supabase/supabase-js';
+import { supabase } from '@/supabaseClient';
+import type { Profile } from '@/types';
+
+interface AuthContextValue {
+  user: User | null;
+  profile: Profile | null;
+  loading: boolean;
+  error: string | null;
+  signInWithGoogle: () => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+const SupabaseAuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+type ProfileRow = {
+  id: string;
+  email: string | null;
+  display_name: string | null;
+  avatar_url: string | null;
+  created_at: string;
+};
+
+const mapProfile = (input: ProfileRow): Profile => ({
+  id: input.id,
+  email: input.email ?? null,
+  displayName: input.display_name ?? null,
+  avatarUrl: input.avatar_url ?? null,
+  createdAt: input.created_at,
+});
+
+export const SupabaseAuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const hydrateSession = async () => {
+      setLoading(true);
+      const { data, error: sessionError } = await supabase.auth.getSession();
+      if (!isMounted) {
+        return;
+      }
+
+      if (sessionError) {
+        setError(sessionError.message);
+        setUser(null);
+        setProfile(null);
+        setLoading(false);
+        return;
+      }
+
+      const activeSession = data.session;
+      setUser(activeSession?.user ?? null);
+      if (activeSession?.user) {
+        await fetchProfile(activeSession.user, false);
+      } else {
+        setProfile(null);
+      }
+      setLoading(false);
+    };
+
+    const fetchProfile = async (sessionUser: User, toggleLoading = true) => {
+      if (toggleLoading) {
+        setLoading(true);
+      }
+      const { data, error: profileError } = await supabase
+        .from('profiles')
+        .select('id, email, display_name, avatar_url, created_at')
+        .eq('id', sessionUser.id)
+        .maybeSingle();
+
+      if (!isMounted) {
+        return;
+      }
+
+      if (profileError) {
+        setError(profileError.message);
+        setProfile(null);
+      } else if (data) {
+        setProfile(mapProfile(data));
+        setError(null);
+      } else {
+        setProfile({
+          id: sessionUser.id,
+          email: sessionUser.email ?? null,
+          displayName: sessionUser.user_metadata?.full_name ?? null,
+          avatarUrl: sessionUser.user_metadata?.avatar_url ?? null,
+          createdAt: new Date().toISOString(),
+        });
+      }
+
+      if (toggleLoading) {
+        setLoading(false);
+      }
+    };
+
+    const { data: authListener } = supabase.auth.onAuthStateChange(async (_event, newSession) => {
+      if (!isMounted) {
+        return;
+      }
+
+      setUser(newSession?.user ?? null);
+      if (newSession?.user) {
+        await fetchProfile(newSession.user);
+      } else {
+        setProfile(null);
+        setLoading(false);
+      }
+    });
+
+    hydrateSession();
+
+    return () => {
+      isMounted = false;
+      authListener?.subscription.unsubscribe();
+    };
+  }, []);
+
+  const signInWithGoogle = async () => {
+    setError(null);
+    const { error: signInError } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: window.location.origin,
+      },
+    });
+    if (signInError) {
+      setError(signInError.message);
+    }
+  };
+
+  const signOut = async () => {
+    setError(null);
+    setLoading(true);
+    const { error: signOutError } = await supabase.auth.signOut();
+    if (signOutError) {
+      setError(signOutError.message);
+    }
+    setLoading(false);
+  };
+
+  const value = useMemo(
+    () => ({ user, profile, loading, error, signInWithGoogle, signOut }),
+    [user, profile, loading, error]
+  );
+
+  return (
+    <SupabaseAuthContext.Provider value={value}>
+      {children}
+    </SupabaseAuthContext.Provider>
+  );
+};
+
+export const useSupabaseAuth = () => {
+  const context = useContext(SupabaseAuthContext);
+  if (!context) {
+    throw new Error('useSupabaseAuth must be used within a SupabaseAuthProvider');
+  }
+  return context;
+};
+

--- a/index.tsx
+++ b/index.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { SupabaseAuthProvider } from '@/hooks/useSupabaseAuth';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -11,6 +12,8 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <SupabaseAuthProvider>
+      <App />
+    </SupabaseAuthProvider>
   </React.StrictMode>
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1370,7 +1369,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -1785,7 +1783,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1827,7 +1824,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2035,7 +2031,6 @@
       "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/supabaseClient.ts
+++ b/supabaseClient.ts
@@ -1,0 +1,20 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl) {
+  throw new Error('VITE_SUPABASE_URL is not set. Please configure it in your environment.');
+}
+
+if (!supabaseAnonKey) {
+  throw new Error('VITE_SUPABASE_ANON_KEY is not set. Please configure it in your environment.');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+  },
+});
+

--- a/types.ts
+++ b/types.ts
@@ -21,6 +21,14 @@ export interface Character {
   ambienceTag: string;
 }
 
+export interface Profile {
+  id: string;
+  email: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+  createdAt: string;
+}
+
 export enum ConnectionState {
   IDLE = 'IDLE',
   CONNECTING = 'CONNECTING',


### PR DESCRIPTION
## Summary
- create a shared Supabase client and auth provider that manages session hydration, profile lookup, and sign-in/out helpers
- gate the app behind a Google SSO entry screen and surface account controls once authenticated
- expose a shared Profile type for Supabase metadata and document the required `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` variables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcb6310330832fa7667b4d6ff6a8d2