### PR TITLE
Add Supabase SSO login gate

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 // Fix: Add necessary imports for summary generation and conversation saving.
 import { GoogleGenAI, Type } from '@google/genai';
+import type { Session } from '@supabase/supabase-js';
 import type {
   Character,
   Quest,
@@ -9,6 +10,7 @@ import type {
   SavedConversation,
   Summary,
   QuestAssessment,
+  UserProfile,
 } from './types';
 import CharacterSelector from './components/CharacterSelector';
 import ConversationView from './components/ConversationView';
@@ -18,6 +20,7 @@ import QuestsView from './components/QuestsView';
 import Instructions from './components/Instructions';
 import { CHARACTERS, QUESTS } from './constants';
 import QuestIcon from './components/icons/QuestIcon';
+import { supabase } from './supabaseClient';
 
 const CUSTOM_CHARACTERS_KEY = 'school-of-the-ancients-custom-characters';
 // Fix: Add history key constant for conversation management.
@@ -69,6 +72,11 @@ const saveCompletedQuests = (questIds: string[]) => {
 };
 
 const App: React.FC = () => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [authLoading, setAuthLoading] = useState(true);
+  const [authError, setAuthError] = useState<string | null>(null);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [isProfileLoading, setIsProfileLoading] = useState(false);
   const [selectedCharacter, setSelectedCharacter] = useState<Character | null>(null);
   const [view, setView] = useState<'selector' | 'conversation' | 'history' | 'creator' | 'quests'>('selector');
   const [customCharacters, setCustomCharacters] = useState<Character[]>([]);
@@ -78,6 +86,91 @@ const App: React.FC = () => {
   const [isSaving, setIsSaving] = useState(false);
   const [completedQuests, setCompletedQuests] = useState<string[]>([]);
   const [lastQuestOutcome, setLastQuestOutcome] = useState<QuestAssessment | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const bootstrapSession = async () => {
+      try {
+        const { data } = await supabase.auth.getSession();
+        if (isMounted) {
+          setSession(data.session);
+        }
+      } catch (error) {
+        console.error('Failed to load auth session:', error);
+        if (isMounted) {
+          setAuthError('Unable to load your session. Please refresh and try again.');
+        }
+      } finally {
+        if (isMounted) {
+          setAuthLoading(false);
+        }
+      }
+    };
+
+    bootstrapSession();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, updatedSession) => {
+      setSession(updatedSession);
+      setAuthError(null);
+    });
+
+    return () => {
+      isMounted = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!session) {
+      setProfile(null);
+      setIsProfileLoading(false);
+      return;
+    }
+
+    let isActive = true;
+    const loadProfile = async () => {
+      setIsProfileLoading(true);
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('id, email, display_name, avatar_url, created_at')
+        .eq('id', session.user.id)
+        .single();
+
+      if (!isActive) {
+        return;
+      }
+
+      if (error) {
+        console.error('Failed to load user profile:', error);
+        setProfile({
+          id: session.user.id,
+          email: session.user.email ?? null,
+          displayName: session.user.user_metadata?.full_name ?? session.user.email ?? null,
+          avatarUrl: session.user.user_metadata?.avatar_url ?? null,
+        });
+        setAuthError('Unable to sync your profile at the moment. Using auth info instead.');
+      } else if (data) {
+        setProfile({
+          id: data.id,
+          email: data.email,
+          displayName: data.display_name,
+          avatarUrl: data.avatar_url,
+          createdAt: data.created_at ?? undefined,
+        });
+      }
+
+      setIsProfileLoading(false);
+    };
+
+    loadProfile();
+
+    return () => {
+      isActive = false;
+    };
+  }, [session]);
 
   useEffect(() => {
     // Load custom characters from local storage
@@ -103,6 +196,32 @@ const App: React.FC = () => {
 
     setCompletedQuests(loadCompletedQuests());
   }, []); // customCharacters dependency is intentionally omitted to avoid re-running on delete
+
+  const handleSignIn = async () => {
+    setAuthError(null);
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: window.location.href,
+      },
+    });
+
+    if (error) {
+      console.error('Failed to start sign-in:', error);
+      setAuthError(error.message);
+    }
+  };
+
+  const handleSignOut = async () => {
+    setAuthError(null);
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      console.error('Failed to sign out:', error);
+      setAuthError(error.message);
+    } else {
+      setProfile(null);
+    }
+  };
 
   const handleSelectCharacter = (character: Character) => {
     setSelectedCharacter(character);
@@ -340,6 +459,15 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
     }
   };
 
+  const activeProfile = session
+    ? profile ?? {
+        id: session.user.id,
+        email: session.user.email ?? null,
+        displayName: session.user.user_metadata?.full_name ?? session.user.email ?? null,
+        avatarUrl: session.user.user_metadata?.avatar_url ?? null,
+      }
+    : null;
+
   const renderContent = () => {
     switch (view) {
       case 'conversation':
@@ -451,6 +579,37 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
     }
   };
 
