### PR TITLE
Add Supabase email auth and remote persistence

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,8 @@
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 // Fix: Add necessary imports for summary generation and conversation saving.
 import { GoogleGenAI, Type } from '@google/genai';
+import type { Session } from '@supabase/supabase-js';
 import type {
   Character,
   Quest,
@@ -18,57 +19,17 @@ import QuestsView from './components/QuestsView';
 import Instructions from './components/Instructions';
 import { CHARACTERS, QUESTS } from './constants';
 import QuestIcon from './components/icons/QuestIcon';
-
-const CUSTOM_CHARACTERS_KEY = 'school-of-the-ancients-custom-characters';
-// Fix: Add history key constant for conversation management.
-const HISTORY_KEY = 'school-of-the-ancients-history';
-const COMPLETED_QUESTS_KEY = 'school-of-the-ancients-completed-quests';
-
-// Fix: Add helper functions to manage conversation history in localStorage.
-const loadConversations = (): SavedConversation[] => {
-  try {
-    const rawHistory = localStorage.getItem(HISTORY_KEY);
-    return rawHistory ? JSON.parse(rawHistory) : [];
-  } catch (error) {
-    console.error("Failed to load conversation history:", error);
-    return [];
-  }
-};
-
-const saveConversationToLocalStorage = (conversation: SavedConversation) => {
-  try {
-    const history = loadConversations();
-    const existingIndex = history.findIndex(c => c.id === conversation.id);
-    if (existingIndex > -1) {
-      history[existingIndex] = conversation;
-    } else {
-      history.unshift(conversation);
-    }
-    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
-  } catch (error) {
-    console.error("Failed to save conversation:", error);
-  }
-};
-
-const loadCompletedQuests = (): string[] => {
-  try {
-    const stored = localStorage.getItem(COMPLETED_QUESTS_KEY);
-    return stored ? JSON.parse(stored) : [];
-  } catch (error) {
-    console.error('Failed to load completed quests:', error);
-    return [];
-  }
-};
-
-const saveCompletedQuests = (questIds: string[]) => {
-  try {
-    localStorage.setItem(COMPLETED_QUESTS_KEY, JSON.stringify(questIds));
-  } catch (error) {
-    console.error('Failed to save completed quests:', error);
-  }
-};
+import { supabase, isSupabaseConfigured } from './supabaseClient';
 
 const App: React.FC = () => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [isAuthLoading, setIsAuthLoading] = useState(true);
+  const [isDataLoading, setIsDataLoading] = useState(false);
+  const [authLoading, setAuthLoading] = useState(false);
+  const [email, setEmail] = useState('');
+  const [authMessage, setAuthMessage] = useState<string | null>(null);
+  const [authError, setAuthError] = useState<string | null>(null);
+  const [history, setHistory] = useState<SavedConversation[]>([]);
   const [selectedCharacter, setSelectedCharacter] = useState<Character | null>(null);
   const [view, setView] = useState<'selector' | 'conversation' | 'history' | 'creator' | 'quests'>('selector');
   const [customCharacters, setCustomCharacters] = useState<Character[]>([]);
@@ -78,17 +39,149 @@ const App: React.FC = () => {
   const [isSaving, setIsSaving] = useState(false);
   const [completedQuests, setCompletedQuests] = useState<string[]>([]);
   const [lastQuestOutcome, setLastQuestOutcome] = useState<QuestAssessment | null>(null);
+  const [initialDataLoaded, setInitialDataLoaded] = useState(false);
 
   useEffect(() => {
-    // Load custom characters from local storage
-    try {
-      const storedCharacters = localStorage.getItem(CUSTOM_CHARACTERS_KEY);
-      if (storedCharacters) {
-        setCustomCharacters(JSON.parse(storedCharacters));
-      }
-    } catch (e) {
-      console.error("Failed to load custom characters:", e);
+    if (!supabase || !isSupabaseConfigured) {
+      setIsAuthLoading(false);
+      return;
     }
+
+    let isMounted = true;
+
+    supabase.auth
+      .getSession()
+      .then(({ data }) => {
+        if (!isMounted) return;
+        setSession(data.session);
+        setIsAuthLoading(false);
+      })
+      .catch(error => {
+        console.error('Failed to retrieve session:', error);
+        if (isMounted) {
+          setIsAuthLoading(false);
+        }
+      });
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, currentSession) => {
+      setSession(currentSession);
+      setIsAuthLoading(false);
+    });
+
+    return () => {
+      isMounted = false;
+      listener.subscription.unsubscribe();
+    };
+  }, []);
+
+  const fetchCustomCharacters = useCallback(async (userId: string) => {
+    if (!supabase) return [] as Character[];
+    type Row = { character: Character };
+    const { data, error } = await supabase
+      .from('custom_characters')
+      .select('character')
+      .eq('user_id', userId)
+      .order('updated_at', { ascending: false });
+
+    if (error) {
+      console.error('Failed to load custom characters:', error);
+      return [];
+    }
+
+    return (data as Row[] | null)?.map(row => row.character) ?? [];
+  }, []);
+
+  const fetchConversations = useCallback(async (userId: string) => {
+    if (!supabase) return [] as SavedConversation[];
+    type Row = { payload: SavedConversation; updated_at: string };
+    const { data, error } = await supabase
+      .from('conversations')
+      .select('payload, updated_at')
+      .eq('user_id', userId)
+      .order('updated_at', { ascending: false });
+
+    if (error) {
+      console.error('Failed to load conversations:', error);
+      return [];
+    }
+
+    return (data as Row[] | null)?.map(row => {
+      const payload = row.payload ?? null;
+      if (!payload) return null;
+      return {
+        ...payload,
+        timestamp: payload.timestamp ?? new Date(row.updated_at).getTime(),
+      } as SavedConversation;
+    })
+      .filter((item): item is SavedConversation => Boolean(item)) ?? [];
+  }, []);
+
+  const fetchCompletedQuestIds = useCallback(async (userId: string) => {
+    if (!supabase) return [] as string[];
+    type Row = { quest_id: string };
+    const { data, error } = await supabase
+      .from('completed_quests')
+      .select('quest_id')
+      .eq('user_id', userId);
+
+    if (error) {
+      console.error('Failed to load completed quests:', error);
+      return [];
+    }
+
+    return (data as Row[] | null)?.map(row => row.quest_id) ?? [];
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+
+    const loadData = async () => {
+      if (!session || !supabase) {
+        if (!active) return;
+        setCustomCharacters([]);
+        setHistory([]);
+        setCompletedQuests([]);
+        setInitialDataLoaded(false);
+        setIsDataLoading(false);
+        setSelectedCharacter(null);
+        setView('selector');
+        setEnvironmentImageUrl(null);
+        setActiveQuest(null);
+        return;
+      }
+
+      setIsDataLoading(true);
+      try {
+        const [characters, conversations, quests] = await Promise.all([
+          fetchCustomCharacters(session.user.id),
+          fetchConversations(session.user.id),
+          fetchCompletedQuestIds(session.user.id),
+        ]);
+
+        if (!active) return;
+
+        setCustomCharacters(characters);
+        setHistory(conversations);
+        setCompletedQuests(quests);
+        setInitialDataLoaded(true);
+      } catch (error) {
+        console.error('Failed to load Supabase data:', error);
+      } finally {
+        if (active) {
+          setIsDataLoading(false);
+        }
+      }
+    };
+
+    void loadData();
+
+    return () => {
+      active = false;
+    };
+  }, [session, fetchCompletedQuestIds, fetchConversations, fetchCustomCharacters]);
+
+  useEffect(() => {
+    if (!initialDataLoaded) return;
 
     const urlParams = new URLSearchParams(window.location.search);
     const characterId = urlParams.get('character');
@@ -100,18 +193,157 @@ const App: React.FC = () => {
         setView('conversation');
       }
     }
+  }, [initialDataLoaded, customCharacters]);
 
