### PR TITLE
Add Supabase auth and migrate storage

### DIFF
--- a/components/AuthGate.tsx
+++ b/components/AuthGate.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { supabase } from '../supabaseClient';
+
+const AuthGate: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [mode, setMode] = useState<'signIn' | 'signUp'>('signIn');
+  const [message, setMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!supabase) {
+      setMessage('Supabase is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.');
+      return;
+    }
+    setIsSubmitting(true);
+    setMessage(null);
+
+    try {
+      if (mode === 'signUp') {
+        const { error } = await supabase.auth.signUp({ email, password });
+        if (error) {
+          throw error;
+        }
+        setMessage('Account created. Check your email to confirm your address if required.');
+      } else {
+        const { error } = await supabase.auth.signInWithPassword({ email, password });
+        if (error) {
+          throw error;
+        }
+      }
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Authentication failed.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[#121212] p-6">
+      <div className="w-full max-w-md bg-gray-900/80 border border-gray-700 rounded-2xl p-8 shadow-2xl text-gray-200">
+        <h1 className="text-3xl font-bold text-center text-amber-300 mb-6">School of the Ancients</h1>
+        <p className="text-center text-gray-400 mb-8">
+          Sign in with your email to continue your conversations with the Ancients.
+        </p>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="email" className="block text-sm font-semibold text-gray-300 mb-2">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={event => setEmail(event.target.value)}
+              required
+              className="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-400"
+            />
+          </div>
+          <div>
+            <label htmlFor="password" className="block text-sm font-semibold text-gray-300 mb-2">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={event => setPassword(event.target.value)}
+              required
+              className="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-3 text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-400"
+            />
+          </div>
+          {message && (
+            <p className="text-sm text-center text-amber-300 bg-amber-500/10 border border-amber-500/40 rounded-lg px-3 py-2">
+              {message}
+            </p>
+          )}
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full bg-amber-500 hover:bg-amber-400 text-black font-semibold py-3 rounded-lg transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? 'Processing...' : mode === 'signIn' ? 'Sign In' : 'Create Account'}
+          </button>
+        </form>
+        <div className="mt-6 text-center text-sm text-gray-400">
+          {mode === 'signIn' ? (
+            <button
+              onClick={() => setMode('signUp')}
+              className="text-amber-300 hover:text-amber-200 font-semibold"
+            >
+              Need an account? Sign up
+            </button>
+          ) : (
+            <button
+              onClick={() => setMode('signIn')}
+              className="text-amber-300 hover:text-amber-200 font-semibold"
+            >
+              Already have an account? Sign in
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AuthGate;

--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -13,8 +13,6 @@ import SendIcon from './icons/SendIcon';
 import MuteIcon from './icons/MuteIcon';
 import UnmuteIcon from './icons/UnmuteIcon';
 
-const HISTORY_KEY = 'school-of-the-ancients-history';
-
 interface ConversationViewProps {
   character: Character;
   onEndConversation: (transcript: ConversationTurn[], sessionId: string) => void;
@@ -22,32 +20,9 @@ interface ConversationViewProps {
   onEnvironmentUpdate: (url: string | null) => void;
   activeQuest: Quest | null;
   isSaving: boolean;
+  existingConversation: SavedConversation | null;
+  onAutosave: (conversation: SavedConversation) => Promise<void> | void;
 }
-
-const loadConversations = (): SavedConversation[] => {
-  try {
-    const rawHistory = localStorage.getItem(HISTORY_KEY);
-    return rawHistory ? JSON.parse(rawHistory) : [];
-  } catch (error) {
-    console.error("Failed to load conversation history:", error);
-    return [];
-  }
-};
-
-const saveConversationToLocalStorage = (conversation: SavedConversation) => {
-  try {
-    const history = loadConversations();
-    const existingIndex = history.findIndex(c => c.id === conversation.id);
-    if (existingIndex > -1) {
-      history[existingIndex] = conversation;
-    } else {
-      history.unshift(conversation);
-    }
-    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
-  } catch (error) {
-    console.error("Failed to save conversation:", error);
-  }
-};
 
 const StatusIndicator: React.FC<{ state: ConnectionState; isMicActive: boolean }> = ({ state, isMicActive }) => {
   let statusText = 'Ready';
@@ -99,7 +74,16 @@ const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifa
     );
   };
 
-const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndConversation, environmentImageUrl, onEnvironmentUpdate, activeQuest, isSaving }) => {
+const ConversationView: React.FC<ConversationViewProps> = ({
+  character,
+  onEndConversation,
+  environmentImageUrl,
+  onEnvironmentUpdate,
+  activeQuest,
+  isSaving,
+  existingConversation,
+  onAutosave,
+}) => {
   const [transcript, setTranscript] = useState<ConversationTurn[]>([]);
   const [textInput, setTextInput] = useState('');
   const [dynamicSuggestions, setDynamicSuggestions] = useState<string[]>([]);
@@ -152,25 +136,22 @@ const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndCon
     };
 
     if (activeQuest) {
-      // Start a fresh conversation for a quest
       setTranscript([greetingTurn]);
       onEnvironmentUpdate(null);
       sessionIdRef.current = `quest_${activeQuest.id}_${Date.now()}`;
-    } else {
-      const history = loadConversations();
-      const existingConversation = history.find(c => c.characterId === character.id);
-      if (existingConversation && existingConversation.transcript.length > 0) {
-          setTranscript(existingConversation.transcript);
-          onEnvironmentUpdate(existingConversation.environmentImageUrl || null);
-          sessionIdRef.current = existingConversation.id; 
-      } else {
-          // This is a new conversation or an empty one from history
-          setTranscript([greetingTurn]);
-          onEnvironmentUpdate(null);
-          sessionIdRef.current = existingConversation ? existingConversation.id : `conv_${character.id}_${Date.now()}`;
-      }
+      return;
     }
-  }, [character, onEnvironmentUpdate, activeQuest]);
+
+    if (existingConversation && existingConversation.transcript.length > 0) {
+      setTranscript(existingConversation.transcript);
+      onEnvironmentUpdate(existingConversation.environmentImageUrl || null);
+      sessionIdRef.current = existingConversation.id;
+    } else {
+      setTranscript([greetingTurn]);
+      onEnvironmentUpdate(null);
+      sessionIdRef.current = existingConversation ? existingConversation.id : `conv_${character.id}_${Date.now()}`;
+    }
+  }, [character, onEnvironmentUpdate, activeQuest, existingConversation?.id]);
 
     // Cycle through placeholders for text input
     useEffect(() => {
@@ -447,8 +428,8 @@ ${contextTranscript}
           }
         : {}),
     };
