### PR TITLE
feat: surface custom quest progress

### DIFF
--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -152,10 +152,19 @@ const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndCon
     };
 
     if (activeQuest) {
-      // Start a fresh conversation for a quest
-      setTranscript([greetingTurn]);
-      onEnvironmentUpdate(null);
-      sessionIdRef.current = `quest_${activeQuest.id}_${Date.now()}`;
+      const history = loadConversations();
+      const existingQuestConversation = history.find(
+        (c) => c.questId === activeQuest.id
+      );
+      if (existingQuestConversation && existingQuestConversation.transcript.length > 0) {
+        setTranscript(existingQuestConversation.transcript);
+        onEnvironmentUpdate(existingQuestConversation.environmentImageUrl || null);
+        sessionIdRef.current = existingQuestConversation.id;
+      } else {
+        setTranscript([greetingTurn]);
+        onEnvironmentUpdate(null);
+        sessionIdRef.current = `quest_${activeQuest.id}_${Date.now()}`;
+      }
     } else {
       const history = loadConversations();
       const existingConversation = history.find(c => c.characterId === character.id);

--- a/components/QuestsView.tsx
+++ b/components/QuestsView.tsx
@@ -10,6 +10,7 @@ interface QuestsViewProps {
   onSelectQuest: (quest: Quest) => void;
   onBack: () => void;
   onCreateQuest: () => void;
+  inProgressQuestIds: string[];
 }
 
 const QuestsView: React.FC<QuestsViewProps> = ({
@@ -19,6 +20,7 @@ const QuestsView: React.FC<QuestsViewProps> = ({
   onSelectQuest,
   onBack,
   onCreateQuest,
+  inProgressQuestIds,
 }) => {
   return (
     <div className="max-w-4xl mx-auto animate-fade-in">
@@ -78,11 +80,27 @@ const QuestsView: React.FC<QuestsViewProps> = ({
             const character = characters.find(c => c.id === quest.characterId);
             if (!character) return null;
             const isCompleted = completedQuestIds.includes(quest.id);
+            const isInProgress = inProgressQuestIds.includes(quest.id);
+            const cardStatusClass = isCompleted
+              ? 'border-emerald-600/80 shadow-lg shadow-emerald-900/40'
+              : isInProgress
+                ? 'border-teal-500/80 shadow-lg shadow-teal-900/40'
+                : 'border-gray-700 hover:border-amber-400';
+            const buttonLabel = isCompleted
+              ? 'Review Quest'
+              : isInProgress
+                ? 'Continue Quest'
+                : 'Begin Quest';
+            const buttonClass = isCompleted
+              ? 'bg-emerald-600 hover:bg-emerald-500 text-black'
+              : isInProgress
+                ? 'bg-teal-600 hover:bg-teal-500 text-black'
+                : 'bg-amber-600 hover:bg-amber-500 text-black';
 
             return (
               <div
                 key={quest.id}
-                className={`bg-gray-800/50 p-5 rounded-lg border flex flex-col text-center transition-colors duration-300 ${isCompleted ? 'border-emerald-600/80 shadow-lg shadow-emerald-900/40' : 'border-gray-700 hover:border-amber-400'}`}
+                className={`bg-gray-800/50 p-5 rounded-lg border flex flex-col text-center transition-colors duration-300 ${cardStatusClass}`}
               >
                 <img src={character.portraitUrl} alt={character.name} className="w-24 h-24 rounded-full mx-auto mb-4 border-2 border-amber-300" />
                 <h3 className="font-bold text-xl text-amber-300">{quest.title}</h3>
@@ -92,6 +110,14 @@ const QuestsView: React.FC<QuestsViewProps> = ({
                     <span className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-emerald-700/30 text-emerald-200 text-xs font-semibold uppercase tracking-wide">
                       <span className="w-2 h-2 rounded-full bg-emerald-300" />
                       Completed
+                    </span>
+                  </div>
+                )}
+                {!isCompleted && isInProgress && (
+                  <div className="mt-2">
+                    <span className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-teal-700/30 text-teal-200 text-xs font-semibold uppercase tracking-wide">
+                      <span className="w-2 h-2 rounded-full bg-teal-300" />
+                      In Progress
                     </span>
                   </div>
                 )}
@@ -117,9 +143,9 @@ const QuestsView: React.FC<QuestsViewProps> = ({
                 </div>
                 <button
                     onClick={() => onSelectQuest(quest)}
-                    className={`mt-6 font-bold py-2 px-4 rounded-lg transition-colors w-full ${isCompleted ? 'bg-emerald-600 hover:bg-emerald-500 text-black' : 'bg-amber-600 hover:bg-amber-500 text-black'}`}
+                    className={`mt-6 font-bold py-2 px-4 rounded-lg transition-colors w-full ${buttonClass}`}
                 >
-                    {isCompleted ? 'Review Quest' : 'Begin Quest'}
+                    {buttonLabel}
                 </button>
               </div>
             );


### PR DESCRIPTION
## Summary
- persist generated quests in local storage and include them in global quest progress tracking
- refresh the Learning Quests grid to show custom and in-progress quests with appropriate call-to-action labels
- allow conversations launched from quests to resume saved transcripts so learners can continue unfinished sessions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e037a64480832fb236126c8b7bc3d6