### PR TITLE
Add Supabase SSO authentication gate

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState, useEffect } from 'react';
+import type { Session } from '@supabase/supabase-js';
 // Fix: Add necessary imports for summary generation and conversation saving.
 import { GoogleGenAI, Type } from '@google/genai';
 import type {
@@ -9,7 +10,9 @@ import type {
   SavedConversation,
   Summary,
   QuestAssessment,
+  UserProfile,
 } from './types';
+import { supabase } from './supabaseClient';
 import CharacterSelector from './components/CharacterSelector';
 import ConversationView from './components/ConversationView';
 import HistoryView from './components/HistoryView';
@@ -24,35 +27,38 @@ const CUSTOM_CHARACTERS_KEY = 'school-of-the-ancients-custom-characters';
 const HISTORY_KEY = 'school-of-the-ancients-history';
 const COMPLETED_QUESTS_KEY = 'school-of-the-ancients-completed-quests';
 
+const getUserScopedKey = (baseKey: string, userId?: string) =>
+  userId ? `${baseKey}:${userId}` : baseKey;
+
 // Fix: Add helper functions to manage conversation history in localStorage.
-const loadConversations = (): SavedConversation[] => {
+const loadConversations = (storageKey: string): SavedConversation[] => {
   try {
-    const rawHistory = localStorage.getItem(HISTORY_KEY);
+    const rawHistory = localStorage.getItem(storageKey);
     return rawHistory ? JSON.parse(rawHistory) : [];
   } catch (error) {
-    console.error("Failed to load conversation history:", error);
+    console.error('Failed to load conversation history:', error);
     return [];
   }
 };
 
-const saveConversationToLocalStorage = (conversation: SavedConversation) => {
+const saveConversationToLocalStorage = (storageKey: string, conversation: SavedConversation) => {
   try {
-    const history = loadConversations();
+    const history = loadConversations(storageKey);
     const existingIndex = history.findIndex(c => c.id === conversation.id);
     if (existingIndex > -1) {
       history[existingIndex] = conversation;
     } else {
       history.unshift(conversation);
     }
-    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+    localStorage.setItem(storageKey, JSON.stringify(history));
   } catch (error) {
-    console.error("Failed to save conversation:", error);
+    console.error('Failed to save conversation:', error);
   }
 };
 
-const loadCompletedQuests = (): string[] => {
+const loadCompletedQuests = (storageKey: string): string[] => {
   try {
-    const stored = localStorage.getItem(COMPLETED_QUESTS_KEY);
+    const stored = localStorage.getItem(storageKey);
     return stored ? JSON.parse(stored) : [];
   } catch (error) {
     console.error('Failed to load completed quests:', error);
@@ -60,15 +66,41 @@ const loadCompletedQuests = (): string[] => {
   }
 };
 
-const saveCompletedQuests = (questIds: string[]) => {
+const saveCompletedQuests = (storageKey: string, questIds: string[]) => {
   try {
-    localStorage.setItem(COMPLETED_QUESTS_KEY, JSON.stringify(questIds));
+    localStorage.setItem(storageKey, JSON.stringify(questIds));
   } catch (error) {
     console.error('Failed to save completed quests:', error);
   }
 };
 
+const loadCustomCharacters = (storageKey: string): Character[] => {
+  try {
+    const storedCharacters = localStorage.getItem(storageKey);
+    return storedCharacters ? JSON.parse(storedCharacters) : [];
+  } catch (error) {
+    console.error('Failed to load custom characters:', error);
+    return [];
+  }
+};
+
+const saveCustomCharacters = (storageKey: string, characters: Character[]) => {
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(characters));
+  } catch (error) {
+    console.error('Failed to persist custom characters:', error);
+  }
+};
+
 const App: React.FC = () => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [authLoading, setAuthLoading] = useState(true);
+  const [authError, setAuthError] = useState<string | null>(null);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [profileLoading, setProfileLoading] = useState(false);
+  const [profileError, setProfileError] = useState<string | null>(null);
+  const [ssoEmail, setSsoEmail] = useState('');
+  const [isProcessingSSO, setIsProcessingSSO] = useState(false);
   const [selectedCharacter, setSelectedCharacter] = useState<Character | null>(null);
   const [view, setView] = useState<'selector' | 'conversation' | 'history' | 'creator' | 'quests'>('selector');
   const [customCharacters, setCustomCharacters] = useState<Character[]>([]);
@@ -79,30 +111,167 @@ const App: React.FC = () => {
   const [completedQuests, setCompletedQuests] = useState<string[]>([]);
   const [lastQuestOutcome, setLastQuestOutcome] = useState<QuestAssessment | null>(null);
 
+  const userId = session?.user?.id;
+  const customCharactersStorageKey = getUserScopedKey(CUSTOM_CHARACTERS_KEY, userId);
+  const historyStorageKey = getUserScopedKey(HISTORY_KEY, userId);
+  const completedQuestsStorageKey = getUserScopedKey(COMPLETED_QUESTS_KEY, userId);
+
   useEffect(() => {
-    // Load custom characters from local storage
-    try {
-      const storedCharacters = localStorage.getItem(CUSTOM_CHARACTERS_KEY);
-      if (storedCharacters) {
-        setCustomCharacters(JSON.parse(storedCharacters));
+    let isMounted = true;
+
+    const initializeSession = async () => {
+      try {
+        const { data, error } = await supabase.auth.getSession();
+        if (!isMounted) return;
+        if (error) {
+          console.error('Failed to fetch auth session:', error);
+          setAuthError('Unable to contact the authentication service. Please refresh and try again.');
+          setSession(null);
+        } else {
+          setSession(data.session ?? null);
+        }
+      } catch (error) {
+        console.error('Failed to fetch auth session:', error);
+        if (isMounted) {
+          setAuthError('Unable to contact the authentication service. Please refresh and try again.');
+          setSession(null);
+        }
+      } finally {
+        if (isMounted) {
+          setAuthLoading(false);
+        }
       }
-    } catch (e) {
-      console.error("Failed to load custom characters:", e);
+    };
+
+    initializeSession();
+
+    const { data: authListener } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      setSession(nextSession);
+      if (nextSession) {
+        setAuthError(null);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+      authListener.subscription?.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!session?.user) {
+      setProfile(null);
+      setProfileLoading(false);
+      return;
     }
+
+    let isActive = true;
+    const fetchProfile = async () => {
+      setProfileLoading(true);
+      setProfileError(null);
+
+      try {
+        const { data, error } = await supabase
+          .from('profiles')
+          .select('id, email, display_name, avatar_url, created_at')
+          .eq('id', session.user.id)
+          .maybeSingle();
+
+        if (!isActive) {
+          return;
+        }
+
+        if (error) {
+          throw error;
+        }
+
+        if (data) {
+          setProfile({
+            id: data.id,
+            email: data.email ?? session.user.email ?? null,
+            displayName:
+              data.display_name ??
+              (session.user.user_metadata?.full_name ?? session.user.email) ??
+              null,
+            avatarUrl: data.avatar_url ?? session.user.user_metadata?.avatar_url ?? null,
+            createdAt: data.created_at ?? null,
+          });
+        } else {
+          setProfile({
+            id: session.user.id,
+            email: session.user.email ?? null,
+            displayName: session.user.user_metadata?.full_name ?? session.user.email ?? null,
+            avatarUrl: session.user.user_metadata?.avatar_url ?? null,
+            createdAt: null,
+          });
+        }
+      } catch (error) {
+        console.error('Failed to load profile:', error);
+        if (isActive) {
+          setProfileError('We could not load your profile information. Some features may be unavailable.');
+          setProfile({
+            id: session.user.id,
+            email: session.user.email ?? null,
+            displayName: session.user.user_metadata?.full_name ?? session.user.email ?? null,
+            avatarUrl: session.user.user_metadata?.avatar_url ?? null,
+            createdAt: null,
+          });
+        }
+      } finally {
+        if (isActive) {
+          setProfileLoading(false);
+        }
+      }
+    };
+
+    fetchProfile();
+
+    return () => {
+      isActive = false;
+    };
+  }, [session]);
+
+  useEffect(() => {
+    if (!session) {
+      setSelectedCharacter(null);
+      setView('selector');
+      setEnvironmentImageUrl(null);
+      setActiveQuest(null);
+      setCompletedQuests([]);
+      setCustomCharacters([]);
+      setLastQuestOutcome(null);
+      return;
+    }
+  }, [session]);
+
+  useEffect(() => {
+    if (session) {
+      setSsoEmail('');
+    }
+  }, [session]);
+
+  useEffect(() => {
+    if (!userId) {
+      return;
+    }
+
+    const storedCharacters = loadCustomCharacters(customCharactersStorageKey);
+    setCustomCharacters(storedCharacters);
+
+    const storedCompletedQuests = loadCompletedQuests(completedQuestsStorageKey);
+    setCompletedQuests(storedCompletedQuests);
 
     const urlParams = new URLSearchParams(window.location.search);
     const characterId = urlParams.get('character');
     if (characterId) {
-      const allCharacters = [...customCharacters, ...CHARACTERS];
+      const allCharacters = [...storedCharacters, ...CHARACTERS];
       const characterFromUrl = allCharacters.find(c => c.id === characterId);
       if (characterFromUrl) {
         setSelectedCharacter(characterFromUrl);
         setView('conversation');
       }
     }
-
-    setCompletedQuests(loadCompletedQuests());
-  }, []); // customCharacters dependency is intentionally omitted to avoid re-running on delete
+  }, [userId, customCharactersStorageKey, completedQuestsStorageKey]);
 
   const handleSelectCharacter = (character: Character) => {
     setSelectedCharacter(character);
@@ -131,11 +300,7 @@ const App: React.FC = () => {
   const handleCharacterCreated = (newCharacter: Character) => {
     const updatedCharacters = [newCharacter, ...customCharacters];
     setCustomCharacters(updatedCharacters);
-    try {
-      localStorage.setItem(CUSTOM_CHARACTERS_KEY, JSON.stringify(updatedCharacters));
-    } catch (e) {
-      console.error("Failed to save custom character:", e);
-    }
+    saveCustomCharacters(customCharactersStorageKey, updatedCharacters);
     handleSelectCharacter(newCharacter);
   };
 
@@ -143,11 +308,80 @@ const App: React.FC = () => {
     if (window.confirm('Are you sure you want to permanently delete this ancient?')) {
       const updatedCharacters = customCharacters.filter(c => c.id !== characterId);
       setCustomCharacters(updatedCharacters);
-      try {
-        localStorage.setItem(CUSTOM_CHARACTERS_KEY, JSON.stringify(updatedCharacters));
-      } catch (e) {
-        console.error("Failed to delete custom character:", e);
+      saveCustomCharacters(customCharactersStorageKey, updatedCharacters);
+    }
+  };
+
+  const handleGoogleSignIn = async () => {
+    setAuthError(null);
+
+    try {
+      setAuthLoading(true);
+      const { data, error } = await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: {
+          redirectTo: window.location.origin,
+        },
+      });
+
+      if (error) {
+        throw error;
       }
+
+      if (data?.url) {
+        window.location.href = data.url;
+      }
+    } catch (error) {
+      console.error('Failed to start Google sign-in:', error);
+      setAuthError(error instanceof Error ? error.message : 'Unable to start Google sign-in. Please try again.');
+    } finally {
+      setAuthLoading(false);
+    }
+  };
+
+  const handleSsoSignIn = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedEmail = ssoEmail.trim();
+    const domain = trimmedEmail.split('@')[1];
+
+    if (!domain) {
+      setAuthError('Enter your work email to continue.');
+      return;
+    }
+
+    setAuthError(null);
+    setIsProcessingSSO(true);
+
+    try {
+      const { data, error } = await supabase.auth.signInWithSSO({
+        domain,
+        options: {
+          redirectTo: window.location.origin,
+        },
+      });
+
+      if (error) {
+        throw error;
+      }
+
+      if (data?.url) {
+        window.location.href = data.url;
+      }
+    } catch (error) {
+      console.error('Failed to start SSO sign-in:', error);
+      setAuthError(error instanceof Error ? error.message : 'Unable to start SSO sign-in. Please try again.');
+    } finally {
+      setIsProcessingSSO(false);
+    }
+  };
+
+  const handleSignOut = async () => {
+    try {
+      await supabase.auth.signOut();
+    } catch (error) {
+      console.error('Failed to sign out:', error);
+    } finally {
+      setSsoEmail('');
     }
   };
 
@@ -158,7 +392,7 @@ const App: React.FC = () => {
     let questAssessment: QuestAssessment | null = null;
 
     try {
-      const conversationHistory = loadConversations();
+      const conversationHistory = loadConversations(historyStorageKey);
       const existingConversation = conversationHistory.find(c => c.id === sessionId);
 
       let updatedConversation: SavedConversation = existingConversation ?? {
@@ -294,21 +528,21 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
           if (questAssessment.passed) {
             setCompletedQuests(prev => {
               if (prev.includes(activeQuest.id)) {
-                saveCompletedQuests(prev);
+                saveCompletedQuests(completedQuestsStorageKey, prev);
                 return prev;
               }
               const updated = [...prev, activeQuest.id];
-              saveCompletedQuests(updated);
+              saveCompletedQuests(completedQuestsStorageKey, updated);
               return updated;
             });
           } else {
             setCompletedQuests(prev => {
               if (!prev.includes(activeQuest.id)) {
-                saveCompletedQuests(prev);
+                saveCompletedQuests(completedQuestsStorageKey, prev);
                 return prev;
               }
               const updated = prev.filter(id => id !== activeQuest.id);
-              saveCompletedQuests(updated);
+              saveCompletedQuests(completedQuestsStorageKey, updated);
               return updated;
             });
           }
@@ -322,7 +556,7 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
         };
       }
 
-      saveConversationToLocalStorage(updatedConversation);
+      saveConversationToLocalStorage(historyStorageKey, updatedConversation);
     } catch (error) {
       console.error('Failed to finalize conversation:', error);
     } finally {
@@ -340,6 +574,17 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
     }
   };
 
+  const profileDisplayName =
+    (profile?.displayName && profile.displayName.trim()) ||
+    profile?.email ||
+    session?.user?.user_metadata?.full_name ||
+    session?.user?.email ||
+    'Explorer';
+
+  const profileEmail = profile?.email ?? session?.user?.email ?? '';
+  const profileInitial = profileDisplayName.charAt(0).toUpperCase() || '?';
+  const showLoading = authLoading || (session && profileLoading);
+
   const renderContent = () => {
     switch (view) {
       case 'conversation':
@@ -352,10 +597,11 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
             activeQuest={activeQuest}
             // Fix: Pass the isSaving prop to ConversationView.
             isSaving={isSaving}
+            historyStorageKey={historyStorageKey}
           />
         ) : null;
       case 'history':
-        return <HistoryView onBack={() => setView('selector')} />;
+        return <HistoryView onBack={() => setView('selector')} storageKey={historyStorageKey} />;
       case 'creator':
         return <CharacterCreator onCharacterCreated={handleCharacterCreated} onBack={() => setView('selector')} />;
       case 'quests':
@@ -451,6 +697,74 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
     }
   };
 
+  if (showLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#0b0b0f] text-gray-200">
+        <div className="flex flex-col items-center gap-4">
+          <div className="w-12 h-12 border-2 border-amber-400 border-t-transparent rounded-full animate-spin" />
+          <p className="text-sm text-gray-400">Preparing your learning space...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#0b0b0f] text-gray-200 p-4">
+        <div className="w-full max-w-lg space-y-6 rounded-2xl border border-gray-800 bg-gray-900/80 p-8 shadow-2xl">
+          <div className="text-center space-y-2">
+            <h1 className="text-3xl font-bold text-amber-300 tracking-wide">School of the Ancients</h1>
+            <p className="text-sm text-gray-400">
+              Sign in with your organization account to begin your journey.
+            </p>
+          </div>
+          {authError && (
+            <div className="rounded-lg border border-red-700 bg-red-900/40 px-4 py-3 text-sm text-red-100">
+              {authError}
+            </div>
+          )}
+          <button
+            onClick={handleGoogleSignIn}
+            disabled={authLoading}
+            className="w-full rounded-lg bg-amber-500 py-3 px-4 text-center text-base font-semibold text-black transition-colors hover:bg-amber-400 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Continue with Google
+          </button>
+          <div className="relative text-center text-xs uppercase tracking-wide text-gray-500">
+            <span className="bg-gray-900 px-3">or</span>
+            <span className="absolute left-0 right-0 top-1/2 -z-10 h-px bg-gray-800" aria-hidden="true" />
+          </div>
+          <form onSubmit={handleSsoSignIn} className="space-y-3">
+            <label htmlFor="sso-email" className="block text-sm font-semibold text-gray-300">
+              Work email
+            </label>
+            <input
+              id="sso-email"
+              type="email"
+              value={ssoEmail}
+              onChange={event => {
+                setSsoEmail(event.target.value);
+                if (authError) {
+                  setAuthError(null);
+                }
+              }}
+              placeholder="you@yourcompany.com"
+              className="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-3 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-400"
+              required
+            />
+            <button
+              type="submit"
+              disabled={isProcessingSSO}
+              className="w-full rounded-lg border border-gray-700 bg-gray-800 py-3 px-4 text-base font-semibold text-amber-300 transition-colors hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isProcessingSSO ? 'Redirecting…' : 'Continue with SSO'}
+            </button>
+          </form>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="relative min-h-screen bg-[#1a1a1a]">
       <div
@@ -463,12 +777,45 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
         className="relative z-10 min-h-screen flex flex-col text-gray-200 font-serif p-4 sm:p-6 lg:p-8"
         style={{ background: environmentImageUrl ? 'transparent' : 'linear-gradient(to bottom right, #1a1a1a, #2b2b2b)' }}
       >
-        <header className="text-center mb-8">
-          <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold text-amber-300 tracking-wider" style={{ textShadow: '0 0 10px rgba(252, 211, 77, 0.5)' }}>
-            School of the Ancients
-          </h1>
-          <p className="text-gray-400 mt-2 text-lg">Old world wisdom. New world classroom.</p>
+        <header className="mb-8 flex flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+          <div>
+            <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold text-amber-300 tracking-wider" style={{ textShadow: '0 0 10px rgba(252, 211, 77, 0.5)' }}>
+              School of the Ancients
+            </h1>
+            <p className="mt-2 text-lg text-gray-400">Old world wisdom. New world classroom.</p>
+          </div>
+          <div className="flex flex-col items-center gap-3 sm:flex-row sm:items-center sm:justify-end">
+            <div className="flex items-center gap-3 rounded-full border border-gray-700 bg-gray-800/60 px-3 py-2">
+              {profile?.avatarUrl ? (
+                <img
+                  src={profile.avatarUrl}
+                  alt={profileDisplayName}
+                  referrerPolicy="no-referrer"
+                  className="h-10 w-10 rounded-full object-cover"
+                />
+              ) : (
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-amber-500/20 text-lg font-semibold text-amber-200">
+                  {profileInitial}
+                </div>
+              )}
+              <div className="text-left">
+                <p className="text-sm font-semibold text-amber-200">{profileDisplayName}</p>
+                {profileEmail && <p className="text-xs text-gray-400">{profileEmail}</p>}
+              </div>
+            </div>
+            <button
+              onClick={handleSignOut}
+              className="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2 text-sm font-semibold text-amber-300 transition-colors hover:bg-gray-700 sm:w-auto"
+            >
+              Sign out
+            </button>
+          </div>
         </header>
+        {profileError && (
+          <div className="mx-auto mb-6 w-full max-w-3xl rounded-lg border border-red-700 bg-red-900/40 px-4 py-3 text-sm text-red-100">
+            {profileError}
+          </div>
+        )}
         <main className="max-w-7xl w-full mx-auto flex-grow flex flex-col">
           {renderContent()}
         </main>

--- a/components/HistoryView.tsx
+++ b/components/HistoryView.tsx
@@ -3,11 +3,11 @@ import React, { useState, useEffect, useMemo } from 'react';
 import type { SavedConversation, ConversationTurn } from '../types';
 import DownloadIcon from './icons/DownloadIcon';
 
-const HISTORY_KEY = 'school-of-the-ancients-history';
+const HISTORY_KEY_BASE = 'school-of-the-ancients-history';
 
-const loadConversations = (): SavedConversation[] => {
+const loadConversations = (storageKey: string): SavedConversation[] => {
   try {
-    const rawHistory = localStorage.getItem(HISTORY_KEY);
+    const rawHistory = localStorage.getItem(storageKey);
     return rawHistory ? JSON.parse(rawHistory) : [];
   } catch (error) {
     console.error("Failed to load conversation history:", error);
@@ -15,11 +15,11 @@ const loadConversations = (): SavedConversation[] => {
   }
 };
 
-const deleteConversationFromLocalStorage = (id: string) => {
+const deleteConversationFromLocalStorage = (storageKey: string, id: string) => {
   try {
-    let history = loadConversations();
+    let history = loadConversations(storageKey);
     history = history.filter(c => c.id !== id);
-    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+    localStorage.setItem(storageKey, JSON.stringify(history));
   } catch (error) {
     console.error("Failed to delete conversation:", error);
   }
@@ -38,20 +38,22 @@ const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifa
 
 interface HistoryViewProps {
   onBack: () => void;
+  storageKey?: string;
 }
 
-const HistoryView: React.FC<HistoryViewProps> = ({ onBack }) => {
+const HistoryView: React.FC<HistoryViewProps> = ({ onBack, storageKey }) => {
+  const resolvedStorageKey = storageKey ?? HISTORY_KEY_BASE;
   const [history, setHistory] = useState<SavedConversation[]>([]);
   const [selectedConversation, setSelectedConversation] = useState<SavedConversation | null>(null);
 
   useEffect(() => {
-    setHistory(loadConversations());
-  }, []);
+    setHistory(loadConversations(resolvedStorageKey));
+  }, [resolvedStorageKey]);
 
   const handleDelete = (id: string) => {
     if (window.confirm('Are you sure you want to delete this conversation?')) {
-      deleteConversationFromLocalStorage(id);
-      setHistory(loadConversations());
+      deleteConversationFromLocalStorage(resolvedStorageKey, id);
+      setHistory(loadConversations(resolvedStorageKey));
       if (selectedConversation?.id === id) {
         setSelectedConversation(null);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1370,7 +1369,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -1785,7 +1783,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1827,7 +1824,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2035,7 +2031,6 @@
       "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/supabaseClient.ts
+++ b/supabaseClient.ts
@@ -1,0 +1,20 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.warn('Supabase environment variables are missing. Authentication will be disabled.');
+}
+
+export const supabase = createClient(
+  supabaseUrl || '',
+  supabaseAnonKey || '',
+  {
+    auth: {
+      autoRefreshToken: true,
+      persistSession: true,
+      detectSessionInUrl: true,
+    },
+  }
+);

--- a/types.ts
+++ b/types.ts
@@ -72,6 +72,14 @@ export interface SavedConversation {
   questAssessment?: QuestAssessment;
 }
 
+export interface UserProfile {
+  id: string;
+  email: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+  createdAt: string | null;
+}
+
 export interface Quest {
   id: string;
   title: string;


### PR DESCRIPTION
## Summary
- add a shared Supabase client and hydrate the app with session, profile, and SSO login flows
- gate the experience behind a new sign-in screen and show the active user with a sign-out control once authenticated
- scope localStorage keys by user so custom characters, quest progress, and chat history are tied to the signed-in account

## Testing
- `VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_ANON_KEY=dev npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68dcb6310330832fa7667b4d6ff6a8d2