### PR TITLE
Restore character creator discovery features

### DIFF
--- a/components/CharacterCreator.tsx
+++ b/components/CharacterCreator.tsx
@@ -1,7 +1,9 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { GoogleGenAI, Type } from '@google/genai';
 import type { Character, PersonaData } from '../types';
 import { AMBIENCE_LIBRARY, AVAILABLE_VOICES } from '../constants';
+import { HISTORICAL_FIGURES_SUGGESTIONS } from '../suggestions';
+import DiceIcon from './icons/DiceIcon';
 
 interface CharacterCreatorProps {
   onCharacterCreated: (character: Character) => void;
@@ -40,32 +42,144 @@ const CharacterCreator: React.FC<CharacterCreatorProps> = ({ onCharacterCreated,
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const filteredSuggestions = useMemo(() => {
+    const trimmed = name.trim().toLowerCase();
+    if (!trimmed) return HISTORICAL_FIGURES_SUGGESTIONS;
+    return HISTORICAL_FIGURES_SUGGESTIONS.filter(suggestion =>
+      suggestion.toLowerCase().includes(trimmed)
+    );
+  }, [name]);
+
+  const limitedSuggestions = useMemo(() => filteredSuggestions.slice(0, 8), [filteredSuggestions]);
+
+  useEffect(() => {
+    if (!isDropdownOpen) return;
+    setHighlightedIndex(limitedSuggestions.length > 0 ? 0 : -1);
+  }, [isDropdownOpen, limitedSuggestions]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsDropdownOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSuggestionSelect = (suggestion: string) => {
+    setName(suggestion);
+    setError(null);
+    setIsDropdownOpen(false);
+    requestAnimationFrame(() => inputRef.current?.focus());
+  };
+
+  const handleRollSuggestion = () => {
+    const randomSuggestion =
+      HISTORICAL_FIGURES_SUGGESTIONS[Math.floor(Math.random() * HISTORICAL_FIGURES_SUGGESTIONS.length)];
+    handleSuggestionSelect(randomSuggestion);
+  };
+
+  const handleInputChange = (value: string) => {
+    setName(value);
+    setError(null);
+    if (!isDropdownOpen) {
+      setIsDropdownOpen(true);
+    }
+  };
+
+  const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!isDropdownOpen || limitedSuggestions.length === 0) return;
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setHighlightedIndex(prev => (prev + 1) % limitedSuggestions.length);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setHighlightedIndex(prev => (prev - 1 + limitedSuggestions.length) % limitedSuggestions.length);
+    } else if (event.key === 'Enter') {
+      if (highlightedIndex >= 0 && highlightedIndex < limitedSuggestions.length) {
+        event.preventDefault();
+        handleSuggestionSelect(limitedSuggestions[highlightedIndex]);
+      }
+    } else if (event.key === 'Escape') {
+      setIsDropdownOpen(false);
+    }
+  };
 
   const handleCreate = async () => {
     setError(null);
     const clean = name.trim();
     if (!clean) return setError('Enter a historical figure’s name.');
+    setIsDropdownOpen(false);
 
     try {
       setLoading(true);
-      setMsg('Summoning your mentor…');
-
       if (!process.env.API_KEY) throw new Error('API_KEY not set.');
       const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
 
+      setMsg('Consulting the academy archives…');
+
+      const verificationPrompt = `You are the registrar of a historical academy. Verify whether the provided name refers to a real, well-documented historical figure (before the 21st century or of significant historical impact). Respond with JSON containing\n- isHistoricalFigure (boolean)\n- canonicalName (the standardized name or empty string)\n- reason (succinct explanation).\nName: ${clean}`;
+
+      const verificationResp = await ai.models.generateContent({
+        model: 'gemini-2.5-flash',
+        config: {
+          responseMimeType: 'application/json',
+          responseSchema: {
+            type: Type.OBJECT,
+            properties: {
+              isHistoricalFigure: { type: Type.BOOLEAN },
+              canonicalName: { type: Type.STRING },
+              reason: { type: Type.STRING },
+            },
+            required: ['isHistoricalFigure', 'reason'],
+          },
+        },
+        contents: verificationPrompt,
+      });
+
+      const verificationRaw = (verificationResp as any)?.text;
+      if (!verificationRaw) throw new Error('Verification failed. No response received.');
+
+      const verification = JSON.parse(verificationRaw) as {
+        isHistoricalFigure: boolean;
+        canonicalName?: string;
+        reason: string;
+      };
+
+      if (!verification.isHistoricalFigure) {
+        setError(verification.reason || `I could not verify ${clean} as a historical figure.`);
+        setLoading(false);
+        setMsg('');
+        return;
+      }
+
+      const verifiedName = verification.canonicalName?.trim() || clean;
+      setName(verifiedName);
+
+      setMsg('Summoning your mentor…');
+
       const availableAmbienceTags = AMBIENCE_LIBRARY.map(a => a.tag).join(', ');
-      const personaPrompt = `Based on the historical figure "${clean}", return JSON with:
-- title
-- bio (first person)
-- greeting (first person, short)
-- timeframe (centuries)
-- expertise (comma list)
-- passion (short phrase)
-- systemInstruction (act as mentor; emphasize Socratic prompts; may call changeEnvironment() or displayArtifact() as function-only lines)
-- suggestedPrompts (3, one must be environmental/visual)
-- voiceName (one of: ${AVAILABLE_VOICES.join(', ')})
-- voiceAccent (describe the precise accent, vocal gender, and tone the mentor should maintain)
-- ambienceTag (one of: ${availableAmbienceTags})`;
+      const personaPrompt = `Based on the historical figure "${verifiedName}", return JSON with:
+      - title
+      - bio (first person)
+      - greeting (first person, short)
+      - timeframe (centuries)
+      - expertise (comma list)
+      - passion (short phrase)
+      - systemInstruction (act as mentor; emphasize Socratic prompts; may call changeEnvironment() or displayArtifact() as function-only lines)
+      - suggestedPrompts (3, one must be environmental/visual)
+      - voiceName (one of: ${AVAILABLE_VOICES.join(', ')})
+      - voiceAccent (describe the precise accent, vocal gender, and tone the mentor should maintain)
+      - ambienceTag (one of: ${availableAmbienceTags})`;
 
       const personaResp = await ai.models.generateContent({
         model: 'gemini-2.5-flash',
@@ -104,14 +218,17 @@ const CharacterCreator: React.FC<CharacterCreatorProps> = ({ onCharacterCreated,
         contents: personaPrompt,
       });
 
-      const persona: PersonaData = JSON.parse(personaResp.text);
+      const personaRaw = (personaResp as any)?.text;
+      if (!personaRaw) throw new Error('Persona generation failed. No response received.');
+
+      const persona: PersonaData = JSON.parse(personaRaw);
 
       // --- SAFE portrait generation with fallback ---
-      let portraitUrl = makeFallbackAvatar(clean, persona.title);
+      let portraitUrl = makeFallbackAvatar(verifiedName, persona.title);
       try {
         const imgResp = await ai.models.generateImages({
           model: 'imagen-4.0-generate-001',
-          prompt: `A realistic, academic portrait of ${clean}, ${persona.title}. Dignified, historical lighting, 1:1, museum catalogue style.`,
+          prompt: `A realistic, academic portrait of ${verifiedName}, ${persona.title}. Dignified, historical lighting, 1:1, museum catalogue style.`,
           config: { numberOfImages: 1, outputMimeType: 'image/jpeg', aspectRatio: '1:1' },
         });
 
@@ -132,7 +249,7 @@ const CharacterCreator: React.FC<CharacterCreatorProps> = ({ onCharacterCreated,
 
       const character: Character = {
         id: `custom_${Date.now()}`,
-        name: clean,
+        name: verifiedName,
         title: persona.title,
         bio: persona.bio,
         greeting: persona.greeting,
@@ -158,7 +275,10 @@ const CharacterCreator: React.FC<CharacterCreatorProps> = ({ onCharacterCreated,
   };
 
   return (
-    <div className="max-w-3xl w-full mx-auto bg-[#202020] p-4 sm:p-6 md:p-8 rounded-2xl shadow-2xl border border-gray-700 relative">
+    <div
+      ref={containerRef}
+      className="max-w-3xl w-full mx-auto bg-[#202020] p-4 sm:p-6 md:p-8 rounded-2xl shadow-2xl border border-gray-700 relative"
+    >
       {loading && (
         <div className="absolute inset-0 bg-black/80 flex flex-col items-center justify-center z-20 rounded-lg">
           <div className="w-12 h-12 border-4 border-amber-400 border-t-transparent rounded-full animate-spin"></div>
@@ -170,7 +290,7 @@ const CharacterCreator: React.FC<CharacterCreatorProps> = ({ onCharacterCreated,
         <div className="flex justify-between items-start mb-4">
           <div>
             <h2 className="text-3xl font-bold text-amber-200">Create an Ancient</h2>
-            <p className="text-gray-400">Type any historical figure’s name. We’ll craft a mentor persona.</p>
+            <p className="text-gray-400">Whom shall we invite to the academy?</p>
           </div>
           <button
             onClick={onBack}
@@ -187,13 +307,59 @@ const CharacterCreator: React.FC<CharacterCreatorProps> = ({ onCharacterCreated,
         )}
 
         <label className="block text-sm font-medium text-gray-300 mb-2">Historical figure</label>
-        <input
-          type="text"
-          value={name}
-          onChange={e => setName(e.target.value)}
-          placeholder="Ada Lovelace, Marcus Aurelius, Alhazen, Confucius, ..."
-          className="w-full bg-gray-800 border border-gray-600 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-amber-400 text-lg mb-4"
-        />
+        <div className="relative mb-4">
+          <div className="flex items-center gap-2">
+            <input
+              ref={inputRef}
+              type="text"
+              value={name}
+              onFocus={() => setIsDropdownOpen(true)}
+              onChange={e => handleInputChange(e.target.value)}
+              onKeyDown={handleInputKeyDown}
+              placeholder="Ada Lovelace, Marcus Aurelius, Alhazen, Confucius, ..."
+              className="w-full bg-gray-800 border border-gray-600 rounded-lg px-4 py-3 focus:outline-none focus:ring-2 focus:ring-amber-400 text-lg"
+              aria-autocomplete="list"
+              aria-expanded={isDropdownOpen}
+              aria-controls="historical-figure-suggestions"
+            />
+            <button
+              type="button"
+              onClick={handleRollSuggestion}
+              className="flex items-center justify-center h-12 w-12 bg-gray-800 border border-gray-600 rounded-lg text-amber-300 hover:bg-gray-700 transition-colors"
+              aria-label="Roll a random historical figure"
+            >
+              <DiceIcon className="w-6 h-6" />
+            </button>
+          </div>
+          {isDropdownOpen && (
+            <div
+              id="historical-figure-suggestions"
+              role="listbox"
+              className="absolute z-10 mt-2 w-full bg-gray-900 border border-gray-700 rounded-lg shadow-xl max-h-64 overflow-y-auto"
+            >
+              {limitedSuggestions.length === 0 ? (
+                <div className="px-4 py-3 text-sm text-gray-400">No matches found. Try another name.</div>
+              ) : (
+                limitedSuggestions.map((suggestion, index) => (
+                  <button
+                    key={suggestion}
+                    type="button"
+                    role="option"
+                    onMouseDown={() => handleSuggestionSelect(suggestion)}
+                    className={`w-full text-left px-4 py-3 text-sm transition-colors ${
+                      index === highlightedIndex
+                        ? 'bg-amber-500/20 text-amber-200'
+                        : 'text-gray-200 hover:bg-gray-800'
+                    }`}
+                    aria-selected={index === highlightedIndex}
+                  >
+                    {suggestion}
+                  </button>
+                ))
+              )}
+            </div>
+          )}
+        </div>
 
         <button
           onClick={handleCreate}

--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -526,6 +526,17 @@ ${contextTranscript}
             <h2 className="text-2xl sm:text-3xl font-bold text-amber-200 mt-8">{character.name}</h2>
             <p className="text-gray-400 italic">{character.title}</p>
 
+            <div className="mt-4 text-sm text-gray-300 space-y-3">
+                <div className="text-left">
+                    <p className="text-[10px] uppercase tracking-wide text-gray-500">Era</p>
+                    <p className="text-gray-200">{character.timeframe}</p>
+                </div>
+                <div className="text-left">
+                    <p className="text-[10px] uppercase tracking-wide text-gray-500">Voice &amp; Accent</p>
+                    <p className="text-gray-200">{character.voiceName} · {character.voiceAccent}</p>
+                </div>
+            </div>
+
             {activeQuest && (
                 <div className="mt-4 p-4 w-full max-w-xs bg-amber-900/40 border border-amber-800/80 rounded-lg text-left animate-fade-in space-y-3">
                     <div>

--- a/components/icons/DiceIcon.tsx
+++ b/components/icons/DiceIcon.tsx
@@ -1,22 +1,26 @@
 import React from 'react';
 
-const DiceIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+interface DiceIconProps {
+  className?: string;
+}
+
+const DiceIcon: React.FC<DiceIconProps> = ({ className = 'w-6 h-6' }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"
-    strokeWidth={1.5}
+    strokeWidth="1.5"
     strokeLinecap="round"
     strokeLinejoin="round"
-    {...props}
+    className={className}
   >
-    <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-    <path d="M16 8h.01" />
-    <path d="M12 12h.01" />
-    <path d="M8 16h.01" />
-    <path d="M8 8h.01" />
-    <path d="M16 16h.01" />
+    <rect x="3" y="3" width="18" height="18" rx="3" ry="3" />
+    <circle cx="8.5" cy="8.5" r="1.25" />
+    <circle cx="15.5" cy="8.5" r="1.25" />
+    <circle cx="8.5" cy="15.5" r="1.25" />
+    <circle cx="12" cy="12" r="1.25" />
+    <circle cx="15.5" cy="15.5" r="1.25" />
   </svg>
 );
 


### PR DESCRIPTION
## Summary
- revive the character creator suggestion dropdown with keyboard navigation, random dice roll, and the academy invitation prompt
- add API-backed historical figure verification before persona generation and surface canonical results
- display each mentor's era and voice accent details in the conversation view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df0fad80d8832f87ae96e61075a841