### PR TITLE
Implement Supabase authentication and storage

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,7 @@
 
-import React, { useState, useEffect } from 'react';
-// Fix: Add necessary imports for summary generation and conversation saving.
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { GoogleGenAI, Type } from '@google/genai';
+import type { Session } from '@supabase/supabase-js';
 import type {
   Character,
   Quest,
@@ -18,82 +18,144 @@ import QuestsView from './components/QuestsView';
 import Instructions from './components/Instructions';
 import { CHARACTERS, QUESTS } from './constants';
 import QuestIcon from './components/icons/QuestIcon';
+import { supabase } from './supabaseClient';
 
-const CUSTOM_CHARACTERS_KEY = 'school-of-the-ancients-custom-characters';
-// Fix: Add history key constant for conversation management.
-const HISTORY_KEY = 'school-of-the-ancients-history';
-const COMPLETED_QUESTS_KEY = 'school-of-the-ancients-completed-quests';
-
-// Fix: Add helper functions to manage conversation history in localStorage.
-const loadConversations = (): SavedConversation[] => {
-  try {
-    const rawHistory = localStorage.getItem(HISTORY_KEY);
-    return rawHistory ? JSON.parse(rawHistory) : [];
-  } catch (error) {
-    console.error("Failed to load conversation history:", error);
-    return [];
-  }
-};
-
-const saveConversationToLocalStorage = (conversation: SavedConversation) => {
-  try {
-    const history = loadConversations();
-    const existingIndex = history.findIndex(c => c.id === conversation.id);
-    if (existingIndex > -1) {
-      history[existingIndex] = conversation;
-    } else {
-      history.unshift(conversation);
-    }
-    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
-  } catch (error) {
-    console.error("Failed to save conversation:", error);
-  }
-};
-
-const loadCompletedQuests = (): string[] => {
-  try {
-    const stored = localStorage.getItem(COMPLETED_QUESTS_KEY);
-    return stored ? JSON.parse(stored) : [];
-  } catch (error) {
-    console.error('Failed to load completed quests:', error);
-    return [];
-  }
-};
-
-const saveCompletedQuests = (questIds: string[]) => {
-  try {
-    localStorage.setItem(COMPLETED_QUESTS_KEY, JSON.stringify(questIds));
-  } catch (error) {
-    console.error('Failed to save completed quests:', error);
-  }
-};
+const sortConversations = (items: SavedConversation[]) =>
+  [...items].sort((a, b) => b.timestamp - a.timestamp);
 
 const App: React.FC = () => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [authLoaded, setAuthLoaded] = useState(false);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [authError, setAuthError] = useState<string | null>(null);
+  const [authMessage, setAuthMessage] = useState<string | null>(null);
+  const [isAuthLoading, setIsAuthLoading] = useState(false);
+
   const [selectedCharacter, setSelectedCharacter] = useState<Character | null>(null);
   const [view, setView] = useState<'selector' | 'conversation' | 'history' | 'creator' | 'quests'>('selector');
   const [customCharacters, setCustomCharacters] = useState<Character[]>([]);
+  const [customCharactersLoaded, setCustomCharactersLoaded] = useState(false);
+  const [conversationHistory, setConversationHistory] = useState<SavedConversation[]>([]);
   const [environmentImageUrl, setEnvironmentImageUrl] = useState<string | null>(null);
   const [activeQuest, setActiveQuest] = useState<Quest | null>(null);
-  // Fix: Add isSaving state to manage the end conversation flow.
   const [isSaving, setIsSaving] = useState(false);
   const [completedQuests, setCompletedQuests] = useState<string[]>([]);
   const [lastQuestOutcome, setLastQuestOutcome] = useState<QuestAssessment | null>(null);
+  const [hasAppliedCharacterFromUrl, setHasAppliedCharacterFromUrl] = useState(false);
+
+  const allCharacters = useMemo(() => [...customCharacters, ...CHARACTERS], [customCharacters]);
 
   useEffect(() => {
-    // Load custom characters from local storage
-    try {
-      const storedCharacters = localStorage.getItem(CUSTOM_CHARACTERS_KEY);
-      if (storedCharacters) {
-        setCustomCharacters(JSON.parse(storedCharacters));
+    let isMounted = true;
+
+    const loadSession = async () => {
+      try {
+        const { data } = await supabase.auth.getSession();
+        if (isMounted) {
+          setSession(data.session);
+        }
+      } catch (error) {
+        console.error('Failed to retrieve auth session:', error);
+      } finally {
+        if (isMounted) {
+          setAuthLoaded(true);
+        }
       }
-    } catch (e) {
-      console.error("Failed to load custom characters:", e);
+    };
+
+    loadSession();
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, newSession) => {
+      if (isMounted) {
+        setSession(newSession);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+      listener.subscription.unsubscribe();
+    };
+  }, []);
+
+  const fetchCustomCharacters = useCallback(async () => {
+    if (!session) return;
+    try {
+      const { data, error } = await supabase
+        .from('custom_characters')
+        .select<{ character: Character }>('character')
+        .eq('user_id', session.user.id)
+        .order('created_at', { ascending: false });
+      if (error) {
+        throw error;
+      }
+      const characters = (data ?? []).map(row => row.character);
+      setCustomCharacters(characters);
+    } catch (error) {
+      console.error('Failed to load custom characters:', error);
+    } finally {
+      setCustomCharactersLoaded(true);
+    }
+  }, [session]);
+
+  const fetchConversationHistory = useCallback(async () => {
+    if (!session) return;
+    try {
+      const { data, error } = await supabase
+        .from('conversations')
+        .select<{ data: SavedConversation }>('data')
+        .eq('user_id', session.user.id)
+        .order('updated_at', { ascending: false });
+      if (error) {
+        throw error;
+      }
+      const conversations = (data ?? []).map(row => row.data);
+      setConversationHistory(sortConversations(conversations));
+    } catch (error) {
+      console.error('Failed to load conversation history:', error);
+    }
+  }, [session]);
+
+  const fetchCompletedQuests = useCallback(async () => {
+    if (!session) return;
+    try {
+      const { data, error } = await supabase
+        .from('completed_quests')
+        .select<{ quest_id: string }>('quest_id')
+        .eq('user_id', session.user.id);
+      if (error) {
+        throw error;
+      }
+      setCompletedQuests((data ?? []).map(row => row.quest_id));
+    } catch (error) {
+      console.error('Failed to load completed quests:', error);
+    }
+  }, [session]);
+
+  useEffect(() => {
+    if (!session) {
+      setCustomCharacters([]);
+      setConversationHistory([]);
+      setCompletedQuests([]);
+      setCustomCharactersLoaded(false);
+      setHasAppliedCharacterFromUrl(false);
+      return;
+    }
+
+    fetchCustomCharacters();
+    fetchConversationHistory();
+    fetchCompletedQuests();
+  }, [session, fetchCustomCharacters, fetchConversationHistory, fetchCompletedQuests]);
+
+  useEffect(() => {
+    if (!session || !customCharactersLoaded || hasAppliedCharacterFromUrl) {
+      return;
     }
 
     const urlParams = new URLSearchParams(window.location.search);
     const characterId = urlParams.get('character');
+
     if (characterId) {
-      const allCharacters = [...customCharacters, ...CHARACTERS];
       const characterFromUrl = allCharacters.find(c => c.id === characterId);
       if (characterFromUrl) {
         setSelectedCharacter(characterFromUrl);
@@ -101,146 +163,329 @@ const App: React.FC = () => {
       }
     }
 
-    setCompletedQuests(loadCompletedQuests());
-  }, []); // customCharacters dependency is intentionally omitted to avoid re-running on delete
+    setHasAppliedCharacterFromUrl(true);
+  }, [session, customCharactersLoaded, hasAppliedCharacterFromUrl, allCharacters]);
 
-  const handleSelectCharacter = (character: Character) => {
+  const handleAuth = useCallback(
+    async (mode: 'signin' | 'signup') => {
+      setAuthError(null);
+      setAuthMessage(null);
+      setIsAuthLoading(true);
+
+      try {
+        if (mode === 'signin') {
+          const { error } = await supabase.auth.signInWithPassword({
+            email: email.trim(),
+            password,
+          });
+          if (error) {
+            throw error;
+          }
+        } else {
+          const { error } = await supabase.auth.signUp({
+            email: email.trim(),
+            password,
+          });
+          if (error) {
+            throw error;
+          }
+          setAuthMessage('Check your email to confirm your account before signing in.');
+        }
+      } catch (error) {
+        if (error instanceof Error) {
+          setAuthError(error.message);
+        } else {
+          setAuthError('Authentication failed. Please try again.');
+        }
+      } finally {
+        setIsAuthLoading(false);
+      }
+    },
+    [email, password]
+  );
+
+  const handleSignIn = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      await handleAuth('signin');
+    },
+    [handleAuth]
+  );
+
+  const handleSignUp = useCallback(async () => {
+    await handleAuth('signup');
+  }, [handleAuth]);
+
+  const handleSignOut = useCallback(async () => {
+    try {
+      await supabase.auth.signOut();
+    } catch (error) {
+      console.error('Failed to sign out:', error);
+    } finally {
+      setSelectedCharacter(null);
+      setView('selector');
+      setEnvironmentImageUrl(null);
+      setActiveQuest(null);
+      setConversationHistory([]);
+      setCompletedQuests([]);
+    }
+  }, []);
+
+  const handleSelectCharacter = useCallback((character: Character) => {
     setSelectedCharacter(character);
     setView('conversation');
-    setActiveQuest(null); // Clear quest if a character is selected manually
+    setActiveQuest(null);
     const url = new URL(window.location.href);
     url.searchParams.set('character', character.id);
     window.history.pushState({}, '', url);
-  };
+  }, []);
 
