### PR TITLE
feat: add supabase sso login flow

### DIFF
--- a/hooks/useSupabaseAuth.ts
+++ b/hooks/useSupabaseAuth.ts
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { Session, User } from '@supabase/supabase-js';
+import { supabase } from '../supabaseClient';
+import type { UserProfile } from '../types';
+
+interface ProfileRow {
+  id: string;
+  email: string | null;
+  display_name: string | null;
+  avatar_url: string | null;
+  created_at: string | null;
+}
+
+const mapProfile = (row: ProfileRow | null): UserProfile | null => {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    id: row.id,
+    email: row.email,
+    displayName: row.display_name,
+    avatarUrl: row.avatar_url,
+    createdAt: row.created_at,
+  };
+};
+
+const useSupabaseAuth = () => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchProfile = useCallback(async (user: User | null) => {
+    if (!user) {
+      setProfile(null);
+      return;
+    }
+
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('id, email, display_name, avatar_url, created_at')
+      .eq('id', user.id)
+      .single();
+
+    if (error) {
+      console.error('Failed to load profile:', error.message);
+      setError(error.message);
+      setProfile(null);
+      return;
+    }
+
+    setProfile(mapProfile(data as ProfileRow));
+  }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const init = async () => {
+      const { data, error } = await supabase.auth.getSession();
+      if (!isMounted) {
+        return;
+      }
+
+      if (error) {
+        console.error('Failed to get session:', error.message);
+        setError(error.message);
+        setSession(null);
+        setProfile(null);
+      } else {
+        setSession(data.session);
+        await fetchProfile(data.session?.user ?? null);
+      }
+
+      setIsLoading(false);
+    };
+
+    init();
+
+    const { data: listener } = supabase.auth.onAuthStateChange(async (_event, newSession) => {
+      if (!isMounted) {
+        return;
+      }
+
+      setSession(newSession);
+      await fetchProfile(newSession?.user ?? null);
+      setError(null);
+    });
+
+    return () => {
+      isMounted = false;
+      listener.subscription.unsubscribe();
+    };
+  }, [fetchProfile]);
+
+  const signInWithGoogle = useCallback(async () => {
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: window.location.origin,
+      },
+    });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+  }, []);
+
+  const signInWithSSO = useCallback(async (domain: string) => {
+    const normalizedDomain = domain.trim();
+    if (!normalizedDomain) {
+      throw new Error('Please provide your organization domain.');
+    }
+
+    const { error } = await supabase.auth.signInWithSSO({
+      domain: normalizedDomain,
+      options: {
+        redirectTo: window.location.origin,
+      },
+    });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+  }, []);
+
+  const signOut = useCallback(async () => {
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      throw new Error(error.message);
+    }
+  }, []);
+
+  return {
+    session,
+    user: session?.user ?? null,
+    profile,
+    isLoading,
+    error,
+    signInWithGoogle,
+    signInWithSSO,
+    signOut,
+  };
+};
+
+export default useSupabaseAuth;

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1370,7 +1369,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -1785,7 +1783,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1827,7 +1824,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2035,7 +2031,6 @@
       "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/supabaseClient.ts
+++ b/supabaseClient.ts
@@ -1,0 +1,19 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl) {
+  throw new Error('Missing VITE_SUPABASE_URL environment variable');
+}
+
+if (!supabaseAnonKey) {
+  throw new Error('Missing VITE_SUPABASE_ANON_KEY environment variable');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: true,
+    storageKey: 'sota-beta-auth',
+  },
+});

--- a/types.ts
+++ b/types.ts
@@ -81,3 +81,11 @@ export interface Quest {
   duration: string;
   focusPoints: string[];
 }
+
+export interface UserProfile {
+  id: string;
+  email: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+  createdAt: string | null;
+}


### PR DESCRIPTION
## Summary
- add a shared Supabase client and auth hook that loads sessions and profiles
- gate the experience behind a Supabase-powered login with Google and SSO options
- show the authenticated profile in the app header with a sign-out control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcb6310330832fa7667b4d6ff6a8d2