### PR TITLE
Add Supabase auth and persist user data remotely

### DIFF
--- a/components/AuthGate.tsx
+++ b/components/AuthGate.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from 'react';
+import { supabase } from '../supabaseClient';
+
+const AuthGate: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [mode, setMode] = useState<'sign-in' | 'sign-up'>('sign-in');
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setMessage('');
+    const trimmedEmail = email.trim();
+    const trimmedPassword = password.trim();
+
+    if (!trimmedEmail || !trimmedPassword) {
+      setError('Enter both email and password.');
+      return;
+    }
+
+    try {
+      setLoading(true);
+      if (mode === 'sign-in') {
+        const { error: signInError } = await supabase.auth.signInWithPassword({
+          email: trimmedEmail,
+          password: trimmedPassword,
+        });
+        if (signInError) throw signInError;
+      } else {
+        const { error: signUpError } = await supabase.auth.signUp({
+          email: trimmedEmail,
+          password: trimmedPassword,
+          options: {
+            emailRedirectTo: window.location.origin,
+          },
+        });
+        if (signUpError) throw signUpError;
+        setMessage('Account created! Check your inbox for a confirmation email.');
+        setMode('sign-in');
+      }
+    } catch (err: any) {
+      console.error('Authentication failed:', err);
+      setError(err?.message || 'Unable to complete the request.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[#111] p-4 text-gray-200">
+      <div className="w-full max-w-md bg-gray-900/80 border border-gray-700 rounded-2xl shadow-2xl p-6">
+        <h1 className="text-3xl font-bold text-amber-300 text-center mb-2">School of the Ancients</h1>
+        <p className="text-center text-gray-400 mb-6">
+          {mode === 'sign-in' ? 'Sign in to access your mentors and quests.' : 'Create an account to save your progress across devices.'}
+        </p>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-semibold text-gray-300 mb-1" htmlFor="email">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={event => setEmail(event.target.value)}
+              className="w-full px-4 py-2 rounded-lg bg-gray-800 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-amber-400"
+              autoComplete="email"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-semibold text-gray-300 mb-1" htmlFor="password">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={event => setPassword(event.target.value)}
+              className="w-full px-4 py-2 rounded-lg bg-gray-800 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-amber-400"
+              autoComplete={mode === 'sign-in' ? 'current-password' : 'new-password'}
+              minLength={6}
+              required
+            />
+          </div>
+          {error && <p className="text-sm text-red-400">{error}</p>}
+          {message && <p className="text-sm text-emerald-400">{message}</p>}
+          <button
+            type="submit"
+            className="w-full bg-amber-600 hover:bg-amber-500 text-black font-bold py-2 px-4 rounded-lg transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+            disabled={loading}
+          >
+            {loading ? 'Please wait…' : mode === 'sign-in' ? 'Sign In' : 'Create Account'}
+          </button>
+        </form>
+        <div className="mt-6 text-center text-sm text-gray-400">
+          {mode === 'sign-in' ? (
+            <button
+              onClick={() => {
+                setMode('sign-up');
+                setError(null);
+                setMessage('');
+              }}
+              className="text-amber-300 hover:text-amber-200 font-semibold"
+            >
+              Need an account? Sign up
+            </button>
+          ) : (
+            <button
+              onClick={() => {
+                setMode('sign-in');
+                setError(null);
+                setMessage('');
+              }}
+              className="text-amber-300 hover:text-amber-200 font-semibold"
+            >
+              Already registered? Sign in
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AuthGate;

--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -13,8 +13,6 @@ import SendIcon from './icons/SendIcon';
 import MuteIcon from './icons/MuteIcon';
 import UnmuteIcon from './icons/UnmuteIcon';
 
-const HISTORY_KEY = 'school-of-the-ancients-history';
-
 interface ConversationViewProps {
   character: Character;
   onEndConversation: (transcript: ConversationTurn[], sessionId: string) => void;
@@ -22,32 +20,9 @@ interface ConversationViewProps {
   onEnvironmentUpdate: (url: string | null) => void;
   activeQuest: Quest | null;
   isSaving: boolean;
+  existingConversation: SavedConversation | null;
+  onAutosave: (conversation: SavedConversation) => void | Promise<void>;
 }
-
-const loadConversations = (): SavedConversation[] => {
-  try {
-    const rawHistory = localStorage.getItem(HISTORY_KEY);
-    return rawHistory ? JSON.parse(rawHistory) : [];
-  } catch (error) {
-    console.error("Failed to load conversation history:", error);
-    return [];
-  }
-};
-
-const saveConversationToLocalStorage = (conversation: SavedConversation) => {
-  try {
-    const history = loadConversations();
-    const existingIndex = history.findIndex(c => c.id === conversation.id);
-    if (existingIndex > -1) {
-      history[existingIndex] = conversation;
-    } else {
-      history.unshift(conversation);
-    }
-    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
-  } catch (error) {
-    console.error("Failed to save conversation:", error);
-  }
-};
 
 const StatusIndicator: React.FC<{ state: ConnectionState; isMicActive: boolean }> = ({ state, isMicActive }) => {
   let statusText = 'Ready';
@@ -99,7 +74,16 @@ const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifa
     );
   };
 
-const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndConversation, environmentImageUrl, onEnvironmentUpdate, activeQuest, isSaving }) => {
+const ConversationView: React.FC<ConversationViewProps> = ({
+  character,
+  onEndConversation,
+  environmentImageUrl,
+  onEnvironmentUpdate,
+  activeQuest,
+  isSaving,
+  existingConversation,
+  onAutosave,
+}) => {
   const [transcript, setTranscript] = useState<ConversationTurn[]>([]);
   const [textInput, setTextInput] = useState('');
   const [dynamicSuggestions, setDynamicSuggestions] = useState<string[]>([]);
@@ -152,25 +136,28 @@ const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndCon
     };
 
     if (activeQuest) {
-      // Start a fresh conversation for a quest
       setTranscript([greetingTurn]);
       onEnvironmentUpdate(null);
       sessionIdRef.current = `quest_${activeQuest.id}_${Date.now()}`;
-    } else {
-      const history = loadConversations();
-      const existingConversation = history.find(c => c.characterId === character.id);
-      if (existingConversation && existingConversation.transcript.length > 0) {
-          setTranscript(existingConversation.transcript);
-          onEnvironmentUpdate(existingConversation.environmentImageUrl || null);
-          sessionIdRef.current = existingConversation.id; 
-      } else {
-          // This is a new conversation or an empty one from history
-          setTranscript([greetingTurn]);
-          onEnvironmentUpdate(null);
-          sessionIdRef.current = existingConversation ? existingConversation.id : `conv_${character.id}_${Date.now()}`;
-      }
+      return;
     }
-  }, [character, onEnvironmentUpdate, activeQuest]);
+
+    if (existingConversation && existingConversation.id === sessionIdRef.current) {
+      return;
+    }
+
+    if (existingConversation) {
+      setTranscript(
+        existingConversation.transcript.length > 0 ? existingConversation.transcript : [greetingTurn]
+      );
+      onEnvironmentUpdate(existingConversation.environmentImageUrl || null);
+      sessionIdRef.current = existingConversation.id;
+    } else {
+      setTranscript([greetingTurn]);
+      onEnvironmentUpdate(null);
+      sessionIdRef.current = `conv_${character.id}_${Date.now()}`;
+    }
+  }, [character.id, character.greeting, character.name, onEnvironmentUpdate, activeQuest, existingConversation]);
 
     // Cycle through placeholders for text input
     useEffect(() => {
@@ -455,8 +442,9 @@ ${contextTranscript}
           }
         : {}),
     };