+  if (authLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#0b0b0b] text-gray-200">
+        <p className="text-lg font-semibold">Loading session...</p>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#0b0b0b] text-gray-200 p-6">
+        <div className="w-full max-w-md bg-gray-900 border border-gray-800 rounded-2xl shadow-2xl p-8 space-y-6 text-center">
+          <h1 className="text-3xl font-bold text-amber-300">School of the Ancients</h1>
+          <p className="text-gray-400">Sign in with your workspace account to continue.</p>
+          {authError && (
+            <div className="bg-red-900/40 border border-red-600 text-red-100 text-sm rounded-lg px-4 py-3 text-left">
+              {authError}
+            </div>
+          )}
+          <button
+            onClick={handleSignIn}
+            className="w-full flex items-center justify-center gap-2 bg-amber-500 hover:bg-amber-400 text-black font-semibold py-3 px-4 rounded-lg transition-colors"
+          >
+            Continue with Google
+          </button>
+          <p className="text-xs text-gray-500">We use Supabase Auth for secure single sign-on.</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="relative min-h-screen bg-[#1a1a1a]">
       <div
@@ -459,16 +618,58 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
       />
       {environmentImageUrl && <div className="absolute inset-0 bg-black/50 z-0" />}
 
-      <div 
+      <div
         className="relative z-10 min-h-screen flex flex-col text-gray-200 font-serif p-4 sm:p-6 lg:p-8"
         style={{ background: environmentImageUrl ? 'transparent' : 'linear-gradient(to bottom right, #1a1a1a, #2b2b2b)' }}
       >
-        <header className="text-center mb-8">
-          <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold text-amber-300 tracking-wider" style={{ textShadow: '0 0 10px rgba(252, 211, 77, 0.5)' }}>
-            School of the Ancients
-          </h1>
-          <p className="text-gray-400 mt-2 text-lg">Old world wisdom. New world classroom.</p>
-        </header>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between mb-6">
+          <div className="text-left">
+            <h1 className="text-3xl sm:text-4xl font-bold text-amber-300 tracking-wider" style={{ textShadow: '0 0 10px rgba(252, 211, 77, 0.5)' }}>
+              School of the Ancients
+            </h1>
+            <p className="text-gray-400 mt-1 text-base">Old world wisdom. New world classroom.</p>
+          </div>
+          <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
+            {authError && session && (
+              <div className="bg-red-900/40 border border-red-700 text-red-100 text-xs sm:text-sm rounded-lg px-3 py-2">
+                {authError}
+              </div>
+            )}
+            <div className="flex items-center gap-3 bg-gray-800/60 border border-gray-700 rounded-full px-3 py-2">
+              {activeProfile?.avatarUrl ? (
+                <img
+                  src={activeProfile.avatarUrl}
+                  alt={activeProfile.displayName ?? activeProfile.email ?? 'User avatar'}
+                  className="w-10 h-10 rounded-full object-cover border border-gray-700"
+                  referrerPolicy="no-referrer"
+                />
+              ) : (
+                <div className="w-10 h-10 rounded-full bg-gray-700 flex items-center justify-center text-amber-200 font-semibold">
+                  {(activeProfile?.displayName ?? activeProfile?.email ?? 'U')
+                    .split(' ')
+                    .map(part => part[0])
+                    .join('')
+                    .slice(0, 2)
+                    .toUpperCase()}
+                </div>
+              )}
+              <div className="flex flex-col text-left">
+                <span className="text-sm font-semibold text-amber-200">
+                  {activeProfile?.displayName ?? activeProfile?.email ?? 'Learner'}
+                </span>
+                {(activeProfile?.email || session.user.email) && (
+                  <span className="text-xs text-gray-400">{activeProfile?.email ?? session.user.email}</span>
+                )}
+              </div>
+            </div>
+            <button
+              onClick={handleSignOut}
+              className="text-sm font-semibold bg-gray-700 hover:bg-gray-600 text-amber-200 px-4 py-2 rounded-lg border border-gray-600 transition-colors"
+            >
+              Sign out
+            </button>
+          </div>
+        </div>
         <main className="max-w-7xl w-full mx-auto flex-grow flex flex-col">
           {renderContent()}
         </main>

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1370,7 +1369,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -1785,7 +1783,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1827,7 +1824,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2035,7 +2031,6 @@
       "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/supabaseClient.ts
+++ b/supabaseClient.ts
@@ -1,0 +1,20 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl) {
+  throw new Error('Missing VITE_SUPABASE_URL environment variable');
+}
+
+if (!supabaseAnonKey) {
+  throw new Error('Missing VITE_SUPABASE_ANON_KEY environment variable');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
+  },
+});

--- a/types.ts
+++ b/types.ts
@@ -81,3 +81,11 @@ export interface Quest {
   duration: string;
   focusPoints: string[];
 }
+
+export interface UserProfile {
+  id: string;
+  email: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+  createdAt?: string;
+}


### PR DESCRIPTION
## Summary
- create a reusable Supabase client that reads the Vercel-provided auth environment variables
- gate the SPA behind Supabase Google SSO, loading each user's profile or auth metadata on login
- show the active user's identity with sign-out controls in the header

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcb6310330832fa7667b4d6ff6a8d2