### PR TITLE
Fix quest continuation by resuming stored conversations

### DIFF
--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -151,24 +151,36 @@ const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndCon
       text: character.greeting,
     };
 
+    const history = loadConversations();
+
     if (activeQuest) {
-      // Start a fresh conversation for a quest
+      const existingQuestConversation = history.find(
+        c => c.questId === activeQuest.id && c.characterId === character.id,
+      );
+
+      if (existingQuestConversation && existingQuestConversation.transcript.length > 0) {
+        setTranscript(existingQuestConversation.transcript);
+        onEnvironmentUpdate(existingQuestConversation.environmentImageUrl || null);
+        sessionIdRef.current = existingQuestConversation.id;
+        return;
+      }
+
       setTranscript([greetingTurn]);
       onEnvironmentUpdate(null);
       sessionIdRef.current = `quest_${activeQuest.id}_${Date.now()}`;
+      return;
+    }
+
+    const existingConversation = history.find(c => c.characterId === character.id);
+    if (existingConversation && existingConversation.transcript.length > 0) {
+      setTranscript(existingConversation.transcript);
+      onEnvironmentUpdate(existingConversation.environmentImageUrl || null);
+      sessionIdRef.current = existingConversation.id;
     } else {
-      const history = loadConversations();
-      const existingConversation = history.find(c => c.characterId === character.id);
-      if (existingConversation && existingConversation.transcript.length > 0) {
-          setTranscript(existingConversation.transcript);
-          onEnvironmentUpdate(existingConversation.environmentImageUrl || null);
-          sessionIdRef.current = existingConversation.id; 
-      } else {
-          // This is a new conversation or an empty one from history
-          setTranscript([greetingTurn]);
-          onEnvironmentUpdate(null);
-          sessionIdRef.current = existingConversation ? existingConversation.id : `conv_${character.id}_${Date.now()}`;
-      }
+      // This is a new conversation or an empty one from history
+      setTranscript([greetingTurn]);
+      onEnvironmentUpdate(null);
+      sessionIdRef.current = existingConversation ? existingConversation.id : `conv_${character.id}_${Date.now()}`;
     }
   }, [character, onEnvironmentUpdate, activeQuest]);
 


### PR DESCRIPTION
## Summary
- resume active quest conversations by loading the most recent saved transcript when a quest is reopened
- keep quest environments and session identifiers in sync so subsequent saves update the same record

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df1f40c1e8832fafd1db91bc1f3d22