### PR TITLE
Add continue quest link for failed quest outcomes

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -185,6 +185,18 @@ const App: React.FC = () => {
     }
   };
 
+  const handleContinueQuest = (questId: string | undefined) => {
+    if (!questId) {
+      return;
+    }
+    const questToResume = allQuests.find((quest) => quest.id === questId);
+    if (!questToResume) {
+      console.warn(`Quest with ID ${questId} could not be found for continuation.`);
+      return;
+    }
+    handleSelectQuest(questToResume);
+  };
+
   const handleCharacterCreated = (newCharacter: Character) => {
     const updatedCharacters = [newCharacter, ...customCharacters];
     setCustomCharacters(updatedCharacters);
@@ -537,6 +549,16 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
                       ))}
                     </ul>
                   </div>
+                )}
+
+                {!lastQuestOutcome.passed && lastQuestOutcome.questId && (
+                  <button
+                    type="button"
+                    onClick={() => handleContinueQuest(lastQuestOutcome.questId)}
+                    className="mt-4 inline-flex items-center text-sm font-semibold text-amber-200 hover:text-amber-100 hover:underline focus:outline-none"
+                  >
+                    Continue quest?
+                  </button>
                 )}
               </div>
             )}


### PR DESCRIPTION
## Summary
- add a quest continuation handler that reopens the mentor and quest selection when a generated quest fails
- surface a "Continue quest?" link inside the latest quest review card so learners can immediately retry

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68e063884aec832fbde2eb8ca9e54028