### PR TITLE
Fix quest continuation by loading saved transcript

### DIFF
--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -152,10 +152,21 @@ const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndCon
     };
 
     if (activeQuest) {
-      // Start a fresh conversation for a quest
-      setTranscript([greetingTurn]);
-      onEnvironmentUpdate(null);
-      sessionIdRef.current = `quest_${activeQuest.id}_${Date.now()}`;
+      const history = loadConversations();
+      const existingQuestConversation = history.find(
+        (conversation) => conversation.questId === activeQuest.id
+      );
+
+      if (existingQuestConversation && existingQuestConversation.transcript.length > 0) {
+        setTranscript(existingQuestConversation.transcript);
+        onEnvironmentUpdate(existingQuestConversation.environmentImageUrl || null);
+        sessionIdRef.current = existingQuestConversation.id;
+      } else {
+        // Start a fresh conversation for a quest when no history is available
+        setTranscript([greetingTurn]);
+        onEnvironmentUpdate(null);
+        sessionIdRef.current = `quest_${activeQuest.id}_${Date.now()}`;
+      }
     } else {
       const history = loadConversations();
       const existingConversation = history.find(c => c.characterId === character.id);


### PR DESCRIPTION
## Summary
- load the saved conversation when re-opening a quest so players can continue after ending a session

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df1f40c1e8832fafd1db91bc1f3d22