### PR TITLE
Add continue quest prompt for failed quest outcomes

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -185,6 +185,17 @@ const App: React.FC = () => {
     }
   };
 
+  const handleContinueQuest = () => {
+    if (!lastQuestOutcome) return;
+    const questToResume = allQuests.find((quest) => quest.id === lastQuestOutcome.questId);
+    if (questToResume) {
+      handleSelectQuest(questToResume);
+    } else {
+      console.warn(`Quest with ID ${lastQuestOutcome.questId} could not be found.`);
+      setView('quests');
+    }
+  };
+
   const handleCharacterCreated = (newCharacter: Character) => {
     const updatedCharacters = [newCharacter, ...customCharacters];
     setCustomCharacters(updatedCharacters);
@@ -537,6 +548,16 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
                       ))}
                     </ul>
                   </div>
+                )}
+
+                {!lastQuestOutcome.passed && (
+                  <button
+                    type="button"
+                    onClick={handleContinueQuest}
+                    className="mt-6 inline-flex items-center text-sm font-semibold text-amber-200 hover:text-amber-100 underline decoration-dotted underline-offset-4"
+                  >
+                    Continue quest?
+                  </button>
                 )}
               </div>
             )}


### PR DESCRIPTION
## Summary
- add a helper that reopens a quest from the latest failed assessment
- surface a "Continue quest?" control when the most recent quest outcome needs review

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e063884aec832fbde2eb8ca9e54028