### PR TITLE
Fix quest sessions resuming after ending

### DIFF
--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -152,17 +152,30 @@ const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndCon
     };
 
     if (activeQuest) {
-      // Start a fresh conversation for a quest
-      setTranscript([greetingTurn]);
-      onEnvironmentUpdate(null);
-      sessionIdRef.current = `quest_${activeQuest.id}_${Date.now()}`;
+      const history = loadConversations();
+      const existingQuestConversation = history
+        .filter(c => c.questId === activeQuest.id)
+        .sort((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0))[0];
+
+      if (existingQuestConversation && existingQuestConversation.transcript.length > 0) {
+        setTranscript(existingQuestConversation.transcript);
+        onEnvironmentUpdate(existingQuestConversation.environmentImageUrl || null);
+        sessionIdRef.current = existingQuestConversation.id;
+      } else {
+        // Start a fresh conversation for this quest
+        setTranscript([greetingTurn]);
+        onEnvironmentUpdate(null);
+        sessionIdRef.current = existingQuestConversation
+          ? existingQuestConversation.id
+          : `quest_${activeQuest.id}_${Date.now()}`;
+      }
     } else {
       const history = loadConversations();
       const existingConversation = history.find(c => c.characterId === character.id);
       if (existingConversation && existingConversation.transcript.length > 0) {
           setTranscript(existingConversation.transcript);
           onEnvironmentUpdate(existingConversation.environmentImageUrl || null);
-          sessionIdRef.current = existingConversation.id; 
+          sessionIdRef.current = existingConversation.id;
       } else {
           // This is a new conversation or an empty one from history
           setTranscript([greetingTurn]);


### PR DESCRIPTION
## Summary
- load the latest saved conversation when re-opening a quest so the session can continue instead of starting over

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df1f40c1e8832fafd1db91bc1f3d22