### PR TITLE
feat: integrate supabase auth and persistence

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { GoogleGenAI, Type } from '@google/genai';
-
 import type {
   Character,
   Quest,
@@ -9,6 +8,7 @@ import type {
   Summary,
   QuestAssessment,
 } from './types';
+import type { Session } from '@supabase/supabase-js';
 
 import CharacterSelector from './components/CharacterSelector';
 import ConversationView from './components/ConversationView';
@@ -17,109 +17,269 @@ import CharacterCreator from './components/CharacterCreator';
 import QuestsView from './components/QuestsView';
 import Instructions from './components/Instructions';
 import QuestIcon from './components/icons/QuestIcon';
-import QuestCreator from './components/QuestCreator'; // NEW
+import QuestCreator from './components/QuestCreator';
 
 import { CHARACTERS, QUESTS } from './constants';
-
-const CUSTOM_CHARACTERS_KEY = 'school-of-the-ancients-custom-characters';
-const HISTORY_KEY = 'school-of-the-ancients-history';
-const COMPLETED_QUESTS_KEY = 'school-of-the-ancients-completed-quests';
-
-// ---- Local storage helpers -------------------------------------------------
-
-const loadConversations = (): SavedConversation[] => {
-  try {
-    const rawHistory = localStorage.getItem(HISTORY_KEY);
-    return rawHistory ? JSON.parse(rawHistory) : [];
-  } catch (error) {
-    console.error('Failed to load conversation history:', error);
-    return [];
-  }
-};
-
-const saveConversationToLocalStorage = (conversation: SavedConversation) => {
-  try {
-    const history = loadConversations();
-    const existingIndex = history.findIndex((c) => c.id === conversation.id);
-    if (existingIndex > -1) {
-      history[existingIndex] = conversation;
-    } else {
-      history.unshift(conversation);
-    }
-    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
-  } catch (error) {
-    console.error('Failed to save conversation:', error);
-  }
-};
-
-const loadCompletedQuests = (): string[] => {
-  try {
-    const stored = localStorage.getItem(COMPLETED_QUESTS_KEY);
-    return stored ? JSON.parse(stored) : [];
-  } catch (error) {
-    console.error('Failed to load completed quests:', error);
-    return [];
-  }
-};
-
-const saveCompletedQuests = (questIds: string[]) => {
-  try {
-    localStorage.setItem(COMPLETED_QUESTS_KEY, JSON.stringify(questIds));
-  } catch (error) {
-    console.error('Failed to save completed quests:', error);
-  }
-};
-
-// ---- App -------------------------------------------------------------------
+import { supabase } from './supabaseClient';
 
 const App: React.FC = () => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [authMode, setAuthMode] = useState<'signIn' | 'signUp'>('signIn');
+  const [authEmail, setAuthEmail] = useState('');
+  const [authPassword, setAuthPassword] = useState('');
+  const [authError, setAuthError] = useState<string | null>(null);
+  const [authMessage, setAuthMessage] = useState<string | null>(null);
+  const [isAuthSubmitting, setIsAuthSubmitting] = useState(false);
+  const [isAuthLoading, setIsAuthLoading] = useState(true);
+
+  const [customCharacters, setCustomCharacters] = useState<Character[]>([]);
+  const [conversations, setConversations] = useState<SavedConversation[]>([]);
+  const [completedQuests, setCompletedQuests] = useState<string[]>([]);
+  const [isUserDataLoading, setIsUserDataLoading] = useState(false);
+
   const [selectedCharacter, setSelectedCharacter] = useState<Character | null>(null);
   const [view, setView] = useState<
     'selector' | 'conversation' | 'history' | 'creator' | 'quests' | 'questCreator'
   >('selector');
-
-  const [customCharacters, setCustomCharacters] = useState<Character[]>([]);
   const [environmentImageUrl, setEnvironmentImageUrl] = useState<string | null>(null);
   const [activeQuest, setActiveQuest] = useState<Quest | null>(null);
-
-  // end-conversation save/AI-eval flag
   const [isSaving, setIsSaving] = useState(false);
-
-  const [completedQuests, setCompletedQuests] = useState<string[]>([]);
   const [lastQuestOutcome, setLastQuestOutcome] = useState<QuestAssessment | null>(null);
+  const [hasCheckedUrlCharacter, setHasCheckedUrlCharacter] = useState(false);
 
-  // On mount: load saved characters, url param character, and progress
+  const userId = session?.user?.id ?? null;
+
   useEffect(() => {
-    try {
-      const storedCharacters = localStorage.getItem(CUSTOM_CHARACTERS_KEY);
-      if (storedCharacters) {
-        setCustomCharacters(JSON.parse(storedCharacters));
-      }
-    } catch (e) {
-      console.error('Failed to load custom characters:', e);
+    if (!session) {
+      setHasCheckedUrlCharacter(false);
     }
+  }, [session]);
+
+  useEffect(() => {
+    if (!supabase) {
+      setIsAuthLoading(false);
+      return;
+    }
+
+    supabase.auth
+      .getSession()
+      .then(({ data }) => {
+        setSession(data.session ?? null);
+        setIsAuthLoading(false);
+      })
+      .catch(error => {
+        console.error('Failed to get session:', error);
+        setIsAuthLoading(false);
+      });
+
+    const { data } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      setSession(nextSession);
+      setIsAuthLoading(false);
+    });
+
+    return () => {
+      data.subscription.unsubscribe();
+    };
+  }, []);
+
+  const loadUserData = useCallback(async () => {
+    if (!supabase || !userId) return;
+    setIsUserDataLoading(true);
+
+    try {
+      const { data: characterRows, error: characterError } = await supabase
+        .from('custom_characters')
+        .select('character_id, data')
+        .eq('user_id', userId)
+        .order('inserted_at', { ascending: false });
+
+      if (characterError) throw characterError;
+
+      const characterData = (characterRows ?? []).map(row => {
+        const data = row.data as Character;
+        return {
+          ...data,
+          id: row.character_id ?? data.id,
+        };
+      });
+      setCustomCharacters(characterData);
+
+      const { data: conversationRows, error: conversationError } = await supabase
+        .from('conversations')
+        .select('*')
+        .eq('user_id', userId)
+        .order('updated_at', { ascending: false });
+
+      if (conversationError) throw conversationError;
+
+      const conversationData = (conversationRows ?? []).map(row => ({
+        id: row.id as string,
+        characterId: (row.character_id as string) ?? '',
+        characterName: (row.character_name as string) ?? '',
+        portraitUrl: (row.portrait_url as string) ?? '',
+        timestamp: row.updated_at ? new Date(row.updated_at as string).getTime() : Date.now(),
+        transcript: (row.transcript as ConversationTurn[]) ?? [],
+        environmentImageUrl: (row.environment_image_url as string | null) ?? undefined,
+        summary: (row.summary as Summary | null) ?? undefined,
+        questId: (row.quest_id as string | null) ?? undefined,
+        questTitle: (row.quest_title as string | null) ?? undefined,
+        questAssessment: (row.quest_assessment as QuestAssessment | null) ?? undefined,
+      }));
+      setConversations(conversationData);
+
+      const { data: questRows, error: questError } = await supabase
+        .from('completed_quests')
+        .select('quest_id')
+        .eq('user_id', userId);
+
+      if (questError) throw questError;
+
+      setCompletedQuests((questRows ?? []).map(row => row.quest_id as string));
+    } catch (error) {
+      console.error('Failed to load Supabase data:', error);
+    } finally {
+      setIsUserDataLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    if (!userId) {
+      setCustomCharacters([]);
+      setConversations([]);
+      setCompletedQuests([]);
+      return;
+    }
+
+    loadUserData();
+  }, [userId, loadUserData]);
+
+  useEffect(() => {
+    if (!session || hasCheckedUrlCharacter || isUserDataLoading) return;
 
     const urlParams = new URLSearchParams(window.location.search);
     const characterId = urlParams.get('character');
+
     if (characterId) {
       const allCharacters = [...customCharacters, ...CHARACTERS];
-      const characterFromUrl = allCharacters.find((c) => c.id === characterId);
+      const characterFromUrl = allCharacters.find(c => c.id === characterId);
       if (characterFromUrl) {
         setSelectedCharacter(characterFromUrl);
         setView('conversation');
       }
     }
 
-    setCompletedQuests(loadCompletedQuests());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    setHasCheckedUrlCharacter(true);
+  }, [session, customCharacters, hasCheckedUrlCharacter, isUserDataLoading]);
 
-  // ---- Navigation helpers ----
+  const persistCustomCharacter = useCallback(
+    async (character: Character) => {
+      if (!supabase || !userId) return;
+
+      const { error } = await supabase.from('custom_characters').upsert({
+        user_id: userId,
+        character_id: character.id,
+        data: character,
+      });
+
+      if (error) throw error;
+
+      setCustomCharacters(prev => {
+        const filtered = prev.filter(c => c.id !== character.id);
+        return [character, ...filtered];
+      });
+    },
+    [userId]
+  );
+
+  const persistConversation = useCallback(
+    async (conversation: SavedConversation) => {
+      if (!supabase || !userId) return;
+
+      const { error } = await supabase.from('conversations').upsert({
+        id: conversation.id,
+        user_id: userId,
+        character_id: conversation.characterId,
+        character_name: conversation.characterName,
+        portrait_url: conversation.portraitUrl,
+        transcript: conversation.transcript,
+        environment_image_url: conversation.environmentImageUrl ?? null,
+        summary: conversation.summary ?? null,
+        quest_id: conversation.questId ?? null,
+        quest_title: conversation.questTitle ?? null,
+        quest_assessment: conversation.questAssessment ?? null,
+        updated_at: new Date(conversation.timestamp).toISOString(),
+      });
+
+      if (error) throw error;
+
+      setConversations(prev => {
+        const existingIndex = prev.findIndex(c => c.id === conversation.id);
+        if (existingIndex > -1) {
+          const updated = [...prev];
+          updated[existingIndex] = conversation;
+          return updated.sort((a, b) => b.timestamp - a.timestamp);
+        }
+        return [conversation, ...prev].sort((a, b) => b.timestamp - a.timestamp);
+      });
+    },
+    [userId]
+  );
+
+  const deleteConversation = useCallback(
+    async (id: string) => {
+      if (!supabase || !userId) return;
+
+      const { error } = await supabase
+        .from('conversations')
+        .delete()
+        .eq('user_id', userId)
+        .eq('id', id);
+
+      if (error) throw error;
+
+      setConversations(prev => prev.filter(c => c.id !== id));
+    },
+    [userId]
+  );
+
+  const addQuestCompletion = useCallback(
+    async (questId: string) => {
+      if (!supabase || !userId) return;
+
+      const { error } = await supabase.from('completed_quests').upsert({
+        user_id: userId,
+        quest_id: questId,
+        completed_at: new Date().toISOString(),
+      });
+
+      if (error) throw error;
+
+      setCompletedQuests(prev => (prev.includes(questId) ? prev : [...prev, questId]));
+    },
+    [userId]
+  );
+
+  const removeQuestCompletion = useCallback(
+    async (questId: string) => {
+      if (!supabase || !userId) return;
+
+      const { error } = await supabase
+        .from('completed_quests')
+        .delete()
+        .eq('user_id', userId)
+        .eq('quest_id', questId);
+
+      if (error) throw error;
+
+      setCompletedQuests(prev => prev.filter(id => id !== questId));
+    },
+    [userId]
+  );
 
   const handleSelectCharacter = (character: Character) => {
     setSelectedCharacter(character);
     setView('conversation');
-    setActiveQuest(null); // clear any quest when directly picking a character
+    setActiveQuest(null);
     const url = new URL(window.location.href);
     url.searchParams.set('character', character.id);
     window.history.pushState({}, '', url);
@@ -127,7 +287,7 @@ const App: React.FC = () => {
 
   const handleSelectQuest = (quest: Quest) => {
     const allCharacters = [...customCharacters, ...CHARACTERS];
-    const characterForQuest = allCharacters.find((c) => c.id === quest.characterId);
+    const characterForQuest = allCharacters.find(c => c.id === quest.characterId);
     if (characterForQuest) {
       setActiveQuest(quest);
       setSelectedCharacter(characterForQuest);
@@ -140,30 +300,34 @@ const App: React.FC = () => {
     }
   };
 
-  const handleCharacterCreated = (newCharacter: Character) => {
-    const updatedCharacters = [newCharacter, ...customCharacters];
-    setCustomCharacters(updatedCharacters);
+  const handleCharacterCreated = async (newCharacter: Character) => {
     try {
-      localStorage.setItem(CUSTOM_CHARACTERS_KEY, JSON.stringify(updatedCharacters));
-    } catch (e) {
-      console.error('Failed to save custom character:', e);
+      await persistCustomCharacter(newCharacter);
+      handleSelectCharacter(newCharacter);
+    } catch (error) {
+      console.error('Failed to save custom character:', error);
     }
-    handleSelectCharacter(newCharacter);
   };
 
-  const handleDeleteCharacter = (characterId: string) => {
+  const handleDeleteCharacter = async (characterId: string) => {
+    if (!supabase || !userId) return;
     if (window.confirm('Are you sure you want to permanently delete this ancient?')) {
-      const updatedCharacters = customCharacters.filter((c) => c.id !== characterId);
-      setCustomCharacters(updatedCharacters);
       try {
-        localStorage.setItem(CUSTOM_CHARACTERS_KEY, JSON.stringify(updatedCharacters));
-      } catch (e) {
-        console.error('Failed to delete custom character:', e);
+        const { error } = await supabase
+          .from('custom_characters')
+          .delete()
+          .eq('user_id', userId)
+          .eq('character_id', characterId);
+
+        if (error) throw error;
+
+        setCustomCharacters(prev => prev.filter(c => c.id !== characterId));
+      } catch (error) {
+        console.error('Failed to delete custom character:', error);
       }
     }
   };
 
-  // NEW: handle a freshly-generated quest & mentor from QuestCreator
   const startGeneratedQuest = (quest: Quest, mentor: Character) => {
     setActiveQuest(quest);
     setSelectedCharacter(mentor);
@@ -173,15 +337,13 @@ const App: React.FC = () => {
     window.history.pushState({}, '', url);
   };
 
-  // ---- End conversation: summarize & (if quest) evaluate mastery ----
   const handleEndConversation = async (transcript: ConversationTurn[], sessionId: string) => {
     if (!selectedCharacter) return;
     setIsSaving(true);
     let questAssessment: QuestAssessment | null = null;
 
     try {
-      const conversationHistory = loadConversations();
-      const existingConversation = conversationHistory.find((c) => c.id === sessionId);
+      const existingConversation = conversations.find(c => c.id === sessionId);
 
       let updatedConversation: SavedConversation =
         existingConversation ??
@@ -217,18 +379,14 @@ const App: React.FC = () => {
         ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
       }
 
-      // Conversation summary (skip first system/greeting turn)
       if (ai && transcript.length > 1) {
         const transcriptText = transcript
           .slice(1)
-          .map((turn) => `${turn.speakerName}: ${turn.text}`)
+          .map(turn => `${turn.speakerName}: ${turn.text}`)
           .join('\n\n');
 
         if (transcriptText.trim()) {
-          const prompt = `Please summarize the following educational dialogue with ${selectedCharacter.name}. Provide a concise one-paragraph overview of the key topics discussed, and then list 3-5 of the most important takeaways or concepts as bullet points.
-
-Dialogue:
-${transcriptText}`;
+          const prompt = `Please summarize the following educational dialogue with ${selectedCharacter.name}. Provide a concise one-paragraph overview of the key topics discussed, and then list 3-5 of the most important takeaways or concepts as bullet points.\n\nDialogue:\n${transcriptText}`;
 
           const response = await ai.models.generateContent({
             model: 'gemini-2.5-flash',
@@ -259,22 +417,11 @@ ${transcriptText}`;
         }
       }
 
-      // If this was a quest session, evaluate mastery
       if (ai && activeQuest) {
-        const questTranscriptText = transcript.map((turn) => `${turn.speakerName}: ${turn.text}`).join('\n\n');
+        const questTranscriptText = transcript.map(turn => `${turn.speakerName}: ${turn.text}`).join('\n\n');
 
         if (questTranscriptText.trim()) {
-          const evaluationPrompt = `You are a meticulous mentor evaluating whether a student has mastered the quest "${activeQuest.title}". Review the conversation transcript between the mentor and student. Determine if the student demonstrates a working understanding of the quest objective: "${activeQuest.objective}".
-
-Return a JSON object with this structure:
-{
-  "passed": boolean,
-  "summary": string,          // one or two sentences explaining your verdict in plain language
-  "evidence": string[],       // bullet-friendly phrases citing what the student said that shows understanding
-  "improvements": string[]    // actionable suggestions if the student has gaps (empty if passed)
-}
-
-Focus only on the student's contributions. Mark passed=true only if the learner clearly articulates key ideas from the objective.`;
+          const evaluationPrompt = `You are a meticulous mentor evaluating whether a student has mastered the quest "${activeQuest.title}". Review the conversation transcript between the mentor and student. Determine if the student demonstrates a working understanding of the quest objective: "${activeQuest.objective}".\n\nReturn a JSON object with this structure:\n{\n  "passed": boolean,\n  "summary": string,\n  "evidence": string[],\n  "improvements": string[]\n}\n\nFocus only on the student's contributions. Mark passed=true only if the learner clearly articulates key ideas from the objective.`;
 
           const evaluationResponse = await ai.models.generateContent({
             model: 'gemini-2.5-flash',
@@ -310,29 +457,12 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
           };
 
           if (questAssessment.passed) {
-            setCompletedQuests((prev) => {
-              if (prev.includes(activeQuest.id)) {
-                saveCompletedQuests(prev);
-                return prev;
-              }
-              const updated = [...prev, activeQuest.id]; // FIX
-              saveCompletedQuests(updated);
-              return updated;
-            });
+            await addQuestCompletion(activeQuest.id);
           } else {
-            setCompletedQuests((prev) => {
-              if (!prev.includes(activeQuest.id)) {
-                saveCompletedQuests(prev);
-                return prev;
-              }
-              const updated = prev.filter((id) => id !== activeQuest.id);
-              saveCompletedQuests(updated);
-              return updated;
-            });
+            await removeQuestCompletion(activeQuest.id);
           }
         }
       } else if (activeQuest) {
-        // Ensure quest metadata is retained even without AI assistance.
         updatedConversation = {
           ...updatedConversation,
           questId: activeQuest.id,
@@ -340,7 +470,7 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
         };
       }
 
-      saveConversationToLocalStorage(updatedConversation);
+      await persistConversation(updatedConversation);
     } catch (error) {
       console.error('Failed to finalize conversation:', error);
     } finally {
@@ -358,8 +488,6 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
     }
   };
 
-  // ---- View switcher ----
-
   const renderContent = () => {
     switch (view) {
       case 'conversation':
@@ -370,15 +498,29 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
             environmentImageUrl={environmentImageUrl}
             onEnvironmentUpdate={setEnvironmentImageUrl}
             activeQuest={activeQuest}
-            isSaving={isSaving} // pass saving state
+            isSaving={isSaving}
+            savedConversation={conversations.find(c => c.characterId === selectedCharacter.id) ?? null}
+            onAutoSave={persistConversation}
           />
         ) : null;
       case 'history':
-        return <HistoryView onBack={() => setView('selector')} />;
+        return (
+          <HistoryView
+            onBack={() => setView('selector')}
+            history={conversations}
+            onDeleteConversation={deleteConversation}
+            isLoading={isUserDataLoading}
+          />
+        );
       case 'creator':
-        return <CharacterCreator onCharacterCreated={handleCharacterCreated} onBack={() => setView('selector')} />;
+        return (
+          <CharacterCreator
+            onCharacterCreated={handleCharacterCreated}
+            onBack={() => setView('selector')}
+          />
+        );
       case 'quests': {
-        const allCharacters = [...customCharacters, ...CHARACTERS]; // FIX
+        const allCharacters = [...customCharacters, ...CHARACTERS];
         return (
           <QuestsView
             onBack={() => setView('selector')}
@@ -397,12 +539,12 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
             characters={allChars}
             onBack={() => setView('selector')}
             onQuestReady={startGeneratedQuest}
-            onCharacterCreated={(newChar) => {
-              const updated = [newChar, ...customCharacters];
-              setCustomCharacters(updated);
+            onCharacterCreated={async newChar => {
               try {
-                localStorage.setItem(CUSTOM_CHARACTERS_KEY, JSON.stringify(updated));
-              } catch {}
+                await persistCustomCharacter(newChar);
+              } catch (error) {
+                console.error('Failed to store generated character:', error);
+              }
             }}
           />
         );
@@ -460,7 +602,7 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
                   <div className="mt-4">
                     <p className="text-sm font-semibold text-emerald-200 uppercase tracking-wide mb-1">Highlights</p>
                     <ul className="list-disc list-inside text-gray-100 space-y-1 text-sm">
-                      {lastQuestOutcome.evidence.map((item) => (
+                      {lastQuestOutcome.evidence.map(item => (
                         <li key={item}>{item}</li>
                       ))}
                     </ul>
@@ -471,7 +613,7 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
                   <div className="mt-4">
                     <p className="text-sm font-semibold text-red-200 uppercase tracking-wide mb-1">Next Steps</p>
                     <ul className="list-disc list-inside text-red-100 space-y-1 text-sm">
-                      {lastQuestOutcome.improvements.map((item) => (
+                      {lastQuestOutcome.improvements.map(item => (
                         <li key={item}>{item}</li>
                       ))}
                     </ul>
@@ -496,7 +638,6 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
                 View Conversation History
               </button>
 
-              {/* NEW CTA */}
               <button
                 onClick={() => setView('questCreator')}
                 className="bg-teal-700 hover:bg-teal-600 text-white font-bold py-3 px-8 rounded-lg transition-colors duration-300 w-full sm:w-auto"
@@ -518,6 +659,132 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
     }
   };
 
+  const handleAuthSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!supabase) return;
+
+    setIsAuthSubmitting(true);
+    setAuthError(null);
+    setAuthMessage(null);
+
+    try {
+      if (authMode === 'signIn') {
+        const { error } = await supabase.auth.signInWithPassword({
+          email: authEmail,
+          password: authPassword,
+        });
+        if (error) throw error;
+      } else {
+        const { data, error } = await supabase.auth.signUp({
+          email: authEmail,
+          password: authPassword,
+        });
+        if (error) throw error;
+        if (!data.session) {
+          setAuthMessage('Check your inbox to confirm your email address.');
+        }
+      }
+    } catch (error) {
+      console.error('Authentication failed:', error);
+      setAuthError(error instanceof Error ? error.message : 'Authentication failed.');
+    } finally {
+      setIsAuthSubmitting(false);
+    }
+  };
+
+  const handleSignOut = async () => {
+    if (!supabase) return;
+    try {
+      await supabase.auth.signOut();
+    } catch (error) {
+      console.error('Failed to sign out:', error);
+    }
+  };
+
+  if (!supabase) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#1a1a1a] text-gray-200 p-6 text-center">
+        <div className="max-w-lg">
+          <h1 className="text-3xl font-bold mb-4">Supabase Not Configured</h1>
+          <p className="text-gray-400">
+            Please set the <code className="text-amber-300">VITE_SUPABASE_URL</code> and{' '}
+            <code className="text-amber-300">VITE_SUPABASE_ANON_KEY</code> environment variables to enable authentication and
+            cloud saves.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (isAuthLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#1a1a1a] text-gray-200">
+        <div className="text-center">
+          <div className="w-12 h-12 border-4 border-amber-400 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+          <p>Preparing the academy...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#1a1a1a] text-gray-200 p-4">
+        <div className="w-full max-w-md bg-gray-900/80 border border-gray-700 rounded-2xl p-6 shadow-2xl">
+          <h1 className="text-3xl font-bold text-amber-300 text-center mb-6">School of the Ancients</h1>
+          <form onSubmit={handleAuthSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-semibold text-gray-300 mb-2" htmlFor="email">
+                Email
+              </label>
+              <input
+                id="email"
+                type="email"
+                required
+                value={authEmail}
+                onChange={e => setAuthEmail(e.target.value)}
+                className="w-full px-3 py-2 rounded-lg bg-gray-800 border border-gray-700 text-gray-200 focus:outline-none focus:ring-2 focus:ring-amber-400"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-semibold text-gray-300 mb-2" htmlFor="password">
+                Password
+              </label>
+              <input
+                id="password"
+                type="password"
+                required
+                minLength={6}
+                value={authPassword}
+                onChange={e => setAuthPassword(e.target.value)}
+                className="w-full px-3 py-2 rounded-lg bg-gray-800 border border-gray-700 text-gray-200 focus:outline-none focus:ring-2 focus:ring-amber-400"
+              />
+            </div>
+            {authError && <p className="text-red-400 text-sm">{authError}</p>}
+            {authMessage && <p className="text-emerald-400 text-sm">{authMessage}</p>}
+            <button
+              type="submit"
+              className="w-full bg-amber-500 hover:bg-amber-400 text-black font-semibold py-2 rounded-lg transition-colors disabled:opacity-60"
+              disabled={isAuthSubmitting}
+            >
+              {isAuthSubmitting ? 'Please wait...' : authMode === 'signIn' ? 'Sign In' : 'Create Account'}
+            </button>
+          </form>
+          <p className="text-center text-sm text-gray-400 mt-4">
+            {authMode === 'signIn' ? 'Need an account?' : 'Already enrolled?'}{' '}
+            <button
+              type="button"
+              className="text-amber-300 hover:text-amber-200 font-semibold"
+              onClick={() => setAuthMode(authMode === 'signIn' ? 'signUp' : 'signIn')}
+            >
+              {authMode === 'signIn' ? 'Create one' : 'Sign in'}
+            </button>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="relative min-h-screen bg-[#1a1a1a]">
       <div
@@ -531,6 +798,14 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
         style={{ background: environmentImageUrl ? 'transparent' : 'linear-gradient(to bottom right, #1a1a1a, #2b2b2b)' }}
       >
         <header className="text-center mb-8">
+          <div className="flex justify-end mb-2">
+            <button
+              onClick={handleSignOut}
+              className="text-sm text-gray-400 hover:text-amber-300 transition-colors"
+            >
+              Sign out
+            </button>
+          </div>
           <h1
             className="text-4xl sm:text-5xl md:text-6xl font-bold text-amber-300 tracking-wider"
             style={{ textShadow: '0 0 10px rgba(252, 211, 77, 0.5)' }}
@@ -547,3 +822,4 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
 };
 
 export default App;
+

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ School of the Ancients is a modern web application that pairs immersive visuals 
 - **Curated quest board** &mdash; Pick from ready-to-run quests, each linking a legendary mentor with a focused learning objective and estimated duration.
 - **Quest-aware conversations** &mdash; When a quest is active, the mentor keeps you on track, surfaces scene changes, and captures artifacts tied to the objective.
 - **Automatic mastery reviews** &mdash; Ending a quest triggers an AI assessment of your transcript, summarizing what you grasped, what evidence proves it, and what to revisit.
-- **Progress tracking** &mdash; Completed quest IDs persist in `localStorage`, powering progress meters and keeping your accomplishments pinned between sessions.
+- **Progress tracking** &mdash; Completed quest IDs sync to your Supabase profile, powering progress meters and keeping achievements pinned across devices.
 
 ### Custom Mentors & Quest Builder
 
@@ -63,7 +63,7 @@ School of the Ancients is a modern web application that pairs immersive visuals 
 
 ### Progression & Reflection
 
-- **Conversation history** &mdash; Sessions, transcripts, artifacts, and environments are stored in browser `localStorage` for later review or resuming quests.
+- **Conversation history** &mdash; Sessions, transcripts, artifacts, and environments live in Supabase so you can resume quests from any signed-in device.
 - **Quest dossiers** &mdash; Each AI review summarizes mastery, highlights evidence, and recommends improvements so you can iterate on your learning plan.
 - **Responsive design** &mdash; Tailwind CSS keeps the UI beautiful and accessible on mobile, tablet, and desktop displays.
 

--- a/supabaseClient.ts
+++ b/supabaseClient.ts
@@ -1,0 +1,14 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+let client: SupabaseClient | null = null;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.warn('Missing Supabase configuration. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.');
+} else {
+  client = createClient(supabaseUrl, supabaseAnonKey);
+}
+
+export const supabase = client;


### PR DESCRIPTION
## Summary
- replace local storage auth and persistence with Supabase email/password login and per-user data syncing
- auto-save conversations, custom characters, and quest progress via Supabase and surface sign-in UI and logout
- adjust conversation and history views to consume Supabase data and update README docs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df02d8892c832faf3e891fc43ff79e