-  const handleSelectQuest = (quest: Quest) => {
-    const allCharacters = [...customCharacters, ...CHARACTERS];
-    const characterForQuest = allCharacters.find(c => c.id === quest.characterId);
-    if (characterForQuest) {
-      setActiveQuest(quest);
-      setSelectedCharacter(characterForQuest);
-      setView('conversation');
-      const url = new URL(window.location.href);
-      url.searchParams.set('character', characterForQuest.id);
-      window.history.pushState({}, '', url);
-    } else {
-      console.error(`Character with ID ${quest.characterId} not found for the selected quest.`);
-    }
-  };
-
-  const handleCharacterCreated = (newCharacter: Character) => {
-    const updatedCharacters = [newCharacter, ...customCharacters];
-    setCustomCharacters(updatedCharacters);
-    try {
-      localStorage.setItem(CUSTOM_CHARACTERS_KEY, JSON.stringify(updatedCharacters));
-    } catch (e) {
-      console.error("Failed to save custom character:", e);
-    }
-    handleSelectCharacter(newCharacter);
-  };
-
-  const handleDeleteCharacter = (characterId: string) => {
-    if (window.confirm('Are you sure you want to permanently delete this ancient?')) {
-      const updatedCharacters = customCharacters.filter(c => c.id !== characterId);
-      setCustomCharacters(updatedCharacters);
-      try {
-        localStorage.setItem(CUSTOM_CHARACTERS_KEY, JSON.stringify(updatedCharacters));
-      } catch (e) {
-        console.error("Failed to delete custom character:", e);
+  const handleSelectQuest = useCallback(
+    (quest: Quest) => {
+      const characterForQuest = allCharacters.find(c => c.id === quest.characterId);
+      if (characterForQuest) {
+        setActiveQuest(quest);
+        setSelectedCharacter(characterForQuest);
+        setView('conversation');
+        const url = new URL(window.location.href);
+        url.searchParams.set('character', characterForQuest.id);
+        window.history.pushState({}, '', url);
+      } else {
+        console.error(`Character with ID ${quest.characterId} not found for the selected quest.`);
       }
-    }
-  };
+    },
+    [allCharacters]
+  );
 
-  // Fix: Implement summary generation and state reset on conversation end.
-  const handleEndConversation = async (transcript: ConversationTurn[], sessionId: string) => {
-    if (!selectedCharacter) return;
-    setIsSaving(true);
-    let questAssessment: QuestAssessment | null = null;
+  const handleCharacterCreated = useCallback(
+    async (newCharacter: Character) => {
+      if (!session) return;
 
-    try {
-      const conversationHistory = loadConversations();
-      const existingConversation = conversationHistory.find(c => c.id === sessionId);
+      try {
+        const { error } = await supabase
+          .from('custom_characters')
+          .upsert({
+            id: newCharacter.id,
+            user_id: session.user.id,
+            character: newCharacter,
+          });
+        if (error) {
+          throw error;
+        }
+        setCustomCharacters(prev => [newCharacter, ...prev.filter(c => c.id !== newCharacter.id)]);
+        handleSelectCharacter(newCharacter);
+      } catch (error) {
+        console.error('Failed to save custom character:', error);
+      }
+    },
+    [session, handleSelectCharacter]
+  );
 
-      let updatedConversation: SavedConversation = existingConversation ?? {
-        id: sessionId,
-        characterId: selectedCharacter.id,
-        characterName: selectedCharacter.name,
-        portraitUrl: selectedCharacter.portraitUrl,
-        timestamp: Date.now(),
-        transcript,
-        environmentImageUrl: environmentImageUrl || undefined,
-      };
+  const handleDeleteCharacter = useCallback(
+    async (characterId: string) => {
+      if (!session) return;
+      if (!window.confirm('Are you sure you want to permanently delete this ancient?')) {
+        return;
+      }
 
-      updatedConversation = {
-        ...updatedConversation,
-        transcript,
-        environmentImageUrl: environmentImageUrl || undefined,
-        timestamp: Date.now(),
-      };
+      try {
+        const { error } = await supabase
+          .from('custom_characters')
+          .delete()
+          .eq('id', characterId)
+          .eq('user_id', session.user.id);
+        if (error) {
+          throw error;
+        }
+        setCustomCharacters(prev => prev.filter(c => c.id !== characterId));
+        setConversationHistory(prev => prev.filter(c => c.characterId !== characterId));
+      } catch (error) {
+        console.error('Failed to delete custom character:', error);
+      }
+    },
+    [session]
+  );
 
-      if (activeQuest) {
+  const upsertConversation = useCallback(
+    async (conversation: SavedConversation) => {
+      if (!session) return;
+
+      setConversationHistory(prev => {
+        const updated = [...prev];
+        const existingIndex = updated.findIndex(item => item.id === conversation.id);
+        if (existingIndex > -1) {
+          updated[existingIndex] = conversation;
+        } else {
+          updated.push(conversation);
+        }
+        return sortConversations(updated);
+      });
+
+      const { error } = await supabase
+        .from('conversations')
+        .upsert({
+          id: conversation.id,
+          user_id: session.user.id,
+          character_id: conversation.characterId,
+          character_name: conversation.characterName,
+          data: conversation,
+          updated_at: new Date(conversation.timestamp).toISOString(),
+        });
+
+      if (error) {
+        console.error('Failed to persist conversation:', error);
+        fetchConversationHistory();
+      }
+    },
+    [session, fetchConversationHistory]
+  );
+
+  const handleConversationDraftChange = useCallback(
+    async (conversation: SavedConversation) => {
+      await upsertConversation(conversation);
+    },
+    [upsertConversation]
+  );
+
+  const syncCompletedQuest = useCallback(
+    async (questId: string, passed: boolean) => {
+      if (!session) return;
+
+      if (passed) {
+        setCompletedQuests(prev => (prev.includes(questId) ? prev : [...prev, questId]));
+        const { error } = await supabase
+          .from('completed_quests')
+          .upsert({ user_id: session.user.id, quest_id: questId });
+        if (error) {
+          console.error('Failed to mark quest complete:', error);
+          fetchCompletedQuests();
+        }
+      } else {
+        setCompletedQuests(prev => prev.filter(id => id !== questId));
+        const { error } = await supabase
+          .from('completed_quests')
+          .delete()
+          .match({ user_id: session.user.id, quest_id: questId });
+        if (error) {
+          console.error('Failed to update quest completion:', error);
+          fetchCompletedQuests();
+        }
+      }
+    },
+    [session, fetchCompletedQuests]
+  );
+
+  const handleDeleteConversation = useCallback(
+    async (conversationId: string) => {
+      if (!session) return;
+
+      setConversationHistory(prev => prev.filter(c => c.id !== conversationId));
+      try {
+        const { error } = await supabase
+          .from('conversations')
+          .delete()
+          .eq('id', conversationId)
+          .eq('user_id', session.user.id);
+        if (error) {
+          throw error;
+        }
+      } catch (error) {
+        console.error('Failed to delete conversation:', error);
+        fetchConversationHistory();
+      }
+    },
+    [session, fetchConversationHistory]
+  );
+
+  const handleEndConversation = useCallback(
+    async (transcript: ConversationTurn[], sessionId: string) => {
+      if (!selectedCharacter) return;
+      setIsSaving(true);
+      let questAssessment: QuestAssessment | null = null;
+
+      try {
+        const existingConversation = conversationHistory.find(c => c.id === sessionId);
+
+        let updatedConversation: SavedConversation = existingConversation ?? {
+          id: sessionId,
+          characterId: selectedCharacter.id,
+          characterName: selectedCharacter.name,
+          portraitUrl: selectedCharacter.portraitUrl,
+          timestamp: Date.now(),
+          transcript,
+          environmentImageUrl: environmentImageUrl || undefined,
+        };
+
         updatedConversation = {
           ...updatedConversation,
-          questId: activeQuest.id,
-          questTitle: activeQuest.title,
+          transcript,
+          environmentImageUrl: environmentImageUrl || undefined,
+          timestamp: Date.now(),
         };
-      }
 
-      let ai: GoogleGenAI | null = null;
-      if (!process.env.API_KEY) {
-        console.error('API_KEY not set, skipping summary and quest assessment.');
-      } else {
-        ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
-      }
+        if (activeQuest) {
+          updatedConversation = {
+            ...updatedConversation,
+            questId: activeQuest.id,
+            questTitle: activeQuest.title,
+          };
+        }
 
-      if (ai && transcript.length > 1) {
-        const transcriptText = transcript
-          .slice(1)
-          .map(turn => `${turn.speakerName}: ${turn.text}`)
-          .join('\n\n');
+        let ai: GoogleGenAI | null = null;
+        if (!process.env.API_KEY) {
+          console.error('API_KEY not set, skipping summary and quest assessment.');
+        } else {
+          ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+        }
 
-        if (transcriptText.trim()) {
-          const prompt = `Please summarize the following educational dialogue with ${selectedCharacter.name}. Provide a concise one-paragraph overview of the key topics discussed, and then list 3-5 of the most important takeaways or concepts as bullet points.
+        if (ai && transcript.length > 1) {
+          const transcriptText = transcript
+            .slice(1)
+            .map(turn => `${turn.speakerName}: ${turn.text}`)
+            .join('\n\n');
+
+          if (transcriptText.trim()) {
+            const prompt = `Please summarize the following educational dialogue with ${selectedCharacter.name}. Provide a concise one-paragraph overview of the key topics discussed, and then list 3-5 of the most important takeaways or concepts as bullet points.
 
 Dialogue:
 ${transcriptText}`;
 
-          const response = await ai.models.generateContent({
-            model: 'gemini-2.5-flash',
-            contents: prompt,
-            config: {
-              responseMimeType: 'application/json',
-              responseSchema: {
-                type: Type.OBJECT,
-                properties: {
-                  overview: { type: Type.STRING, description: 'A one-paragraph overview of the conversation.' },
-                  takeaways: {
-                    type: Type.ARRAY,
-                    items: { type: Type.STRING },
-                    description: 'A list of 3-5 key takeaways from the conversation.'
-                  }
+            const response = await ai.models.generateContent({
+              model: 'gemini-2.5-flash',
+              contents: prompt,
+              config: {
+                responseMimeType: 'application/json',
+                responseSchema: {
+                  type: Type.OBJECT,
+                  properties: {
+                    overview: { type: Type.STRING, description: 'A one-paragraph overview of the conversation.' },
+                    takeaways: {
+                      type: Type.ARRAY,
+                      items: { type: Type.STRING },
+                      description: 'A list of 3-5 key takeaways from the conversation.'
+                    }
+                  },
+                  required: ['overview', 'takeaways']
                 },
-                required: ['overview', 'takeaways']
               },
-            },
-          });
+            });
 
-          const summary: Summary = JSON.parse(response.text);
-          updatedConversation = {
-            ...updatedConversation,
-            summary,
-            timestamp: Date.now(),
-          };
+            const summary: Summary = JSON.parse(response.text);
+            updatedConversation = {
+              ...updatedConversation,
+              summary,
+              timestamp: Date.now(),
+            };
+          }
         }
-      }
 
-      if (ai && activeQuest) {
-        const questTranscriptText = transcript
-          .map(turn => `${turn.speakerName}: ${turn.text}`)
-          .join('\n\n');
+        if (ai && activeQuest) {
+          const questTranscriptText = transcript
+            .map(turn => `${turn.speakerName}: ${turn.text}`)
+            .join('\n\n');
 
-        if (questTranscriptText.trim()) {
-          const evaluationPrompt = `You are a meticulous mentor evaluating whether a student has mastered the quest "${activeQuest.title}". Review the conversation transcript between the mentor and student. Determine if the student demonstrates a working understanding of the quest objective: "${activeQuest.objective}".
+          if (questTranscriptText.trim()) {
+            const evaluationPrompt = `You are a meticulous mentor evaluating whether a student has mastered the quest "${activeQuest.title}". Review the conversation transcript between the mentor and student. Determine if the student demonstrates a working understanding of the quest objective: "${activeQuest.objective}".
 
 Return a JSON object with this structure:
 {
@@ -252,114 +497,117 @@ Return a JSON object with this structure:
 
 Focus only on the student's contributions. Mark passed=true only if the learner clearly articulates key ideas from the objective.`;
 
-          const evaluationResponse = await ai.models.generateContent({
-            model: 'gemini-2.5-flash',
-            contents: evaluationPrompt + `\n\nTranscript:\n${questTranscriptText}`,
-            config: {
-              responseMimeType: 'application/json',
-              responseSchema: {
-                type: Type.OBJECT,
-                properties: {
-                  passed: { type: Type.BOOLEAN },
-                  summary: { type: Type.STRING },
-                  evidence: {
-                    type: Type.ARRAY,
-                    items: { type: Type.STRING },
+            const evaluationResponse = await ai.models.generateContent({
+              model: 'gemini-2.5-flash',
+              contents: evaluationPrompt + `\n\nTranscript:\n${questTranscriptText}`,
+              config: {
+                responseMimeType: 'application/json',
+                responseSchema: {
+                  type: Type.OBJECT,
+                  properties: {
+                    passed: { type: Type.BOOLEAN },
+                    summary: { type: Type.STRING },
+                    evidence: {
+                      type: Type.ARRAY,
+                      items: { type: Type.STRING },
+                    },
+                    improvements: {
+                      type: Type.ARRAY,
+                      items: { type: Type.STRING },
+                    },
                   },
-                  improvements: {
-                    type: Type.ARRAY,
-                    items: { type: Type.STRING },
-                  },
+                  required: ['passed', 'summary', 'evidence', 'improvements'],
                 },
-                required: ['passed', 'summary', 'evidence', 'improvements'],
               },
-            },
-          });
+            });
 
-          const evaluation = JSON.parse(evaluationResponse.text);
-          questAssessment = {
-            questId: activeQuest.id,
-            questTitle: activeQuest.title,
-            passed: Boolean(evaluation.passed),
-            summary: evaluation.summary || '',
-            evidence: Array.isArray(evaluation.evidence) ? evaluation.evidence : [],
-            improvements: Array.isArray(evaluation.improvements) ? evaluation.improvements : [],
-          };
+            const evaluation = JSON.parse(evaluationResponse.text);
+            questAssessment = {
+              questId: activeQuest.id,
+              questTitle: activeQuest.title,
+              passed: Boolean(evaluation.passed),
+              summary: evaluation.summary || '',
+              evidence: Array.isArray(evaluation.evidence) ? evaluation.evidence : [],
+              improvements: Array.isArray(evaluation.improvements) ? evaluation.improvements : [],
+            };
 
+            updatedConversation = {
+              ...updatedConversation,
+              questAssessment,
+            };
+
+            await syncCompletedQuest(activeQuest.id, questAssessment.passed);
+          }
+        } else if (activeQuest) {
           updatedConversation = {
             ...updatedConversation,
-            questAssessment,
+            questId: activeQuest.id,
+            questTitle: activeQuest.title,
           };
-
-          if (questAssessment.passed) {
-            setCompletedQuests(prev => {
-              if (prev.includes(activeQuest.id)) {
-                saveCompletedQuests(prev);
-                return prev;
-              }
-              const updated = [...prev, activeQuest.id];
-              saveCompletedQuests(updated);
-              return updated;
-            });
-          } else {
-            setCompletedQuests(prev => {
-              if (!prev.includes(activeQuest.id)) {
-                saveCompletedQuests(prev);
-                return prev;
-              }
-              const updated = prev.filter(id => id !== activeQuest.id);
-              saveCompletedQuests(updated);
-              return updated;
-            });
-          }
         }
-      } else if (activeQuest) {
-        // Ensure quest metadata is retained even without AI assistance.
-        updatedConversation = {
-          ...updatedConversation,
-          questId: activeQuest.id,
-          questTitle: activeQuest.title,
-        };
-      }
 
-      saveConversationToLocalStorage(updatedConversation);
-    } catch (error) {
-      console.error('Failed to finalize conversation:', error);
-    } finally {
-      setIsSaving(false);
-      if (questAssessment) {
-        setLastQuestOutcome(questAssessment);
-      } else if (activeQuest) {
-        setLastQuestOutcome(null);
+        await upsertConversation(updatedConversation);
+      } catch (error) {
+        console.error('Failed to finalize conversation:', error);
+      } finally {
+        setIsSaving(false);
+        if (questAssessment) {
+          setLastQuestOutcome(questAssessment);
+        } else if (activeQuest) {
+          setLastQuestOutcome(null);
+        }
+        setSelectedCharacter(null);
+        setView('selector');
+        setEnvironmentImageUrl(null);
+        setActiveQuest(null);
+        window.history.pushState({}, '', window.location.pathname);
       }
-      setSelectedCharacter(null);
-      setView('selector');
-      setEnvironmentImageUrl(null);
-      setActiveQuest(null);
-      window.history.pushState({}, '', window.location.pathname);
-    }
-  };
+    },
+    [
+      selectedCharacter,
+      conversationHistory,
+      environmentImageUrl,
+      activeQuest,
+      syncCompletedQuest,
+      upsertConversation,
+    ]
+  );
 
   const renderContent = () => {
     switch (view) {
-      case 'conversation':
-        return selectedCharacter ? (
+      case 'conversation': {
+        if (!selectedCharacter) return null;
+        const initialConversation = conversationHistory.find(conv => {
+          if (activeQuest) {
+            return conv.questId === activeQuest.id;
+          }
+          return conv.characterId === selectedCharacter.id && !conv.questId;
+        }) ?? null;
+
+        return (
           <ConversationView
             character={selectedCharacter}
             onEndConversation={handleEndConversation}
             environmentImageUrl={environmentImageUrl}
             onEnvironmentUpdate={setEnvironmentImageUrl}
             activeQuest={activeQuest}
-            // Fix: Pass the isSaving prop to ConversationView.
             isSaving={isSaving}
+            initialConversation={initialConversation}
+            onConversationDraftChange={handleConversationDraftChange}
           />
-        ) : null;
+        );
+      }
       case 'history':
-        return <HistoryView onBack={() => setView('selector')} />;
+        return (
+          <HistoryView
+            onBack={() => setView('selector')}
+            history={conversationHistory}
+            onDeleteConversation={handleDeleteConversation}
+          />
+        );
       case 'creator':
         return <CharacterCreator onCharacterCreated={handleCharacterCreated} onBack={() => setView('selector')} />;
       case 'quests':
-        const allCharacters = [...customCharacters, ...CHARACTERS];
         return (
           <QuestsView
             onBack={() => setView('selector')}
@@ -441,7 +689,7 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
             <Instructions />
 
             <CharacterSelector
-              characters={[...customCharacters, ...CHARACTERS]}
+              characters={allCharacters}
               onSelectCharacter={handleSelectCharacter}
               onStartCreation={() => setView('creator')}
               onDeleteCharacter={handleDeleteCharacter}
@@ -451,8 +699,90 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
     }
   };
 
+  if (!authLoaded) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#1a1a1a] text-gray-200">
+        <p className="text-lg">Loading...</p>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#1a1a1a] text-gray-200 p-4">
+        <div className="w-full max-w-md bg-[#202020] p-6 sm:p-8 rounded-2xl shadow-2xl border border-gray-700 space-y-6">
+          <div className="text-center space-y-2">
+            <h1 className="text-3xl font-bold text-amber-300 tracking-wide">School of the Ancients</h1>
+            <p className="text-gray-400">Sign in with your Supabase account to continue your studies.</p>
+          </div>
+          {authError && <div className="bg-red-900/50 border border-red-700 text-red-200 px-3 py-2 rounded-lg text-sm">{authError}</div>}
+          {authMessage && <div className="bg-emerald-900/40 border border-emerald-700 text-emerald-200 px-3 py-2 rounded-lg text-sm">{authMessage}</div>}
+          <form onSubmit={handleSignIn} className="space-y-4">
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-300 mb-1">
+                Email
+              </label>
+              <input
+                id="email"
+                type="email"
+                required
+                value={email}
+                onChange={event => setEmail(event.target.value)}
+                className="w-full bg-gray-800 border border-gray-600 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-amber-400"
+                placeholder="you@example.com"
+                autoComplete="email"
+              />
+            </div>
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-1">
+                Password
+              </label>
+              <input
+                id="password"
+                type="password"
+                required
+                value={password}
+                onChange={event => setPassword(event.target.value)}
+                className="w-full bg-gray-800 border border-gray-600 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-amber-400"
+                placeholder="Enter your password"
+                autoComplete="current-password"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={isAuthLoading}
+              className="w-full bg-amber-600 hover:bg-amber-500 text-black font-semibold py-3 rounded-lg transition-colors disabled:opacity-60"
+            >
+              {isAuthLoading ? 'Signing in...' : 'Sign In'}
+            </button>
+          </form>
+          <button
+            type="button"
+            onClick={handleSignUp}
+            disabled={isAuthLoading}
+            className="w-full bg-gray-700 hover:bg-gray-600 text-amber-200 font-semibold py-3 rounded-lg transition-colors border border-gray-600 disabled:opacity-60"
+          >
+            Create Account
+          </button>
+          <p className="text-xs text-gray-500 text-center">
+            New accounts require email confirmation sent by Supabase before the first sign-in.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="relative min-h-screen bg-[#1a1a1a]">
+      <div className="absolute top-4 right-4 z-20 flex items-center gap-3 text-sm text-gray-300 bg-black/40 px-3 py-2 rounded-full border border-gray-700">
+        <span className="hidden sm:inline">{session.user.email ?? 'Signed in'}</span>
+        <button
+          onClick={handleSignOut}
+          className="bg-gray-700 hover:bg-gray-600 text-amber-200 font-semibold px-3 py-1 rounded-full transition-colors"
+        >
+          Sign Out
+        </button>
+      </div>
       <div
         className="absolute inset-0 bg-cover bg-center transition-opacity duration-1000 z-0"
         style={{ backgroundImage: environmentImageUrl ? `url(${environmentImageUrl})` : 'none' }}

--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -13,8 +13,6 @@ import SendIcon from './icons/SendIcon';
 import MuteIcon from './icons/MuteIcon';
 import UnmuteIcon from './icons/UnmuteIcon';
 
-const HISTORY_KEY = 'school-of-the-ancients-history';
-
 interface ConversationViewProps {
   character: Character;
   onEndConversation: (transcript: ConversationTurn[], sessionId: string) => void;
@@ -22,32 +20,9 @@ interface ConversationViewProps {
   onEnvironmentUpdate: (url: string | null) => void;
   activeQuest: Quest | null;
   isSaving: boolean;
+  initialConversation: SavedConversation | null;
+  onConversationDraftChange: (conversation: SavedConversation) => Promise<void> | void;
 }
-
-const loadConversations = (): SavedConversation[] => {
-  try {
-    const rawHistory = localStorage.getItem(HISTORY_KEY);
-    return rawHistory ? JSON.parse(rawHistory) : [];
-  } catch (error) {
-    console.error("Failed to load conversation history:", error);
-    return [];
-  }
-};
-
-const saveConversationToLocalStorage = (conversation: SavedConversation) => {
-  try {
-    const history = loadConversations();
-    const existingIndex = history.findIndex(c => c.id === conversation.id);
-    if (existingIndex > -1) {
-      history[existingIndex] = conversation;
-    } else {
-      history.unshift(conversation);
-    }
-    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
-  } catch (error) {
-    console.error("Failed to save conversation:", error);
-  }
-};
 
 const StatusIndicator: React.FC<{ state: ConnectionState; isMicActive: boolean }> = ({ state, isMicActive }) => {
   let statusText = 'Ready';
@@ -99,7 +74,16 @@ const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifa
     );
   };
 
-const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndConversation, environmentImageUrl, onEnvironmentUpdate, activeQuest, isSaving }) => {
+const ConversationView: React.FC<ConversationViewProps> = ({
+  character,
+  onEndConversation,
+  environmentImageUrl,
+  onEnvironmentUpdate,
+  activeQuest,
+  isSaving,
+  initialConversation,
+  onConversationDraftChange,
+}) => {
   const [transcript, setTranscript] = useState<ConversationTurn[]>([]);
   const [textInput, setTextInput] = useState('');
   const [dynamicSuggestions, setDynamicSuggestions] = useState<string[]>([]);
@@ -152,25 +136,22 @@ const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndCon
     };
 
     if (activeQuest) {
-      // Start a fresh conversation for a quest
       setTranscript([greetingTurn]);
       onEnvironmentUpdate(null);
       sessionIdRef.current = `quest_${activeQuest.id}_${Date.now()}`;
-    } else {
-      const history = loadConversations();
-      const existingConversation = history.find(c => c.characterId === character.id);
-      if (existingConversation && existingConversation.transcript.length > 0) {
-          setTranscript(existingConversation.transcript);
-          onEnvironmentUpdate(existingConversation.environmentImageUrl || null);
-          sessionIdRef.current = existingConversation.id; 
-      } else {
-          // This is a new conversation or an empty one from history
-          setTranscript([greetingTurn]);
-          onEnvironmentUpdate(null);
-          sessionIdRef.current = existingConversation ? existingConversation.id : `conv_${character.id}_${Date.now()}`;
-      }
+      return;
     }
-  }, [character, onEnvironmentUpdate, activeQuest]);
+
+    if (initialConversation && initialConversation.transcript.length > 0) {
+      setTranscript(initialConversation.transcript);
+      onEnvironmentUpdate(initialConversation.environmentImageUrl || null);
+      sessionIdRef.current = initialConversation.id;
+    } else {
+      setTranscript([greetingTurn]);
+      onEnvironmentUpdate(null);
+      sessionIdRef.current = `conv_${character.id}_${Date.now()}`;
+    }
+  }, [character, onEnvironmentUpdate, activeQuest, initialConversation]);
 
     // Cycle through placeholders for text input
     useEffect(() => {
@@ -447,8 +428,9 @@ ${contextTranscript}
           }
         : {}),
     };
