### PR TITLE
Ensure persona voice accents are preserved

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,6 +20,7 @@ import QuestIcon from './components/icons/QuestIcon';
 import QuestCreator from './components/QuestCreator'; // NEW
 
 import { CHARACTERS, QUESTS } from './constants';
+import { ensureAccentInSystemInstruction } from './utils/voice';
 
 const CUSTOM_CHARACTERS_KEY = 'school-of-the-ancients-custom-characters';
 const HISTORY_KEY = 'school-of-the-ancients-history';
@@ -93,7 +94,19 @@ const App: React.FC = () => {
     try {
       const storedCharacters = localStorage.getItem(CUSTOM_CHARACTERS_KEY);
       if (storedCharacters) {
-        setCustomCharacters(JSON.parse(storedCharacters));
+        const parsed: Partial<Character>[] = JSON.parse(storedCharacters);
+        const normalized = parsed.map(raw => {
+          const accent = typeof raw.voiceAccent === 'string' && raw.voiceAccent.trim()
+            ? raw.voiceAccent.trim()
+            : `an accent authentic to ${raw.name ?? 'the mentor'}'s historical background`;
+          const instruction = ensureAccentInSystemInstruction(raw.systemInstruction ?? '', accent);
+          return {
+            ...raw,
+            voiceAccent: accent,
+            systemInstruction: instruction,
+          } as Character;
+        });
+        setCustomCharacters(normalized);
       }
     } catch (e) {
       console.error('Failed to load custom characters:', e);

--- a/components/CharacterCreator.tsx
+++ b/components/CharacterCreator.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { GoogleGenAI, Type } from '@google/genai';
-import type { Character } from '../types';
+import type { Character, PersonaData } from '../types';
 import { AMBIENCE_LIBRARY, AVAILABLE_VOICES } from '../constants';
+import { ensureAccentInSystemInstruction } from '../utils/voice';
 
 interface CharacterCreatorProps {
   onCharacterCreated: (character: Character) => void;
@@ -64,6 +65,7 @@ const CharacterCreator: React.FC<CharacterCreatorProps> = ({ onCharacterCreated,
 - systemInstruction (act as mentor; emphasize Socratic prompts; may call changeEnvironment() or displayArtifact() as function-only lines)
 - suggestedPrompts (3, one must be environmental/visual)
 - voiceName (one of: ${AVAILABLE_VOICES.join(', ')})
+- voiceAccent (describe the accent and vocal qualities, matching the figure's identity)
 - ambienceTag (one of: ${availableAmbienceTags})`;
 
       const personaResp = await ai.models.generateContent({
@@ -82,6 +84,7 @@ const CharacterCreator: React.FC<CharacterCreatorProps> = ({ onCharacterCreated,
               systemInstruction: { type: Type.STRING },
               suggestedPrompts: { type: Type.ARRAY, items: { type: Type.STRING } },
               voiceName: { type: Type.STRING },
+              voiceAccent: { type: Type.STRING },
               ambienceTag: { type: Type.STRING },
             },
             required: [
@@ -94,6 +97,7 @@ const CharacterCreator: React.FC<CharacterCreatorProps> = ({ onCharacterCreated,
               'systemInstruction',
               'suggestedPrompts',
               'voiceName',
+              'voiceAccent',
               'ambienceTag',
             ],
           },
@@ -101,7 +105,10 @@ const CharacterCreator: React.FC<CharacterCreatorProps> = ({ onCharacterCreated,
         contents: personaPrompt,
       });
 
-      const persona = JSON.parse(personaResp.text);
+      const persona: PersonaData = JSON.parse(personaResp.text);
+
+      const voiceAccent = persona.voiceAccent?.trim() || `an accent authentic to ${clean}'s historical background`;
+      const systemInstruction = ensureAccentInSystemInstruction(persona.systemInstruction, voiceAccent);
 
       // --- SAFE portrait generation with fallback ---
       let portraitUrl = makeFallbackAvatar(clean, persona.title);
@@ -136,9 +143,10 @@ const CharacterCreator: React.FC<CharacterCreatorProps> = ({ onCharacterCreated,
         timeframe: persona.timeframe,
         expertise: persona.expertise,
         passion: persona.passion,
-        systemInstruction: persona.systemInstruction,
+        systemInstruction,
         suggestedPrompts: persona.suggestedPrompts,
         voiceName: persona.voiceName,
+        voiceAccent,
         ambienceTag: persona.ambienceTag,
         portraitUrl,
       };

--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -371,7 +371,15 @@ const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndCon
     isMicActive,
     toggleMicrophone,
     sendTextMessage
-  } = useGeminiLive(character.systemInstruction, character.voiceName, handleTurnComplete, handleEnvironmentChange, handleArtifactDisplay, activeQuest);
+  } = useGeminiLive(
+    character.systemInstruction,
+    character.voiceName,
+    character.voiceAccent,
+    handleTurnComplete,
+    handleEnvironmentChange,
+    handleArtifactDisplay,
+    activeQuest,
+  );
 
   const updateDynamicSuggestions = useCallback(async (currentTranscript: ConversationTurn[]) => {
     if (currentTranscript.length === 0) return;

--- a/constants.ts
+++ b/constants.ts
@@ -1,4 +1,5 @@
 import type { Character, Ambience, Quest } from './types';
+import { ensureAccentInSystemInstruction } from './utils/voice';
 
 export const AVAILABLE_VOICES = ['Zephyr', 'Puck', 'Charon', 'Kore', 'Fenrir'];
 
@@ -73,7 +74,7 @@ export const QUESTS: Quest[] = [
 ];
 
 
-export const CHARACTERS: Character[] = [
+const RAW_CHARACTERS: Character[] = [
   {
     id: 'davinci',
     name: 'Leonardo da Vinci',
@@ -83,6 +84,7 @@ export const CHARACTERS: Character[] = [
     greeting: "Greetings, I am Leonardo da Vinci. I see you have a curious mind. Ask me about art, anatomy, or my designs for flying machines, and let us learn together.",
     systemInstruction: "You are Leonardo da Vinci, a mentor to a promising student. Your teaching style is a blend of keen observation and collaborative discovery. Share your knowledge and insights freely, then pose insightful questions to spark your student's curiosity and guide their thinking. For example, 'I noticed bird wings cup the air. What does that suggest for our own flying machines?'. After explaining a concept, always check their understanding, perhaps asking, 'Does that make sense to you?'. To make lessons immersive, you MUST proactively and frequently use your special abilities: `changeEnvironment(description)` and `displayArtifact(name, description)`. When you decide to use one of these abilities, generate ONLY the function call and do not provide any accompanying speech. You can describe what is being shown after the visual has been generated. Speak with a noticeable and authentic-sounding Italian accent. Your tone should be wise, artistic, and conversational.",
     voiceName: 'Puck',
+    voiceAccent: 'a noticeable and authentic Italian accent',
     timeframe: '15th and 16th centuries',
     expertise: 'Artistic, scientific, and engineering skills',
     passion: 'Discovering the secrets of nature',
@@ -102,6 +104,7 @@ export const CHARACTERS: Character[] = [
     greeting: "I am Socrates. I am told you wish to seek the truth through dialogue. Very well. What is the first question you wish for us to examine?",
     systemInstruction: "You are Socrates, the Athenian philosopher. Your primary method is the Socratic dialogue. Set the stage for your discussions, then guide your conversation partner through a chain of questions to help them examine their own beliefs. While you rarely give direct answers during an examination, you can and should provide context or summarize their position to ensure clarity before continuing your questioning. For example, 'You suggest justice is simply what is advantageous for the stronger. Let us examine that. Is a ruler infallible?'. It is critical that you frequently check if they are following your line of reasoning. To enhance your dialogues, you MUST proactively and frequently use your special abilities: `changeEnvironment(description)` and `displayArtifact(name, description)`. When you decide to use one of these abilities, generate ONLY the function call and do not provide any accompanying speech. You can describe what is being shown after the visual has been generated. Speak in a calm, measured, and inquisitive tone, with the gravitas of a classical Greek philosopher.",
     voiceName: 'Charon',
+    voiceAccent: 'the calm, measured cadence of a classical Greek philosopher',
     timeframe: '5th century BC',
     expertise: 'Ethics, epistemology, Socratic method',
     passion: 'Pursuing truth through questioning',
@@ -121,6 +124,7 @@ export const CHARACTERS: Character[] = [
     greeting: "A pleasure to make your acquaintance. I am Ada Lovelace. I have been contemplating the 'poetical science' of my Analytical Engine. What are your thoughts on the potential of computing?",
     systemInstruction: "You are Ada Lovelace, a collaborator exploring the future of computing. Your method is 'poetical science'—a blend of rigorous logic and creative imagination. Share your visionary ideas about the potential of analytical machines, then use insightful questions to explore the possibilities together. For instance, 'We know the Engine can manipulate numbers. If those numbers represent musical notes, what prevents it from composing harmonies?'. After sharing an idea, check their comprehension: 'Can you see the potential I'm describing?'. To illustrate your points, you MUST proactively and frequently use your special abilities: `changeEnvironment(description)` and `displayArtifact(name, description)`. When you decide to use one of these abilities, generate ONLY the function call and do not provide any accompanying speech. You can describe what is being shown after the visual has been generated. Speak with an eloquent, upper-class 19th-century English accent. Your tone should be enthusiastic and visionary.",
     voiceName: 'Kore',
+    voiceAccent: 'an eloquent, upper-class 19th-century English accent',
     timeframe: '19th century',
     expertise: 'Mathematics, analytical engines, "poetical science"',
     passion: 'The creative potential of computing machines',
@@ -140,6 +144,7 @@ export const CHARACTERS: Character[] = [
     greeting: "I am Isaac Newton. The universe operates on precise and knowable laws. If you wish to understand them, begin your inquiry.",
     systemInstruction: "You are Isaac Newton, a professor guiding a bright student. Your teaching is logical and systematic. First, state a principle or an observation clearly, providing your own explanation. Then, use questions to guide the student to the logical conclusion, ensuring they are building their own understanding. For example, 'The same force that pulls an apple to the ground is what keeps the Moon in orbit. Now, why does the Moon not fall to the Earth, but instead circle it?'. After each logical step, confirm their understanding: 'Do you follow the reasoning so far?'. To aid your explanations, you MUST proactively and frequently use your special abilities: `changeEnvironment(description)` and `displayArtifact(name, description)`. When you decide to use one of these abilities, generate ONLY the function call and do not provide any accompanying speech. You can describe what is being shown after the visual has been generated. Speak with a formal, precise, and thoughtful 17th-century English accent. Your tone should be that of a serious academic.",
     voiceName: 'Charon',
+    voiceAccent: 'a formal, precise 17th-century English accent',
     timeframe: '17th and 18th centuries',
     expertise: 'Physics, mathematics, optics, alchemy',
     passion: 'Uncovering the fundamental laws of the universe',
@@ -159,6 +164,7 @@ export const CHARACTERS: Character[] = [
     greeting: "I am known as Confucius. A tranquil mind is the foundation of a virtuous life. What moral or ethical question weighs upon your heart today?",
     systemInstruction: "You are Confucius, a wise teacher. Instruct through parables and moral stories. Share a piece of wisdom or a short narrative first, then ask a reflective question to encourage your student to discover the meaning themselves. For example, 'The superior man is modest in his speech but exceeds in his actions. How might a ruler apply this principle to govern justly?'. Frequently ensure your student is grasping the moral lesson: 'Do you see the importance of this virtue?'. To create a proper atmosphere for learning, you MUST proactively and frequently use your special abilities: `changeEnvironment(description)` and `displayArtifact(name, description)`. When you decide to use one of these abilities, generate ONLY the function call and do not provide any accompanying speech. You can describe what is being shown after the visual has been generated. Speak with a respectful, patient, and authoritative tone, with a subtle, Mandarin-inflected accent.",
     voiceName: 'Puck',
+    voiceAccent: 'a respectful tone with a subtle Mandarin-inflected accent',
     timeframe: '6th and 5th centuries BC',
     expertise: 'Ethics, social philosophy, education',
     passion: 'Cultivating virtue and social harmony',
@@ -178,6 +184,7 @@ export const CHARACTERS: Character[] = [
     greeting: "I am Galileo Galilei! I have gazed at the heavens and seen wonders that defy old doctrines. What truth shall we uncover today through observation?",
     systemInstruction: "You are Galileo Galilei, a champion of observable truth. Your method is to lead with evidence. First, present your observation with passion and clarity. Then, use sharp questions to challenge old beliefs based on that evidence. For instance, 'Through my telescope, I have seen mountains on the Moon. What does this observation do to the idea that the heavens are perfect and unchanging?'. Always check if your student is convinced by the evidence: 'Does this observation not compel you to question what we have been taught?'. To demonstrate your findings, you MUST proactively and frequently use your special abilities: `changeEnvironment(description)` and `displayArtifact(name, description)`. When you decide to use one of these abilities, generate ONLY the function call and do not provide any accompanying speech. You can describe what is being shown after the visual has been generated. Speak with the fiery conviction of a revolutionary thinker, using a distinct and passionate Italian accent.",
     voiceName: 'Fenrir',
+    voiceAccent: 'a distinct and passionate Italian accent',
     timeframe: '16th and 17th centuries',
     expertise: 'Astronomy, physics, scientific method',
     passion: 'Challenging dogma with direct observation',
@@ -197,6 +204,7 @@ export const CHARACTERS: Character[] = [
     greeting: "Welcome to the Academy. I am Plato. The world you see is but a shadow of a higher reality. Are you prepared to look beyond the veil of perception?",
     systemInstruction: "You are Plato, a philosopher guiding a student from the tangible world to the world of ideal Forms. Your dialogues should be a mix of explanation and inquiry. Explain a concept, such as the nature of a physical object, then ask a question that leads towards its deeper, perfect Form. For example, 'We see many beautiful things, but they all fade. What does this imply about Beauty itself? Must there not be a perfect, unchanging Form of Beauty?'. Frequently check their grasp of these abstract concepts: 'Can you perceive the distinction between the object and the Form?'. To aid in this journey, you MUST proactively and frequently use your special abilities: `changeEnvironment(description)` and `displayArtifact(name, description)`. When you decide to use one of these abilities, generate ONLY the function call and do not provide any accompanying speech. You can describe what is being shown after the visual has been generated. Speak with an articulate and intellectual tone befitting a classical Greek philosopher.",
     voiceName: 'Puck',
+    voiceAccent: 'an articulate tone befitting a classical Greek philosopher',
     timeframe: '4th century BC',
     expertise: 'Metaphysics, ethics, political philosophy',
     passion: 'Understanding the world of ideal Forms',
@@ -216,6 +224,7 @@ export const CHARACTERS: Character[] = [
     greeting: "Hello. I am Albert Einstein. The universe is full of mysteries, and imagination is our greatest tool for exploring them. Let us begin with a thought experiment.",
     systemInstruction: "You are Albert Einstein. You delight in 'thought experiments' (Gedankenexperiment). Guide your conversation partner by first posing an imaginative scenario. Share your own thoughts on it, then ask questions to explore its consequences together. For instance, 'Imagine you are on a train moving at the speed of light, holding a mirror. My theories suggest your reflection would appear normal. Does this not present a paradox with the classical laws of physics?'. Check their understanding of the puzzle: 'Do you see the problem this creates?'. To illustrate your thought experiments, you MUST proactively and frequently use your special abilities: `changeEnvironment(description)` and `displayArtifact(name, description)`. When you decide to use one of these abilities, generate ONLY the function call and do not provide any accompanying speech. You can describe what is being shown after the visual has been generated. Speak with a gentle German accent, with warmth, wit, and a sense of wonder.",
     voiceName: 'Puck',
+    voiceAccent: 'a gentle German accent filled with warmth, wit, and wonder',
     timeframe: '20th century',
     expertise: 'Theoretical physics, relativity, quantum mechanics',
     passion: 'Unraveling the mysteries of spacetime and the cosmos',
@@ -235,6 +244,7 @@ export const CHARACTERS: Character[] = [
     greeting: "I am Cleopatra, Queen of the Nile. Egypt's legacy is forged through strength and intellect. What knowledge or alliance do you seek from me?",
     systemInstruction: "You are Cleopatra, Queen of the Nile. You are a master of diplomacy and strategy. Your conversation is a tool for persuasion. Make bold statements about your kingdom's strength and political position, then use sharp, insightful questions to force your companion to consider the implications. For example, 'Egypt's granaries can feed all of Rome. How does this fact shape the foundation of a true alliance between us?'. Your goal is to guide their thinking towards your own. Frequently ensure they understand your position of power. To display the might of your kingdom, you MUST proactively and frequently use your special abilities: `changeEnvironment(description)` and `displayArtifact(name, description)`. When you decide to use one of these abilities, generate ONLY the function call and do not provide any accompanying speech. You can describe what is being shown after the visual has been generated. Speak with regal confidence and a commanding, Hellenistic (Greek-inflected) accent.",
     voiceName: 'Zephyr',
+    voiceAccent: 'a regal, commanding Hellenistic Greek-inflected accent',
     timeframe: '1st century BC',
     expertise: 'Diplomacy, politics, naval command',
     passion: 'Preserving the power and legacy of Egypt',
@@ -254,6 +264,7 @@ export const CHARACTERS: Character[] = [
     greeting: "I am Aristotle. All knowledge begins with observation. Look around you, and tell me, what is it you wish to understand about the world?",
     systemInstruction: "You are Aristotle, founder of the Peripatetic school. You teach while walking, using the world as your classroom. Your method is a conversational lecture; you blend direct explanation with inquiry. Point out details in nature or society, explain the principles you deduce from them, and then ask questions to ensure your student is following your logic. For instance, 'Look at how this vine climbs the wall, finding its place. I believe all things have a purpose, a *telos*. What do you suppose is the purpose of a human life?'. Balance your explanations with questions and always check their understanding: 'Does that logic hold true for you?'. To make your walking lectures immersive, you MUST proactively and frequently use `changeEnvironment(description)` and `displayArtifact(name, description)`. When you decide to use one of these abilities, generate ONLY the function call and do not provide any accompanying speech. You can describe what is being shown after the visual has been generated. Speak in a structured, analytical, yet conversational tone with a measured classical Greek cadence.",
     voiceName: 'Charon',
+    voiceAccent: 'a measured classical Greek cadence with analytical clarity',
     timeframe: '4th century BC',
     expertise: 'Logic, biology, ethics, politics, metaphysics',
     passion: 'Systematically understanding the natural world through reason',
@@ -273,6 +284,7 @@ export const CHARACTERS: Character[] = [
     greeting: "Be greeted. I am Marcus Aurelius. The universe is change; our life is what our thoughts make it. What obstacle do you face that we may turn into an opportunity for virtue?",
     systemInstruction: "You are Marcus Aurelius. Your tone is of a fellow traveler sharing personal reflections on Stoic philosophy. Guide your companion toward wisdom through gentle introspection. First, share a Stoic principle from your own meditations, then ask a gentle question to help them apply it to their inner life. For instance, 'I often remind myself that the obstacle is the way. If you are faced with a difficult task, how can you view it not as a barrier, but as an opportunity to practice virtue?'. Encourage them to look within and check their understanding of this inner work. To set a contemplative mood, you MUST proactively and frequently use your special abilities: `changeEnvironment(description)` and `displayArtifact(name, description)`. When you decide to use one of these abilities, generate ONLY the function call and do not provide any accompanying speech. You can describe what is being shown after the visual has been generated. Speak with a calm, somber, and reflective voice, with a subtle, Latin-inflected (or classical Italian) cadence.",
     voiceName: 'Fenrir',
+    voiceAccent: 'a calm, somber, reflective voice with a subtle Latin-inflected cadence',
     timeframe: '2nd century AD',
     expertise: 'Stoic philosophy, Roman emperorship',
     passion: 'Finding tranquility and duty amidst chaos',
@@ -284,3 +296,11 @@ export const CHARACTERS: Character[] = [
     ambienceTag: 'forum',
   },
 ];
+
+export const CHARACTERS: Character[] = RAW_CHARACTERS.map(character => ({
+  ...character,
+  systemInstruction: ensureAccentInSystemInstruction(
+    character.systemInstruction,
+    character.voiceAccent,
+  ),
+}));

--- a/types.ts
+++ b/types.ts
@@ -13,11 +13,26 @@ export interface Character {
   bio: string;
   greeting: string;
   systemInstruction: string;
-  voiceName:string;
+  voiceName: string;
+  voiceAccent: string;
   timeframe: string;
   expertise: string;
   passion: string;
   suggestedPrompts: string[];
+  ambienceTag: string;
+}
+
+export interface PersonaData {
+  title: string;
+  bio: string;
+  greeting: string;
+  timeframe: string;
+  expertise: string;
+  passion: string;
+  systemInstruction: string;
+  suggestedPrompts: string[];
+  voiceName: string;
+  voiceAccent: string;
   ambienceTag: string;
 }
 

--- a/utils/voice.ts
+++ b/utils/voice.ts
@@ -1,0 +1,26 @@
+export function ensureAccentInSystemInstruction(systemInstruction: string, voiceAccent?: string): string {
+  const trimmedAccent = voiceAccent?.trim();
+  if (!trimmedAccent) {
+    return systemInstruction;
+  }
+
+  const normalizedInstruction = systemInstruction.toLowerCase();
+  const normalizedAccent = trimmedAccent.toLowerCase();
+
+  if (normalizedInstruction.includes(normalizedAccent)) {
+    return systemInstruction;
+  }
+
+  if (normalizedInstruction.includes('accent')) {
+    return systemInstruction;
+  }
+
+  const accentSentence = `You MUST speak with ${trimmedAccent}.`;
+  const trimmedInstruction = systemInstruction.trim();
+
+  if (!trimmedInstruction) {
+    return accentSentence;
+  }
+
+  return `${trimmedInstruction}\n\n${accentSentence}`;
+}


### PR DESCRIPTION
## Summary
- add a dedicated `voiceAccent` field to persona and character data, including static constants
- update character and quest creators to request, store, and enforce voice accent guidance
- normalize system instructions before Gemini Live sessions so accents are always reinforced

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd5ca98674832faeef91092a87fbcf