-    setCompletedQuests(loadCompletedQuests());
-  }, []); // customCharacters dependency is intentionally omitted to avoid re-running on delete
+  const persistConversation = useCallback(
+    async (conversation: SavedConversation) => {
+      if (!session || !supabase) return;
 
-  const handleSelectCharacter = (character: Character) => {
+      setHistory(prev => {
+        const existingIndex = prev.findIndex(item => item.id === conversation.id);
+        if (existingIndex > -1) {
+          const updated = [...prev];
+          updated[existingIndex] = conversation;
+          return updated;
+        }
+        return [conversation, ...prev];
+      });
+
+      try {
+        const { error } = await supabase
+          .from('conversations')
+          .upsert({
+            id: conversation.id,
+            user_id: session.user.id,
+            character_id: conversation.characterId,
+            payload: conversation,
+            updated_at: new Date(conversation.timestamp).toISOString(),
+          });
+
+        if (error) {
+          throw error;
+        }
+      } catch (error) {
+        console.error('Failed to persist conversation:', error);
+      }
+    },
+    [session, supabase]
+  );
+
+  const deleteConversation = useCallback(
+    async (id: string) => {
+      if (!session || !supabase) return;
+
+      let previous: SavedConversation[] = [];
+      setHistory(prev => {
+        previous = [...prev];
+        return prev.filter(item => item.id !== id);
+      });
+
+      try {
+        const { error } = await supabase
+          .from('conversations')
+          .delete()
+          .eq('user_id', session.user.id)
+          .eq('id', id);
+
+        if (error) {
+          throw error;
+        }
+      } catch (error) {
+        console.error('Failed to delete conversation:', error);
+        setHistory(previous);
+      }
+    },
+    [session, supabase]
+  );
+
+  const persistCompletedQuestIds = useCallback(
+    async (questIds: string[]) => {
+      if (!session || !supabase) return;
+
+      try {
+        const { error: deleteError } = await supabase
+          .from('completed_quests')
+          .delete()
+          .eq('user_id', session.user.id);
+
+        if (deleteError) {
+          throw deleteError;
+        }
+
+        if (questIds.length === 0) {
+          return;
+        }
+
+        const rows = questIds.map(questId => ({
+          user_id: session.user.id,
+          quest_id: questId,
+        }));
+
+        const { error: insertError } = await supabase
+          .from('completed_quests')
+          .upsert(rows, { onConflict: 'user_id,quest_id' });
+
+        if (insertError) {
+          throw insertError;
+        }
+      } catch (error) {
+        console.error('Failed to update completed quests:', error);
+      }
+    },
+    [session, supabase]
+  );
+
+  const handleEmailLogin = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!supabase) return;
+
+      setAuthLoading(true);
+      setAuthError(null);
+      setAuthMessage(null);
+
+      try {
+        const { error } = await supabase.auth.signInWithOtp({
+          email,
+          options: {
+            emailRedirectTo: window.location.href,
+          },
+        });
+
+        if (error) {
+          throw error;
+        }
+
+        setAuthMessage('Check your email for a login link to continue.');
+      } catch (error) {
+        console.error('Failed to start email login:', error);
+        setAuthError(error instanceof Error ? error.message : 'Failed to send magic link.');
+      } finally {
+        setAuthLoading(false);
+      }
+    },
+    [email, supabase]
+  );
+
+  const handleSignOut = useCallback(async () => {
+    if (!supabase) return;
+    try {
+      await supabase.auth.signOut();
+    } catch (error) {
+      console.error('Failed to sign out:', error);
+    }
+  }, [supabase]);
+
+  const handleSelectCharacter = useCallback((character: Character) => {
     setSelectedCharacter(character);
     setView('conversation');
     setActiveQuest(null); // Clear quest if a character is selected manually
     const url = new URL(window.location.href);
     url.searchParams.set('character', character.id);
     window.history.pushState({}, '', url);
-  };
+  }, []);
 
   const handleSelectQuest = (quest: Quest) => {
     const allCharacters = [...customCharacters, ...CHARACTERS];
@@ -129,37 +361,81 @@ const App: React.FC = () => {
   };
 
   const handleCharacterCreated = (newCharacter: Character) => {
-    const updatedCharacters = [newCharacter, ...customCharacters];
-    setCustomCharacters(updatedCharacters);
-    try {
-      localStorage.setItem(CUSTOM_CHARACTERS_KEY, JSON.stringify(updatedCharacters));
-    } catch (e) {
-      console.error("Failed to save custom character:", e);
-    }
-    handleSelectCharacter(newCharacter);
+    if (!session || !supabase) return;
+
+    setCustomCharacters(prev => [newCharacter, ...prev]);
+
+    void (async () => {
+      try {
+        const { error } = await supabase
+          .from('custom_characters')
+          .upsert({
+            user_id: session.user.id,
+            character_id: newCharacter.id,
+            character: newCharacter,
+          });
+
+        if (error) {
+          throw error;
+        }
+
+        handleSelectCharacter(newCharacter);
+      } catch (error) {
+        console.error('Failed to save custom character:', error);
+        setCustomCharacters(prev => prev.filter(c => c.id !== newCharacter.id));
+      }
+    })();
   };
 
   const handleDeleteCharacter = (characterId: string) => {
-    if (window.confirm('Are you sure you want to permanently delete this ancient?')) {
-      const updatedCharacters = customCharacters.filter(c => c.id !== characterId);
-      setCustomCharacters(updatedCharacters);
-      try {
-        localStorage.setItem(CUSTOM_CHARACTERS_KEY, JSON.stringify(updatedCharacters));
-      } catch (e) {
-        console.error("Failed to delete custom character:", e);
-      }
+    if (!session || !supabase) return;
+    if (!window.confirm('Are you sure you want to permanently delete this ancient?')) {
+      return;
     }
+
+    const previousCharacters = [...customCharacters];
+    setCustomCharacters(prev => prev.filter(c => c.id !== characterId));
+
+    void (async () => {
+      try {
+        const { error } = await supabase
+          .from('custom_characters')
+          .delete()
+          .eq('user_id', session.user.id)
+          .eq('character_id', characterId);
+
+        if (error) {
+          throw error;
+        }
+
+        if (selectedCharacter?.id === characterId) {
+          setSelectedCharacter(null);
+          setView('selector');
+        }
+      } catch (error) {
+        console.error('Failed to delete custom character:', error);
+        setCustomCharacters(previousCharacters);
+      }
+    })();
   };
+
+  const sortedHistory = useMemo(() => {
+    return [...history].sort((a, b) => b.timestamp - a.timestamp);
+  }, [history]);
+
+  const activeConversation = useMemo(() => {
+    if (!selectedCharacter) return null;
+    return sortedHistory.find(conversation => conversation.characterId === selectedCharacter.id) ?? null;
+  }, [selectedCharacter, sortedHistory]);
 
   // Fix: Implement summary generation and state reset on conversation end.
   const handleEndConversation = async (transcript: ConversationTurn[], sessionId: string) => {
-    if (!selectedCharacter) return;
+    if (!selectedCharacter || !session) return;
     setIsSaving(true);
     let questAssessment: QuestAssessment | null = null;
 
     try {
-      const conversationHistory = loadConversations();
-      const existingConversation = conversationHistory.find(c => c.id === sessionId);
+      const existingConversation = history.find(c => c.id === sessionId);
 
       let updatedConversation: SavedConversation = existingConversation ?? {
         id: sessionId,
@@ -294,21 +570,21 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
           if (questAssessment.passed) {
             setCompletedQuests(prev => {
               if (prev.includes(activeQuest.id)) {
-                saveCompletedQuests(prev);
+                void persistCompletedQuestIds(prev);
                 return prev;
               }
               const updated = [...prev, activeQuest.id];
-              saveCompletedQuests(updated);
+              void persistCompletedQuestIds(updated);
               return updated;
             });
           } else {
             setCompletedQuests(prev => {
               if (!prev.includes(activeQuest.id)) {
-                saveCompletedQuests(prev);
+                void persistCompletedQuestIds(prev);
                 return prev;
               }
               const updated = prev.filter(id => id !== activeQuest.id);
-              saveCompletedQuests(updated);
+              void persistCompletedQuestIds(updated);
               return updated;
             });
           }
@@ -322,7 +598,7 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
         };
       }
 
-      saveConversationToLocalStorage(updatedConversation);
+      await persistConversation(updatedConversation);
     } catch (error) {
       console.error('Failed to finalize conversation:', error);
     } finally {
@@ -341,6 +617,71 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
   };
 
   const renderContent = () => {
+    if (!isSupabaseConfigured || !supabase) {
+      return (
+        <div className="max-w-xl mx-auto bg-gray-900/70 border border-gray-700 rounded-2xl p-6 text-center shadow-xl">
+          <h2 className="text-2xl font-semibold text-amber-200 mb-3">Supabase configuration required</h2>
+          <p className="text-gray-300">
+            Add <code className="text-amber-300">VITE_SUPABASE_URL</code> and <code className="text-amber-300">VITE_SUPABASE_ANON_KEY</code> to your environment to enable secure sign-in and cloud saves.
+          </p>
+        </div>
+      );
+    }
+
+    if (isAuthLoading) {
+      return (
+        <div className="flex flex-1 items-center justify-center text-amber-200 gap-3">
+          <div className="w-5 h-5 border-2 border-amber-400 border-t-transparent rounded-full animate-spin" />
+          <span>Checking your session…</span>
+        </div>
+      );
+    }
+
+    if (!session) {
+      return (
+        <div className="max-w-md w-full mx-auto bg-gray-900/70 border border-gray-700 rounded-2xl p-6 text-left shadow-xl">
+          <h2 className="text-2xl font-semibold text-amber-200 mb-2">Sign in to continue</h2>
+          <p className="text-gray-400 text-sm mb-4">
+            Enter your email address and we&apos;ll send you a secure login link powered by Supabase.
+          </p>
+          <form onSubmit={handleEmailLogin} className="space-y-4">
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-300 mb-1">
+                Email address
+              </label>
+              <input
+                id="email"
+                type="email"
+                required
+                value={email}
+                onChange={event => setEmail(event.target.value)}
+                className="w-full rounded-lg border border-gray-600 bg-gray-800/70 px-3 py-2 text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-400"
+                placeholder="you@example.com"
+              />
+            </div>
+            {authError && <p className="text-red-400 text-sm">{authError}</p>}
+            {authMessage && <p className="text-emerald-400 text-sm">{authMessage}</p>}
+            <button
+              type="submit"
+              disabled={authLoading || !email}
+              className="w-full bg-amber-500 hover:bg-amber-400 disabled:bg-amber-800/60 disabled:cursor-not-allowed text-black font-semibold py-2 rounded-lg transition-colors"
+            >
+              {authLoading ? 'Sending magic link…' : 'Email me a login link'}
+            </button>
+          </form>
+        </div>
+      );
+    }
+
+    if (isDataLoading) {
+      return (
+        <div className="flex flex-1 items-center justify-center text-amber-200 gap-3">
+          <div className="w-5 h-5 border-2 border-amber-400 border-t-transparent rounded-full animate-spin" />
+          <span>Loading your library…</span>
+        </div>
+      );
+    }
+
     switch (view) {
       case 'conversation':
         return selectedCharacter ? (
@@ -350,12 +691,19 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
             environmentImageUrl={environmentImageUrl}
             onEnvironmentUpdate={setEnvironmentImageUrl}
             activeQuest={activeQuest}
-            // Fix: Pass the isSaving prop to ConversationView.
             isSaving={isSaving}
+            existingConversation={activeConversation}
+            onPersistDraft={persistConversation}
           />
         ) : null;
       case 'history':
-        return <HistoryView onBack={() => setView('selector')} />;
+        return (
+          <HistoryView
+            onBack={() => setView('selector')}
+            history={sortedHistory}
+            onDeleteConversation={deleteConversation}
+          />
+        );
       case 'creator':
         return <CharacterCreator onCharacterCreated={handleCharacterCreated} onBack={() => setView('selector')} />;
       case 'quests':
@@ -373,8 +721,8 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
       default:
         return (
           <div className="text-center animate-fade-in">
-             <p className="max-w-3xl mx-auto mb-8 text-gray-400 text-lg">
-                Engage in real-time voice conversations with legendary minds from history, or embark on a guided Learning Quest to master a new subject.
+            <p className="max-w-3xl mx-auto mb-8 text-gray-400 text-lg">
+              Engage in real-time voice conversations with legendary minds from history, or embark on a guided Learning Quest to master a new subject.
             </p>
             <div className="max-w-3xl mx-auto mb-8 bg-gray-800/50 border border-gray-700 rounded-lg p-4 text-left">
               <p className="text-sm text-gray-300 mb-2 font-semibold">Quest Progress</p>
@@ -423,19 +771,19 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
               </div>
             )}
             <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mb-12">
-                <button
-                    onClick={() => setView('quests')}
-                    className="flex items-center gap-3 bg-amber-600 hover:bg-amber-500 text-black font-bold py-3 px-8 rounded-lg transition-colors duration-300 text-lg w-full sm:w-auto"
-                >
-                    <QuestIcon className="w-6 h-6" />
-                    <span>Learning Quests</span>
-                </button>
-                <button
-                    onClick={() => setView('history')}
-                    className="bg-gray-700 hover:bg-gray-600 text-amber-300 font-bold py-3 px-8 rounded-lg transition-colors duration-300 border border-gray-600 w-full sm:w-auto"
-                >
-                    View Conversation History
-                </button>
+              <button
+                onClick={() => setView('quests')}
+                className="flex items-center gap-3 bg-amber-600 hover:bg-amber-500 text-black font-bold py-3 px-8 rounded-lg transition-colors duration-300 text-lg w-full sm:w-auto"
+              >
+                <QuestIcon className="w-6 h-6" />
+                <span>Learning Quests</span>
+              </button>
+              <button
+                onClick={() => setView('history')}
+                className="bg-gray-700 hover:bg-gray-600 text-amber-300 font-bold py-3 px-8 rounded-lg transition-colors duration-300 border border-gray-600 w-full sm:w-auto"
+              >
+                View Conversation History
+              </button>
             </div>
 
             <Instructions />
@@ -463,11 +811,29 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
         className="relative z-10 min-h-screen flex flex-col text-gray-200 font-serif p-4 sm:p-6 lg:p-8"
         style={{ background: environmentImageUrl ? 'transparent' : 'linear-gradient(to bottom right, #1a1a1a, #2b2b2b)' }}
       >
-        <header className="text-center mb-8">
-          <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold text-amber-300 tracking-wider" style={{ textShadow: '0 0 10px rgba(252, 211, 77, 0.5)' }}>
-            School of the Ancients
-          </h1>
-          <p className="text-gray-400 mt-2 text-lg">Old world wisdom. New world classroom.</p>
+        <header className="mb-8">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between text-center md:text-left gap-4">
+            <div>
+              <h1
+                className="text-4xl sm:text-5xl md:text-6xl font-bold text-amber-300 tracking-wider"
+                style={{ textShadow: '0 0 10px rgba(252, 211, 77, 0.5)' }}
+              >
+                School of the Ancients
+              </h1>
+              <p className="text-gray-400 mt-2 text-lg">Old world wisdom. New world classroom.</p>
+            </div>
+            {session && (
+              <div className="flex flex-col items-center md:items-end gap-2 text-sm">
+                <span className="text-gray-400">Signed in as {session.user.email}</span>
+                <button
+                  onClick={handleSignOut}
+                  className="px-4 py-1.5 rounded-lg border border-gray-600 text-gray-200 hover:border-amber-400 hover:text-amber-200 transition-colors"
+                >
+                  Sign out
+                </button>
+              </div>
+            )}
+          </div>
         </header>
         <main className="max-w-7xl w-full mx-auto flex-grow flex flex-col">
           {renderContent()}

--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -13,8 +13,6 @@ import SendIcon from './icons/SendIcon';
 import MuteIcon from './icons/MuteIcon';
 import UnmuteIcon from './icons/UnmuteIcon';
 
-const HISTORY_KEY = 'school-of-the-ancients-history';
-
 interface ConversationViewProps {
   character: Character;
   onEndConversation: (transcript: ConversationTurn[], sessionId: string) => void;
@@ -22,32 +20,9 @@ interface ConversationViewProps {
   onEnvironmentUpdate: (url: string | null) => void;
   activeQuest: Quest | null;
   isSaving: boolean;
+  existingConversation: SavedConversation | null;
+  onPersistDraft: (conversation: SavedConversation) => Promise<void>;
 }
-
-const loadConversations = (): SavedConversation[] => {
-  try {
-    const rawHistory = localStorage.getItem(HISTORY_KEY);
-    return rawHistory ? JSON.parse(rawHistory) : [];
-  } catch (error) {
-    console.error("Failed to load conversation history:", error);
-    return [];
-  }
-};
-
-const saveConversationToLocalStorage = (conversation: SavedConversation) => {
-  try {
-    const history = loadConversations();
-    const existingIndex = history.findIndex(c => c.id === conversation.id);
-    if (existingIndex > -1) {
-      history[existingIndex] = conversation;
-    } else {
-      history.unshift(conversation);
-    }
-    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
-  } catch (error) {
-    console.error("Failed to save conversation:", error);
-  }
-};
 
 const StatusIndicator: React.FC<{ state: ConnectionState; isMicActive: boolean }> = ({ state, isMicActive }) => {
   let statusText = 'Ready';
@@ -99,7 +74,16 @@ const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifa
     );
   };
 
-const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndConversation, environmentImageUrl, onEnvironmentUpdate, activeQuest, isSaving }) => {
+const ConversationView: React.FC<ConversationViewProps> = ({
+  character,
+  onEndConversation,
+  environmentImageUrl,
+  onEnvironmentUpdate,
+  activeQuest,
+  isSaving,
+  existingConversation,
+  onPersistDraft,
+}) => {
   const [transcript, setTranscript] = useState<ConversationTurn[]>([]);
   const [textInput, setTextInput] = useState('');
   const [dynamicSuggestions, setDynamicSuggestions] = useState<string[]>([]);
@@ -152,25 +136,26 @@ const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndCon
     };
 
     if (activeQuest) {
-      // Start a fresh conversation for a quest
       setTranscript([greetingTurn]);
       onEnvironmentUpdate(null);
       sessionIdRef.current = `quest_${activeQuest.id}_${Date.now()}`;
-    } else {
-      const history = loadConversations();
-      const existingConversation = history.find(c => c.characterId === character.id);
-      if (existingConversation && existingConversation.transcript.length > 0) {
-          setTranscript(existingConversation.transcript);
-          onEnvironmentUpdate(existingConversation.environmentImageUrl || null);
-          sessionIdRef.current = existingConversation.id; 
-      } else {
-          // This is a new conversation or an empty one from history
-          setTranscript([greetingTurn]);
-          onEnvironmentUpdate(null);
-          sessionIdRef.current = existingConversation ? existingConversation.id : `conv_${character.id}_${Date.now()}`;
-      }
+      return;
     }
-  }, [character, onEnvironmentUpdate, activeQuest]);
+
+    if (existingConversation) {
+      if (existingConversation.transcript.length > 0) {
+        setTranscript(existingConversation.transcript);
+      } else {
+        setTranscript([greetingTurn]);
+      }
+      onEnvironmentUpdate(existingConversation.environmentImageUrl || null);
+      sessionIdRef.current = existingConversation.id;
+    } else {
+      setTranscript([greetingTurn]);
+      onEnvironmentUpdate(null);
+      sessionIdRef.current = `conv_${character.id}_${Date.now()}`;
+    }
+  }, [character, onEnvironmentUpdate, activeQuest, existingConversation]);
 
     // Cycle through placeholders for text input
     useEffect(() => {
@@ -447,8 +432,9 @@ ${contextTranscript}
           }
         : {}),
     };