-    saveConversationToLocalStorage(conversation);
-  }, [transcript, character, environmentImageUrl, activeQuest]);
+
+    void onConversationDraftChange(conversation);
+  }, [transcript, character, environmentImageUrl, activeQuest, onConversationDraftChange]);
 
   const handleReset = () => {
     if (transcript.length === 0 && !environmentImageUrl) return;
@@ -480,7 +462,7 @@ ${contextTranscript}
                 }
               : {}),
         };
-        saveConversationToLocalStorage(clearedConversation);
+        void onConversationDraftChange(clearedConversation);
     }
   };
 

--- a/components/HistoryView.tsx
+++ b/components/HistoryView.tsx
@@ -1,29 +1,7 @@
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import type { SavedConversation, ConversationTurn } from '../types';
 import DownloadIcon from './icons/DownloadIcon';
-
-const HISTORY_KEY = 'school-of-the-ancients-history';
-
-const loadConversations = (): SavedConversation[] => {
-  try {
-    const rawHistory = localStorage.getItem(HISTORY_KEY);
-    return rawHistory ? JSON.parse(rawHistory) : [];
-  } catch (error) {
-    console.error("Failed to load conversation history:", error);
-    return [];
-  }
-};
-
-const deleteConversationFromLocalStorage = (id: string) => {
-  try {
-    let history = loadConversations();
-    history = history.filter(c => c.id !== id);
-    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
-  } catch (error) {
-    console.error("Failed to delete conversation:", error);
-  }
-};
 
 const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifact']> }> = ({ artifact }) => {
   if (!artifact.imageUrl || artifact.loading) return null; // Don't show incomplete artifacts in history
