### PR TITLE
Add Supabase authentication and persistence

### DIFF
--- a/components/CharacterCreator.tsx
+++ b/components/CharacterCreator.tsx
@@ -9,7 +9,7 @@ import {
 } from '../constants';
 
 interface CharacterCreatorProps {
-  onCharacterCreated: (character: Character) => void;
+  onCharacterCreated: (character: Character) => Promise<void> | void;
   onBack: () => void;
 }
 
@@ -176,7 +176,7 @@ Return JSON with:
         portraitUrl,
       };
 
-      onCharacterCreated(character);
+      await Promise.resolve(onCharacterCreated(character));
     } catch (e: any) {
       console.error(e);
       setError(e?.message || 'Failed to create character.');

--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -13,8 +13,6 @@ import SendIcon from './icons/SendIcon';
 import MuteIcon from './icons/MuteIcon';
 import UnmuteIcon from './icons/UnmuteIcon';
 
-const HISTORY_KEY = 'school-of-the-ancients-history';
-
 interface ConversationViewProps {
   character: Character;
   onEndConversation: (transcript: ConversationTurn[], sessionId: string) => void;
@@ -22,32 +20,9 @@ interface ConversationViewProps {
   onEnvironmentUpdate: (url: string | null) => void;
   activeQuest: Quest | null;
   isSaving: boolean;
+  existingConversation?: SavedConversation | null;
+  onAutoSave: (conversation: SavedConversation) => Promise<void>;
 }
-
-const loadConversations = (): SavedConversation[] => {
-  try {
-    const rawHistory = localStorage.getItem(HISTORY_KEY);
-    return rawHistory ? JSON.parse(rawHistory) : [];
-  } catch (error) {
-    console.error("Failed to load conversation history:", error);
-    return [];
-  }
-};
-
-const saveConversationToLocalStorage = (conversation: SavedConversation) => {
-  try {
-    const history = loadConversations();
-    const existingIndex = history.findIndex(c => c.id === conversation.id);
-    if (existingIndex > -1) {
-      history[existingIndex] = conversation;
-    } else {
-      history.unshift(conversation);
-    }
-    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
-  } catch (error) {
-    console.error("Failed to save conversation:", error);
-  }
-};
 
 const StatusIndicator: React.FC<{ state: ConnectionState; isMicActive: boolean }> = ({ state, isMicActive }) => {
   let statusText = 'Ready';
@@ -99,7 +74,16 @@ const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifa
     );
   };
 
-const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndConversation, environmentImageUrl, onEnvironmentUpdate, activeQuest, isSaving }) => {
+const ConversationView: React.FC<ConversationViewProps> = ({
+  character,
+  onEndConversation,
+  environmentImageUrl,
+  onEnvironmentUpdate,
+  activeQuest,
+  isSaving,
+  existingConversation,
+  onAutoSave,
+}) => {
   const [transcript, setTranscript] = useState<ConversationTurn[]>([]);
   const [textInput, setTextInput] = useState('');
   const [dynamicSuggestions, setDynamicSuggestions] = useState<string[]>([]);
@@ -152,25 +136,26 @@ const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndCon
     };
 
     if (activeQuest) {
-      // Start a fresh conversation for a quest
       setTranscript([greetingTurn]);
       onEnvironmentUpdate(null);
       sessionIdRef.current = `quest_${activeQuest.id}_${Date.now()}`;
-    } else {
-      const history = loadConversations();
-      const existingConversation = history.find(c => c.characterId === character.id);
-      if (existingConversation && existingConversation.transcript.length > 0) {
-          setTranscript(existingConversation.transcript);
-          onEnvironmentUpdate(existingConversation.environmentImageUrl || null);
-          sessionIdRef.current = existingConversation.id; 
-      } else {
-          // This is a new conversation or an empty one from history
-          setTranscript([greetingTurn]);
-          onEnvironmentUpdate(null);
-          sessionIdRef.current = existingConversation ? existingConversation.id : `conv_${character.id}_${Date.now()}`;
-      }
+      return;
     }
-  }, [character, onEnvironmentUpdate, activeQuest]);
+
+    if (existingConversation) {
+      const transcriptToUse =
+        existingConversation.transcript && existingConversation.transcript.length > 0
+          ? existingConversation.transcript
+          : [greetingTurn];
+      setTranscript(transcriptToUse);
+      onEnvironmentUpdate(existingConversation.environmentImageUrl || null);
+      sessionIdRef.current = existingConversation.id;
+    } else {
+      setTranscript([greetingTurn]);
+      onEnvironmentUpdate(null);
+      sessionIdRef.current = `conv_${character.id}_${Date.now()}`;
+    }
+  }, [character, onEnvironmentUpdate, activeQuest, existingConversation]);
 
     // Cycle through placeholders for text input
     useEffect(() => {
@@ -455,8 +440,8 @@ ${contextTranscript}
           }
         : {}),
     };