-    saveConversationToLocalStorage(conversation);
-  }, [transcript, character, environmentImageUrl, activeQuest]);
+
+    void onPersistDraft(conversation);
+  }, [transcript, character, environmentImageUrl, activeQuest, onPersistDraft]);
 
   const handleReset = () => {
     if (transcript.length === 0 && !environmentImageUrl) return;
@@ -480,7 +466,7 @@ ${contextTranscript}
                 }
               : {}),
         };
-        saveConversationToLocalStorage(clearedConversation);
+        void onPersistDraft(clearedConversation);
     }
   };
 

--- a/supabaseClient.ts
+++ b/supabaseClient.ts
@@ -1,0 +1,21 @@
+import { createClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+let client: SupabaseClient | null = null;
+
+if (supabaseUrl && supabaseAnonKey) {
+  client = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true,
+    },
+  });
+} else {
+  console.warn('Supabase environment variables are not set. Auth and storage features are disabled.');
+}
+
+export const supabase = client;
+export const isSupabaseConfigured = Boolean(client);


### PR DESCRIPTION
## Summary
- add Supabase client bootstrap and email sign-in flow with logout controls
- persist custom characters, conversations, and quest progress to Supabase instead of localStorage
- refactor history and conversation views to consume remote state and provide draft autosave hooks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcce2d1500832fbe0065c6ada7b29e