@@ -38,23 +16,35 @@ const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifa
 
 interface HistoryViewProps {
   onBack: () => void;
+  history: SavedConversation[];
+  onDeleteConversation: (id: string) => Promise<void> | void;
 }
 
-const HistoryView: React.FC<HistoryViewProps> = ({ onBack }) => {
-  const [history, setHistory] = useState<SavedConversation[]>([]);
+const HistoryView: React.FC<HistoryViewProps> = ({ onBack, history, onDeleteConversation }) => {
   const [selectedConversation, setSelectedConversation] = useState<SavedConversation | null>(null);
 
   useEffect(() => {
-    setHistory(loadConversations());
-  }, []);
+    if (!selectedConversation) return;
+    const updated = history.find(conv => conv.id === selectedConversation.id);
+    if (!updated) {
+      setSelectedConversation(null);
+    } else if (updated !== selectedConversation) {
+      setSelectedConversation(updated);
+    }
+  }, [history, selectedConversation]);
 
-  const handleDelete = (id: string) => {
-    if (window.confirm('Are you sure you want to delete this conversation?')) {
-      deleteConversationFromLocalStorage(id);
-      setHistory(loadConversations());
+  const handleDelete = async (id: string) => {
+    if (!window.confirm('Are you sure you want to delete this conversation?')) {
+      return;
+    }
+
+    try {
+      await onDeleteConversation(id);
       if (selectedConversation?.id === id) {
         setSelectedConversation(null);
       }
+    } catch (error) {
+      console.error('Failed to delete conversation:', error);
     }
   };
 

--- a/supabaseClient.ts
+++ b/supabaseClient.ts
@@ -1,0 +1,10 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Supabase environment variables are not set. Please configure SUPABASE_URL and SUPABASE_ANON_KEY.');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,9 @@ export default defineConfig(({ mode }) => {
       plugins: [react()],
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+        'process.env.SUPABASE_URL': JSON.stringify(env.SUPABASE_URL),
+        'process.env.SUPABASE_ANON_KEY': JSON.stringify(env.SUPABASE_ANON_KEY)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- add a Supabase client and email/password login flow before entering the app
- persist custom characters, conversations, and quest completion data in Supabase instead of localStorage
- update the conversation and history views to read and write conversation drafts through Supabase

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcce2d1500832fbe0065c6ada7b29e