-    saveConversationToLocalStorage(conversation);
-  }, [transcript, character, environmentImageUrl, activeQuest]);
+    void onAutoSave(conversation);
+  }, [transcript, character, environmentImageUrl, activeQuest, onAutoSave]);
 
   const handleReset = () => {
     if (transcript.length === 0 && !environmentImageUrl) return;
@@ -488,7 +473,7 @@ ${contextTranscript}
                 }
               : {}),
         };
-        saveConversationToLocalStorage(clearedConversation);
+        void onAutoSave(clearedConversation);
     }
   };
 

--- a/components/QuestCreator.tsx
+++ b/components/QuestCreator.tsx
@@ -22,7 +22,7 @@ interface QuestCreatorProps {
   characters: Character[];
   onBack: () => void;
   onQuestReady: (quest: Quest, character: Character) => void;
-  onCharacterCreated: (character: Character) => void;
+  onCharacterCreated: (character: Character) => Promise<void> | void;
 }
 
 /** Pretty, branded SVG fallback if portrait generation fails */
@@ -278,7 +278,7 @@ Return JSON with:
       if (!mentor) {
         setMsg(`Creating ${mentorName}…`);
         mentor = await createPersonaFor(mentorName);
-        onCharacterCreated(mentor); // persist
+        await Promise.resolve(onCharacterCreated(mentor)); // persist
       }
 
       const quest: Quest = {

--- a/docs/supabase-schema.sql
+++ b/docs/supabase-schema.sql
@@ -1,0 +1,51 @@
+-- Supabase schema for storing School of the Ancients data per authenticated user
+
+create table if not exists custom_characters (
+  id text primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  data jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists custom_characters_user_created_idx
+  on custom_characters (user_id, created_at desc);
+
+create table if not exists conversations (
+  id text primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  character_id text not null,
+  data jsonb not null,
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists conversations_user_updated_idx
+  on conversations (user_id, updated_at desc);
+
+create table if not exists completed_quests (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  quest_id text not null,
+  completed_at timestamptz not null default now(),
+  primary key (user_id, quest_id)
+);
+
+create index if not exists completed_quests_quest_idx
+  on completed_quests (quest_id);
+
+alter table custom_characters enable row level security;
+alter table conversations enable row level security;
+alter table completed_quests enable row level security;
+
+create policy if not exists "Only owners manage custom characters" on custom_characters
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy if not exists "Only owners manage conversations" on conversations
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy if not exists "Only owners manage completed quests" on completed_quests
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);

--- a/supabaseClient.ts
+++ b/supabaseClient.ts
@@ -1,0 +1,10 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Supabase environment variables are missing. Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- add Supabase email/password authentication and gate the app until a user signs in
- persist conversations, custom characters, and quest completion with Supabase instead of localStorage
- provide a Supabase client helper and SQL schema/policies for the required tables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df02d8892c832faf3e891fc43ff79e