-    saveConversationToLocalStorage(conversation);
-  }, [transcript, character, environmentImageUrl, activeQuest]);
+    onAutosave(conversation);
+  }, [transcript, character, environmentImageUrl, activeQuest, onAutosave]);
 
   const handleReset = () => {
     if (transcript.length === 0 && !environmentImageUrl) return;
@@ -466,21 +447,21 @@ ${contextTranscript}
         changeAmbienceTrack(initialSrc);
         
         const clearedConversation: SavedConversation = {
-            id: sessionIdRef.current,
-            characterId: character.id,
-            characterName: character.name,
-            portraitUrl: character.portraitUrl,
-            timestamp: Date.now(),
-            transcript: [greetingTurn],
-            environmentImageUrl: undefined,
-            ...(activeQuest
-              ? {
-                  questId: activeQuest.id,
-                  questTitle: activeQuest.title,
-                }
-              : {}),
+          id: sessionIdRef.current,
+          characterId: character.id,
+          characterName: character.name,
+          portraitUrl: character.portraitUrl,
+          timestamp: Date.now(),
+          transcript: [greetingTurn],
+          environmentImageUrl: undefined,
+          ...(activeQuest
+            ? {
+                questId: activeQuest.id,
+                questTitle: activeQuest.title,
+              }
+            : {}),
         };
-        saveConversationToLocalStorage(clearedConversation);
+        onAutosave(clearedConversation);
     }
   };
 

--- a/docs/supabase_schema.sql
+++ b/docs/supabase_schema.sql
@@ -1,0 +1,57 @@
+-- Enable row level security for user-scoped data tables.
+
+create table if not exists custom_characters (
+  id text primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  character jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists conversations (
+  id text primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  character_id text not null,
+  character_name text not null,
+  portrait_url text not null,
+  occurred_at timestamptz not null default now(),
+  transcript jsonb not null default '[]'::jsonb,
+  environment_image_url text,
+  summary jsonb,
+  quest_id text,
+  quest_title text,
+  quest_assessment jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists completed_quests (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  quest_id text not null,
+  completed_at timestamptz not null default now(),
+  primary key (user_id, quest_id)
+);
+
+alter table custom_characters enable row level security;
+alter table conversations enable row level security;
+alter table completed_quests enable row level security;
+
+create policy "Users manage their custom characters"
+  on custom_characters
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "Users manage their conversations"
+  on conversations
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "Users manage their quest progress"
+  on completed_quests
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create index if not exists conversations_user_occurred_at_idx on conversations (user_id, occurred_at desc);
+create index if not exists custom_characters_user_created_at_idx on custom_characters (user_id, created_at desc);

--- a/supabaseClient.ts
+++ b/supabaseClient.ts
@@ -1,0 +1,15 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl) {
+  console.warn('VITE_SUPABASE_URL is not set. Supabase features will be disabled.');
+}
+
+if (!supabaseAnonKey) {
+  console.warn('VITE_SUPABASE_ANON_KEY is not set. Supabase features will be disabled.');
+}
+
+export const supabase: SupabaseClient | null =
+  supabaseUrl && supabaseAnonKey ? createClient(supabaseUrl, supabaseAnonKey) : null;


### PR DESCRIPTION
## Summary
- add a Supabase client and email-based authentication gate so the app requires sign-in
- migrate conversations, custom characters, and quest progress from localStorage to Supabase with autosave support
- document the Supabase schema and policies required for the new tables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcce2d1500832fbe0065c6ada7b29e