### PR TITLE
Add persistence and continuation for custom learning quests

### DIFF
--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -21,6 +21,7 @@ interface ConversationViewProps {
   environmentImageUrl: string | null;
   onEnvironmentUpdate: (url: string | null) => void;
   activeQuest: Quest | null;
+  existingQuestConversation: SavedConversation | null;
   isSaving: boolean;
 }
 
@@ -99,7 +100,7 @@ const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifa
     );
   };
 
-const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndConversation, environmentImageUrl, onEnvironmentUpdate, activeQuest, isSaving }) => {
+const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndConversation, environmentImageUrl, onEnvironmentUpdate, activeQuest, existingQuestConversation, isSaving }) => {
   const [transcript, setTranscript] = useState<ConversationTurn[]>([]);
   const [textInput, setTextInput] = useState('');
   const [dynamicSuggestions, setDynamicSuggestions] = useState<string[]>([]);
@@ -152,17 +153,27 @@ const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndCon
     };
 
     if (activeQuest) {
-      // Start a fresh conversation for a quest
-      setTranscript([greetingTurn]);
-      onEnvironmentUpdate(null);
-      sessionIdRef.current = `quest_${activeQuest.id}_${Date.now()}`;
+      if (existingQuestConversation) {
+        if (existingQuestConversation.transcript.length > 0) {
+          setTranscript(existingQuestConversation.transcript);
+        } else {
+          setTranscript([greetingTurn]);
+        }
+        onEnvironmentUpdate(existingQuestConversation.environmentImageUrl || null);
+        sessionIdRef.current = existingQuestConversation.id;
+      } else {
+        // Start a fresh conversation for a quest
+        setTranscript([greetingTurn]);
+        onEnvironmentUpdate(null);
+        sessionIdRef.current = `quest_${activeQuest.id}_${Date.now()}`;
+      }
     } else {
       const history = loadConversations();
       const existingConversation = history.find(c => c.characterId === character.id);
       if (existingConversation && existingConversation.transcript.length > 0) {
           setTranscript(existingConversation.transcript);
           onEnvironmentUpdate(existingConversation.environmentImageUrl || null);
-          sessionIdRef.current = existingConversation.id; 
+          sessionIdRef.current = existingConversation.id;
       } else {
           // This is a new conversation or an empty one from history
           setTranscript([greetingTurn]);
@@ -170,7 +181,7 @@ const ConversationView: React.FC<ConversationViewProps> = ({ character, onEndCon
           sessionIdRef.current = existingConversation ? existingConversation.id : `conv_${character.id}_${Date.now()}`;
       }
     }
-  }, [character, onEnvironmentUpdate, activeQuest]);
+  }, [character, onEnvironmentUpdate, activeQuest, existingQuestConversation]);
 
     // Cycle through placeholders for text input
     useEffect(() => {

--- a/components/QuestsView.tsx
+++ b/components/QuestsView.tsx
@@ -7,6 +7,8 @@ interface QuestsViewProps {
   quests: Quest[];
   characters: Character[];
   completedQuestIds: string[];
+  inProgressQuestIds: string[];
+  customQuestIds: string[];
   onSelectQuest: (quest: Quest) => void;
   onBack: () => void;
   onCreateQuest: () => void;
@@ -16,6 +18,8 @@ const QuestsView: React.FC<QuestsViewProps> = ({
   quests,
   characters,
   completedQuestIds,
+  inProgressQuestIds,
+  customQuestIds,
   onSelectQuest,
   onBack,
   onCreateQuest,
@@ -78,21 +82,44 @@ const QuestsView: React.FC<QuestsViewProps> = ({
             const character = characters.find(c => c.id === quest.characterId);
             if (!character) return null;
             const isCompleted = completedQuestIds.includes(quest.id);
+            const isCustom = customQuestIds.includes(quest.id);
+            const isInProgress = inProgressQuestIds.includes(quest.id) && !isCompleted;
+            const showBadges = isCompleted || isInProgress || isCustom;
+            const buttonText = isCompleted ? 'Review Quest' : isInProgress ? 'Continue Quest' : 'Begin Quest';
+            const buttonClass = isCompleted
+              ? 'bg-emerald-600 hover:bg-emerald-500 text-black'
+              : isInProgress
+              ? 'bg-teal-600 hover:bg-teal-500 text-black'
+              : 'bg-amber-600 hover:bg-amber-500 text-black';
 
             return (
               <div
                 key={quest.id}
-                className={`bg-gray-800/50 p-5 rounded-lg border flex flex-col text-center transition-colors duration-300 ${isCompleted ? 'border-emerald-600/80 shadow-lg shadow-emerald-900/40' : 'border-gray-700 hover:border-amber-400'}`}
+                className={`bg-gray-800/50 p-5 rounded-lg border flex flex-col text-center transition-colors duration-300 ${isCompleted ? 'border-emerald-600/80 shadow-lg shadow-emerald-900/40' : isInProgress ? 'border-teal-600/60 shadow-lg shadow-teal-900/30' : 'border-gray-700 hover:border-amber-400'}`}
               >
                 <img src={character.portraitUrl} alt={character.name} className="w-24 h-24 rounded-full mx-auto mb-4 border-2 border-amber-300" />
                 <h3 className="font-bold text-xl text-amber-300">{quest.title}</h3>
                 <p className="text-sm text-gray-400 mt-1">with {character.name}</p>
-                {isCompleted && (
-                  <div className="mt-2">
-                    <span className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-emerald-700/30 text-emerald-200 text-xs font-semibold uppercase tracking-wide">
-                      <span className="w-2 h-2 rounded-full bg-emerald-300" />
-                      Completed
-                    </span>
+                {showBadges && (
+                  <div className="mt-2 flex flex-wrap justify-center gap-2">
+                    {isCompleted && (
+                      <span className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-emerald-700/30 text-emerald-200 text-xs font-semibold uppercase tracking-wide">
+                        <span className="w-2 h-2 rounded-full bg-emerald-300" />
+                        Completed
+                      </span>
+                    )}
+                    {isInProgress && (
+                      <span className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-teal-700/30 text-teal-200 text-xs font-semibold uppercase tracking-wide">
+                        <span className="w-2 h-2 rounded-full bg-teal-300" />
+                        In Progress
+                      </span>
+                    )}
+                    {isCustom && (
+                      <span className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-amber-700/30 text-amber-200 text-xs font-semibold uppercase tracking-wide">
+                        <span className="w-2 h-2 rounded-full bg-amber-300" />
+                        Custom Quest
+                      </span>
+                    )}
                   </div>
                 )}
                 <div className="mt-3 mb-4">
@@ -117,9 +144,9 @@ const QuestsView: React.FC<QuestsViewProps> = ({
                 </div>
                 <button
                     onClick={() => onSelectQuest(quest)}
-                    className={`mt-6 font-bold py-2 px-4 rounded-lg transition-colors w-full ${isCompleted ? 'bg-emerald-600 hover:bg-emerald-500 text-black' : 'bg-amber-600 hover:bg-amber-500 text-black'}`}
+                    className={`mt-6 font-bold py-2 px-4 rounded-lg transition-colors w-full ${buttonClass}`}
                 >
-                    {isCompleted ? 'Review Quest' : 'Begin Quest'}
+                    {buttonText}
                 </button>
               </div>
             );


### PR DESCRIPTION
## Summary
- persist generated quests in local storage and include them alongside the default Learning Quests
- resume in-progress quest conversations so learners can continue unfinished work
- refresh the Learning Quests UI to highlight custom and in-progress quests while updating progress metrics

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e037a64480832fb236126c8b7bc3d6