-    saveConversationToLocalStorage(conversation);
-  }, [transcript, character, environmentImageUrl, activeQuest]);
+
+    void onAutosave(conversation);
+  }, [transcript, character, environmentImageUrl, activeQuest, onAutosave]);
 
   const handleReset = () => {
     if (transcript.length === 0 && !environmentImageUrl) return;
@@ -488,7 +476,7 @@ ${contextTranscript}
                 }
               : {}),
         };
-        saveConversationToLocalStorage(clearedConversation);
+        void onAutosave(clearedConversation);
     }
   };
 

--- a/docs/supabase-schema.sql
+++ b/docs/supabase-schema.sql
@@ -1,0 +1,44 @@
+-- Supabase schema for School of the Ancients user data
+
+-- Custom mentor personas created by learners
+create table if not exists custom_characters (
+  id text primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  character jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+alter table custom_characters enable row level security;
+create policy "custom_characters_access" on custom_characters
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Conversation transcripts, summaries, and quest assessments
+create table if not exists conversations (
+  id text primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  data jsonb not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table conversations enable row level security;
+create policy "conversations_access" on conversations
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Quest completion tracking
+create table if not exists completed_quests (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  quest_id text not null,
+  completed_at timestamptz not null default now(),
+  primary key (user_id, quest_id)
+);
+
+alter table completed_quests enable row level security;
+create policy "completed_quests_access" on completed_quests
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);

--- a/supabaseClient.ts
+++ b/supabaseClient.ts
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Missing Supabase configuration. Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add a Supabase-powered email auth gate and sign-out controls before rendering the main app
- move custom characters, conversations, and quest progress off localStorage into Supabase queries and upserts
- provide a Supabase client helper and SQL schema for required tables and RLS policies

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df02d8892c832faf3e891fc43ff79e