### PR TITLE
feat: integrate supabase auth and persistence

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { GoogleGenAI, Type } from '@google/genai';
+import type { User } from '@supabase/supabase-js';
 
 import type {
   Character,
@@ -20,99 +21,263 @@ import QuestIcon from './components/icons/QuestIcon';
 import QuestCreator from './components/QuestCreator'; // NEW
 
 import { CHARACTERS, QUESTS } from './constants';
-
-const CUSTOM_CHARACTERS_KEY = 'school-of-the-ancients-custom-characters';
-const HISTORY_KEY = 'school-of-the-ancients-history';
-const COMPLETED_QUESTS_KEY = 'school-of-the-ancients-completed-quests';
-
-// ---- Local storage helpers -------------------------------------------------
-
-const loadConversations = (): SavedConversation[] => {
-  try {
-    const rawHistory = localStorage.getItem(HISTORY_KEY);
-    return rawHistory ? JSON.parse(rawHistory) : [];
-  } catch (error) {
-    console.error('Failed to load conversation history:', error);
-    return [];
-  }
-};
-
-const saveConversationToLocalStorage = (conversation: SavedConversation) => {
-  try {
-    const history = loadConversations();
-    const existingIndex = history.findIndex((c) => c.id === conversation.id);
-    if (existingIndex > -1) {
-      history[existingIndex] = conversation;
-    } else {
-      history.unshift(conversation);
-    }
-    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
-  } catch (error) {
-    console.error('Failed to save conversation:', error);
-  }
-};
-
-const loadCompletedQuests = (): string[] => {
-  try {
-    const stored = localStorage.getItem(COMPLETED_QUESTS_KEY);
-    return stored ? JSON.parse(stored) : [];
-  } catch (error) {
-    console.error('Failed to load completed quests:', error);
-    return [];
-  }
-};
-
-const saveCompletedQuests = (questIds: string[]) => {
-  try {
-    localStorage.setItem(COMPLETED_QUESTS_KEY, JSON.stringify(questIds));
-  } catch (error) {
-    console.error('Failed to save completed quests:', error);
-  }
-};
+import { supabase } from './supabaseClient';
 
 // ---- App -------------------------------------------------------------------
 
 const App: React.FC = () => {
+  const [user, setUser] = useState<User | null>(null);
   const [selectedCharacter, setSelectedCharacter] = useState<Character | null>(null);
   const [view, setView] = useState<
     'selector' | 'conversation' | 'history' | 'creator' | 'quests' | 'questCreator'
   >('selector');
 
   const [customCharacters, setCustomCharacters] = useState<Character[]>([]);
+  const [conversations, setConversations] = useState<SavedConversation[]>([]);
   const [environmentImageUrl, setEnvironmentImageUrl] = useState<string | null>(null);
   const [activeQuest, setActiveQuest] = useState<Quest | null>(null);
 
-  // end-conversation save/AI-eval flag
   const [isSaving, setIsSaving] = useState(false);
+  const [isDataLoading, setIsDataLoading] = useState(false);
 
   const [completedQuests, setCompletedQuests] = useState<string[]>([]);
   const [lastQuestOutcome, setLastQuestOutcome] = useState<QuestAssessment | null>(null);
 
-  // On mount: load saved characters, url param character, and progress
-  useEffect(() => {
-    try {
-      const storedCharacters = localStorage.getItem(CUSTOM_CHARACTERS_KEY);
-      if (storedCharacters) {
-        setCustomCharacters(JSON.parse(storedCharacters));
+  const [authMode, setAuthMode] = useState<'signIn' | 'signUp'>('signIn');
+  const [authEmail, setAuthEmail] = useState('');
+  const [authPassword, setAuthPassword] = useState('');
+  const [authError, setAuthError] = useState<string | null>(null);
+  const [isAuthLoading, setIsAuthLoading] = useState(true);
+
+  const allCharacters = useMemo(() => {
+    const merged = [...customCharacters];
+    const existingIds = new Set(merged.map((c) => c.id));
+    for (const character of CHARACTERS) {
+      if (!existingIds.has(character.id)) {
+        merged.push(character);
       }
-    } catch (e) {
-      console.error('Failed to load custom characters:', e);
+    }
+    return merged;
+  }, [customCharacters]);
+
+  const fetchUserData = async (currentUser: User) => {
+    setIsDataLoading(true);
+    try {
+      const [charactersRes, conversationsRes, questsRes] = await Promise.all([
+        supabase
+          .from('custom_characters')
+          .select('character')
+          .eq('user_id', currentUser.id)
+          .order('created_at', { ascending: false }),
+        supabase
+          .from('conversations')
+          .select(
+            'id, character_id, character_name, portrait_url, timestamp, transcript, environment_image_url, summary, quest_id, quest_title, quest_assessment'
+          )
+          .eq('user_id', currentUser.id)
+          .order('timestamp', { ascending: false }),
+        supabase
+          .from('completed_quests')
+          .select('quest_id')
+          .eq('user_id', currentUser.id),
+      ]);
+
+      if (charactersRes.error) {
+        console.error('Failed to load custom characters:', charactersRes.error.message);
+      } else {
+        const characters =
+          charactersRes.data?.map((row) => row.character as Character).filter(Boolean) ?? [];
+        setCustomCharacters(characters);
+      }
+
+      if (conversationsRes.error) {
+        console.error('Failed to load conversations:', conversationsRes.error.message);
+      } else {
+        const loadedConversations: SavedConversation[] =
+          conversationsRes.data?.map((row) => ({
+            id: row.id,
+            characterId: row.character_id,
+            characterName: row.character_name,
+            portraitUrl: row.portrait_url,
+            timestamp: row.timestamp,
+            transcript: (row.transcript as ConversationTurn[]) ?? [],
+            environmentImageUrl: row.environment_image_url ?? undefined,
+            summary: (row.summary as Summary | null) ?? undefined,
+            questId: row.quest_id ?? undefined,
+            questTitle: row.quest_title ?? undefined,
+            questAssessment: (row.quest_assessment as QuestAssessment | null) ?? undefined,
+          })) ?? [];
+        setConversations(loadedConversations);
+      }
+
+      if (questsRes.error) {
+        console.error('Failed to load completed quests:', questsRes.error.message);
+      } else {
+        const questIds = questsRes.data?.map((row) => row.quest_id).filter(Boolean) ?? [];
+        setCompletedQuests(questIds);
+      }
+    } catch (error) {
+      console.error('Failed to fetch Supabase data:', error);
+    } finally {
+      setIsDataLoading(false);
+    }
+  };
+
+  const persistCustomCharacter = async (character: Character) => {
+    if (!user) return;
+    setCustomCharacters((prev) => {
+      const filtered = prev.filter((c) => c.id !== character.id);
+      return [character, ...filtered];
+    });
+    const { error } = await supabase.from('custom_characters').upsert(
+      {
+        user_id: user.id,
+        character_id: character.id,
+        character,
+      },
+      { onConflict: 'character_id' }
+    );
+    if (error) {
+      console.error('Failed to save custom character:', error.message);
+    }
+  };
+
+  const removeCustomCharacter = async (characterId: string) => {
+    if (!user) return;
+    setCustomCharacters((prev) => prev.filter((c) => c.id !== characterId));
+    const { error } = await supabase
+      .from('custom_characters')
+      .delete()
+      .eq('user_id', user.id)
+      .eq('character_id', characterId);
+    if (error) {
+      console.error('Failed to delete custom character:', error.message);
+    }
+  };
+
+  const upsertConversation = async (conversation: SavedConversation) => {
+    if (!user) return;
+    setConversations((prev) => {
+      const existingIndex = prev.findIndex((c) => c.id === conversation.id);
+      if (existingIndex > -1) {
+        const updated = [...prev];
+        updated[existingIndex] = conversation;
+        return updated.sort((a, b) => b.timestamp - a.timestamp);
+      }
+      return [conversation, ...prev].sort((a, b) => b.timestamp - a.timestamp);
+    });
+
+    const { error } = await supabase.from('conversations').upsert(
+      {
+        id: conversation.id,
+        user_id: user.id,
+        character_id: conversation.characterId,
+        character_name: conversation.characterName,
+        portrait_url: conversation.portraitUrl,
+        timestamp: conversation.timestamp,
+        transcript: conversation.transcript,
+        environment_image_url: conversation.environmentImageUrl ?? null,
+        summary: conversation.summary ?? null,
+        quest_id: conversation.questId ?? null,
+        quest_title: conversation.questTitle ?? null,
+        quest_assessment: conversation.questAssessment ?? null,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'id' }
+    );
+
+    if (error) {
+      console.error('Failed to save conversation:', error.message);
+    }
+  };
+
+  const deleteConversation = async (conversationId: string) => {
+    if (!user) return;
+    setConversations((prev) => prev.filter((conv) => conv.id !== conversationId));
+    const { error } = await supabase
+      .from('conversations')
+      .delete()
+      .eq('user_id', user.id)
+      .eq('id', conversationId);
+    if (error) {
+      console.error('Failed to delete conversation:', error.message);
+    }
+  };
+
+  const markQuestCompleted = async (questId: string) => {
+    if (!user) return;
+    setCompletedQuests((prev) => {
+      if (prev.includes(questId)) return prev;
+      return [...prev, questId];
+    });
+    const { error } = await supabase.from('completed_quests').upsert(
+      {
+        user_id: user.id,
+        quest_id: questId,
+        completed_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id,quest_id' }
+    );
+    if (error) {
+      console.error('Failed to mark quest as completed:', error.message);
+    }
+  };
+
+  const unmarkQuestCompleted = async (questId: string) => {
+    if (!user) return;
+    setCompletedQuests((prev) => prev.filter((id) => id !== questId));
+    const { error } = await supabase
+      .from('completed_quests')
+      .delete()
+      .eq('user_id', user.id)
+      .eq('quest_id', questId);
+    if (error) {
+      console.error('Failed to unmark quest completion:', error.message);
+    }
+  };
+
+  useEffect(() => {
+    const initAuth = async () => {
+      const { data } = await supabase.auth.getSession();
+      setUser(data.session?.user ?? null);
+      setIsAuthLoading(false);
+    };
+
+    void initAuth();
+
+    const { data: subscription } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => {
+      subscription.subscription.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!user) {
+      setCustomCharacters([]);
+      setConversations([]);
+      setCompletedQuests([]);
+      setLastQuestOutcome(null);
+      setEnvironmentImageUrl(null);
+      return;
     }
 
+    void fetchUserData(user);
+  }, [user]);
+
+  useEffect(() => {
+    if (!user || selectedCharacter) return;
     const urlParams = new URLSearchParams(window.location.search);
     const characterId = urlParams.get('character');
-    if (characterId) {
-      const allCharacters = [...customCharacters, ...CHARACTERS];
-      const characterFromUrl = allCharacters.find((c) => c.id === characterId);
-      if (characterFromUrl) {
-        setSelectedCharacter(characterFromUrl);
-        setView('conversation');
-      }
+    if (!characterId) return;
+    const characterFromUrl = allCharacters.find((c) => c.id === characterId);
+    if (characterFromUrl) {
+      setSelectedCharacter(characterFromUrl);
+      setView('conversation');
     }
-
-    setCompletedQuests(loadCompletedQuests());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [allCharacters, selectedCharacter, user]);
 
   // ---- Navigation helpers ----
 
@@ -126,7 +291,6 @@ const App: React.FC = () => {
   };
 
   const handleSelectQuest = (quest: Quest) => {
-    const allCharacters = [...customCharacters, ...CHARACTERS];
     const characterForQuest = allCharacters.find((c) => c.id === quest.characterId);
     if (characterForQuest) {
       setActiveQuest(quest);
@@ -140,26 +304,14 @@ const App: React.FC = () => {
     }
   };
 
-  const handleCharacterCreated = (newCharacter: Character) => {
-    const updatedCharacters = [newCharacter, ...customCharacters];
-    setCustomCharacters(updatedCharacters);
-    try {
-      localStorage.setItem(CUSTOM_CHARACTERS_KEY, JSON.stringify(updatedCharacters));
-    } catch (e) {
-      console.error('Failed to save custom character:', e);
-    }
+  const handleCharacterCreated = async (newCharacter: Character) => {
+    await persistCustomCharacter(newCharacter);
     handleSelectCharacter(newCharacter);
   };
 
   const handleDeleteCharacter = (characterId: string) => {
     if (window.confirm('Are you sure you want to permanently delete this ancient?')) {
-      const updatedCharacters = customCharacters.filter((c) => c.id !== characterId);
-      setCustomCharacters(updatedCharacters);
-      try {
-        localStorage.setItem(CUSTOM_CHARACTERS_KEY, JSON.stringify(updatedCharacters));
-      } catch (e) {
-        console.error('Failed to delete custom character:', e);
-      }
+      void removeCustomCharacter(characterId);
     }
   };
 
@@ -173,30 +325,57 @@ const App: React.FC = () => {
     window.history.pushState({}, '', url);
   };
 
+  const handleAuthSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setAuthError(null);
+
+    if (!authEmail.trim() || !authPassword.trim()) {
+      setAuthError('Please provide both email and password.');
+      return;
+    }
+
+    if (authMode === 'signIn') {
+      const { error } = await supabase.auth.signInWithPassword({
+        email: authEmail,
+        password: authPassword,
+      });
+      if (error) {
+        setAuthError(error.message);
+      }
+    } else {
+      const { error } = await supabase.auth.signUp({
+        email: authEmail,
+        password: authPassword,
+      });
+      if (error) {
+        setAuthError(error.message);
+      }
+    }
+  };
+
+  const handleSignOut = async () => {
+    await supabase.auth.signOut();
+    setAuthEmail('');
+    setAuthPassword('');
+  };
+
   // ---- End conversation: summarize & (if quest) evaluate mastery ----
   const handleEndConversation = async (transcript: ConversationTurn[], sessionId: string) => {
-    if (!selectedCharacter) return;
+    if (!selectedCharacter || !user) return;
     setIsSaving(true);
     let questAssessment: QuestAssessment | null = null;
+    let updatedConversation: SavedConversation | null = null;
 
     try {
-      const conversationHistory = loadConversations();
-      const existingConversation = conversationHistory.find((c) => c.id === sessionId);
+      const existingConversation = conversations.find((c) => c.id === sessionId);
 
-      let updatedConversation: SavedConversation =
-        existingConversation ??
-        ({
+      updatedConversation = {
+        ...(existingConversation ?? {
           id: sessionId,
           characterId: selectedCharacter.id,
           characterName: selectedCharacter.name,
           portraitUrl: selectedCharacter.portraitUrl,
-          timestamp: Date.now(),
-          transcript,
-          environmentImageUrl: environmentImageUrl || undefined,
-        } as SavedConversation);
-
-      updatedConversation = {
-        ...updatedConversation,
+        }),
         transcript,
         environmentImageUrl: environmentImageUrl || undefined,
         timestamp: Date.now(),
@@ -217,7 +396,6 @@ const App: React.FC = () => {
         ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
       }
 
-      // Conversation summary (skip first system/greeting turn)
       if (ai && transcript.length > 1) {
         const transcriptText = transcript
           .slice(1)
@@ -259,7 +437,6 @@ ${transcriptText}`;
         }
       }
 
-      // If this was a quest session, evaluate mastery
       if (ai && activeQuest) {
         const questTranscriptText = transcript.map((turn) => `${turn.speakerName}: ${turn.text}`).join('\n\n');
 
@@ -310,29 +487,12 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
           };
 
           if (questAssessment.passed) {
-            setCompletedQuests((prev) => {
-              if (prev.includes(activeQuest.id)) {
-                saveCompletedQuests(prev);
-                return prev;
-              }
-              const updated = [...prev, activeQuest.id]; // FIX
-              saveCompletedQuests(updated);
-              return updated;
-            });
+            await markQuestCompleted(activeQuest.id);
           } else {
-            setCompletedQuests((prev) => {
-              if (!prev.includes(activeQuest.id)) {
-                saveCompletedQuests(prev);
-                return prev;
-              }
-              const updated = prev.filter((id) => id !== activeQuest.id);
-              saveCompletedQuests(updated);
-              return updated;
-            });
+            await unmarkQuestCompleted(activeQuest.id);
           }
         }
       } else if (activeQuest) {
-        // Ensure quest metadata is retained even without AI assistance.
         updatedConversation = {
           ...updatedConversation,
           questId: activeQuest.id,
@@ -340,7 +500,7 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
         };
       }
 
-      saveConversationToLocalStorage(updatedConversation);
+      await upsertConversation(updatedConversation);
     } catch (error) {
       console.error('Failed to finalize conversation:', error);
     } finally {
@@ -358,6 +518,92 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
     }
   };
 
+  const activeConversationRecord = useMemo(() => {
+    if (!selectedCharacter) return null;
+    return conversations.find((conv) => conv.characterId === selectedCharacter.id) ?? null;
+  }, [conversations, selectedCharacter]);
+
+  if (isAuthLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#1a1a1a] text-gray-300">
+        Checking session...
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#1a1a1a] p-4">
+        <div className="w-full max-w-md bg-gray-900/90 border border-gray-700 rounded-2xl p-8 shadow-2xl">
+          <h1 className="text-3xl font-bold text-amber-300 text-center mb-2">School of the Ancients</h1>
+          <p className="text-center text-gray-400 mb-6">Sign in to continue your studies.</p>
+          <form onSubmit={handleAuthSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-semibold text-gray-300 mb-1" htmlFor="auth-email">
+                Email
+              </label>
+              <input
+                id="auth-email"
+                type="email"
+                value={authEmail}
+                onChange={(e) => setAuthEmail(e.target.value)}
+                className="w-full rounded-lg bg-gray-800 border border-gray-700 px-4 py-2 text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-400"
+                placeholder="you@example.com"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-semibold text-gray-300 mb-1" htmlFor="auth-password">
+                Password
+              </label>
+              <input
+                id="auth-password"
+                type="password"
+                value={authPassword}
+                onChange={(e) => setAuthPassword(e.target.value)}
+                className="w-full rounded-lg bg-gray-800 border border-gray-700 px-4 py-2 text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-400"
+                placeholder="••••••••"
+                required
+              />
+            </div>
+            {authError && <p className="text-sm text-red-400">{authError}</p>}
+            <button
+              type="submit"
+              className="w-full bg-amber-500 hover:bg-amber-400 text-black font-semibold py-2 rounded-lg transition-colors"
+            >
+              {authMode === 'signIn' ? 'Sign In' : 'Create Account'}
+            </button>
+          </form>
+          <div className="mt-6 text-center text-sm text-gray-400">
+            {authMode === 'signIn' ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setAuthMode('signUp');
+                  setAuthError(null);
+                }}
+                className="text-amber-300 hover:text-amber-200"
+              >
+                Need an account? Sign up.
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  setAuthMode('signIn');
+                  setAuthError(null);
+                }}
+                className="text-amber-300 hover:text-amber-200"
+              >
+                Already registered? Sign in.
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   // ---- View switcher ----
 
   const renderContent = () => {
@@ -371,14 +617,21 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
             onEnvironmentUpdate={setEnvironmentImageUrl}
             activeQuest={activeQuest}
             isSaving={isSaving} // pass saving state
+            existingConversation={activeQuest ? null : activeConversationRecord}
+            onAutosave={upsertConversation}
           />
         ) : null;
       case 'history':
-        return <HistoryView onBack={() => setView('selector')} />;
+        return (
+          <HistoryView
+            onBack={() => setView('selector')}
+            history={conversations}
+            onDeleteConversation={deleteConversation}
+          />
+        );
       case 'creator':
         return <CharacterCreator onCharacterCreated={handleCharacterCreated} onBack={() => setView('selector')} />;
       case 'quests': {
-        const allCharacters = [...customCharacters, ...CHARACTERS]; // FIX
         return (
           <QuestsView
             onBack={() => setView('selector')}
@@ -398,11 +651,7 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
             onBack={() => setView('selector')}
             onQuestReady={startGeneratedQuest}
             onCharacterCreated={(newChar) => {
-              const updated = [newChar, ...customCharacters];
-              setCustomCharacters(updated);
-              try {
-                localStorage.setItem(CUSTOM_CHARACTERS_KEY, JSON.stringify(updated));
-              } catch {}
+              void persistCustomCharacter(newChar);
             }}
           />
         );
@@ -538,9 +787,23 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
             School of the Ancients
           </h1>
           <p className="text-gray-400 mt-2 text-lg">Old world wisdom. New world classroom.</p>
+          <div className="mt-4 flex flex-col sm:flex-row items-center justify-center gap-3 text-sm text-gray-400">
+            <span>Signed in as {user.email ?? 'Scholar'}</span>
+            <button
+              onClick={handleSignOut}
+              className="px-4 py-1 rounded-full bg-gray-800/60 border border-gray-700 text-amber-200 hover:bg-gray-700 transition-colors"
+            >
+              Sign out
+            </button>
+          </div>
         </header>
 
-        <main className="max-w-7xl w-full mx-auto flex-grow flex flex-col">{renderContent()}</main>
+        <main className="max-w-7xl w-full mx-auto flex-grow flex flex-col">
+          {isDataLoading && (
+            <div className="mb-4 text-center text-sm text-gray-400">Syncing your progress...</div>
+          )}
+          {renderContent()}
+        </main>
       </div>
     </div>
   );

--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -13,8 +13,6 @@ import SendIcon from './icons/SendIcon';
 import MuteIcon from './icons/MuteIcon';
 import UnmuteIcon from './icons/UnmuteIcon';
 
-const HISTORY_KEY = 'school-of-the-ancients-history';
-
 interface ConversationViewProps {
   character: Character;
   onEndConversation: (transcript: ConversationTurn[], sessionId: string) => void;
@@ -22,32 +20,9 @@ interface ConversationViewProps {
   onEnvironmentUpdate: (url: string | null) => void;
   activeQuest: Quest | null;
   isSaving: boolean;
+  existingConversation: SavedConversation | null;
+  onAutosave: (conversation: SavedConversation) => void | Promise<void>;
 }
-
-const loadConversations = (): SavedConversation[] => {
-  try {
-    const rawHistory = localStorage.getItem(HISTORY_KEY);
-    return rawHistory ? JSON.parse(rawHistory) : [];
-  } catch (error) {
-    console.error("Failed to load conversation history:", error);
-    return [];
-  }
-};
-
-const saveConversationToLocalStorage = (conversation: SavedConversation) => {
-  try {
-    const history = loadConversations();
-    const existingIndex = history.findIndex(c => c.id === conversation.id);
-    if (existingIndex > -1) {
-      history[existingIndex] = conversation;
-    } else {
-      history.unshift(conversation);
-    }
-    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
-  } catch (error) {
-    console.error("Failed to save conversation:", error);
-  }
-};
 
 const StatusIndicator: React.FC<{ state: ConnectionState; isMicActive: boolean }> = ({ state, isMicActive }) => {
   let statusText = 'Ready';
@@ -99,7 +74,16 @@ const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifa
     );
   };
 
-const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndConversation, environmentImageUrl, onEnvironmentUpdate, activeQuest, isSaving }) => {
+const ConversationView: React.FC<ConversationViewProps> = ({
+  character,
+  onEndConversation,
+  environmentImageUrl,
+  onEnvironmentUpdate,
+  activeQuest,
+  isSaving,
+  existingConversation,
+  onAutosave,
+}) => {
   const [transcript, setTranscript] = useState<ConversationTurn[]>([]);
   const [textInput, setTextInput] = useState('');
   const [dynamicSuggestions, setDynamicSuggestions] = useState<string[]>([]);
@@ -152,25 +136,22 @@ const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndCon
     };
 
     if (activeQuest) {
-      // Start a fresh conversation for a quest
       setTranscript([greetingTurn]);
       onEnvironmentUpdate(null);
       sessionIdRef.current = `quest_${activeQuest.id}_${Date.now()}`;
-    } else {
-      const history = loadConversations();
-      const existingConversation = history.find(c => c.characterId === character.id);
-      if (existingConversation && existingConversation.transcript.length > 0) {
-          setTranscript(existingConversation.transcript);
-          onEnvironmentUpdate(existingConversation.environmentImageUrl || null);
-          sessionIdRef.current = existingConversation.id; 
-      } else {
-          // This is a new conversation or an empty one from history
-          setTranscript([greetingTurn]);
-          onEnvironmentUpdate(null);
-          sessionIdRef.current = existingConversation ? existingConversation.id : `conv_${character.id}_${Date.now()}`;
-      }
+      return;
     }
-  }, [character, onEnvironmentUpdate, activeQuest]);
+
+    if (existingConversation && existingConversation.transcript.length > 0) {
+      setTranscript(existingConversation.transcript);
+      onEnvironmentUpdate(existingConversation.environmentImageUrl || null);
+      sessionIdRef.current = existingConversation.id;
+    } else {
+      setTranscript([greetingTurn]);
+      onEnvironmentUpdate(null);
+      sessionIdRef.current = `conv_${character.id}_${Date.now()}`;
+    }
+  }, [character, onEnvironmentUpdate, activeQuest, existingConversation]);
 
     // Cycle through placeholders for text input
     useEffect(() => {
@@ -439,6 +420,7 @@ ${contextTranscript}
   // Auto-save conversation on transcript change
   useEffect(() => {
     if (transcript.length === 0 && !environmentImageUrl) return;
+    if (!onAutosave) return;
 
     const conversation: SavedConversation = {
       id: sessionIdRef.current,
@@ -455,8 +437,8 @@ ${contextTranscript}
           }
         : {}),
     };
-    saveConversationToLocalStorage(conversation);
-  }, [transcript, character, environmentImageUrl, activeQuest]);
+    void onAutosave(conversation);
+  }, [transcript, character, environmentImageUrl, activeQuest, onAutosave]);
 
   const handleReset = () => {
     if (transcript.length === 0 && !environmentImageUrl) return;
@@ -488,7 +470,7 @@ ${contextTranscript}
                 }
               : {}),
         };
-        saveConversationToLocalStorage(clearedConversation);
+        void onAutosave(clearedConversation);
     }
   };
 

--- a/components/HistoryView.tsx
+++ b/components/HistoryView.tsx
@@ -1,29 +1,7 @@
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import type { SavedConversation, ConversationTurn } from '../types';
 import DownloadIcon from './icons/DownloadIcon';
-
-const HISTORY_KEY = 'school-of-the-ancients-history';
-
-const loadConversations = (): SavedConversation[] => {
-  try {
-    const rawHistory = localStorage.getItem(HISTORY_KEY);
-    return rawHistory ? JSON.parse(rawHistory) : [];
-  } catch (error) {
-    console.error("Failed to load conversation history:", error);
-    return [];
-  }
-};
-
-const deleteConversationFromLocalStorage = (id: string) => {
-  try {
-    let history = loadConversations();
-    history = history.filter(c => c.id !== id);
-    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
-  } catch (error) {
-    console.error("Failed to delete conversation:", error);
-  }
-};
 
 const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifact']> }> = ({ artifact }) => {
   if (!artifact.imageUrl || artifact.loading) return null; // Don't show incomplete artifacts in history
@@ -38,20 +16,26 @@ const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifa
 
 interface HistoryViewProps {
   onBack: () => void;
+  history: SavedConversation[];
+  onDeleteConversation: (id: string) => void | Promise<void>;
 }
 
-const HistoryView: React.FC<HistoryViewProps> = ({ onBack }) => {
-  const [history, setHistory] = useState<SavedConversation[]>([]);
+const HistoryView: React.FC<HistoryViewProps> = ({ onBack, history, onDeleteConversation }) => {
   const [selectedConversation, setSelectedConversation] = useState<SavedConversation | null>(null);
 
   useEffect(() => {
-    setHistory(loadConversations());
-  }, []);
+    if (!selectedConversation) return;
+    const updated = history.find((conv) => conv.id === selectedConversation.id) ?? null;
+    if (!updated) {
+      setSelectedConversation(null);
+    } else if (updated !== selectedConversation) {
+      setSelectedConversation(updated);
+    }
+  }, [history, selectedConversation]);
 
   const handleDelete = (id: string) => {
     if (window.confirm('Are you sure you want to delete this conversation?')) {
-      deleteConversationFromLocalStorage(id);
-      setHistory(loadConversations());
+      void onDeleteConversation(id);
       if (selectedConversation?.id === id) {
         setSelectedConversation(null);
       }

--- a/supabaseClient.ts
+++ b/supabaseClient.ts
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.warn('Supabase environment variables are not set.');
+}
+
+export const supabase = createClient(supabaseUrl ?? '', supabaseAnonKey ?? '', {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add a Supabase client and email/password auth gate around the app
- persist custom characters, conversations, and quest progress to Supabase instead of localStorage
- update conversation and history views to read/write Supabase data during autosave and deletion

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df02d8892c832faf3e891fc43ff79e