### PR TITLE
Add resume link for failed quests

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -185,6 +185,17 @@ const App: React.FC = () => {
     }
   };
 
+  const handleResumeQuest = (questId: string) => {
+    const questToResume = allQuests.find((quest) => quest.id === questId);
+    if (questToResume) {
+      setLastQuestOutcome(null);
+      handleSelectQuest(questToResume);
+    } else {
+      console.warn(`Quest with ID ${questId} not found. Redirecting to quest list.`);
+      setView('quests');
+    }
+  };
+
   const handleCharacterCreated = (newCharacter: Character) => {
     const updatedCharacters = [newCharacter, ...customCharacters];
     setCustomCharacters(updatedCharacters);
@@ -537,6 +548,15 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
                       ))}
                     </ul>
                   </div>
+                )}
+
+                {!lastQuestOutcome.passed && (
+                  <button
+                    onClick={() => handleResumeQuest(lastQuestOutcome.questId)}
+                    className="mt-6 inline-flex items-center text-sm font-semibold text-amber-200 hover:text-amber-100 underline"
+                  >
+                    Continue quest?
+                  </button>
                 )}
               </div>
             )}


### PR DESCRIPTION
## Summary
- add a resume handler that finds the previous quest and re-opens it when the latest review fails
- expose a "Continue quest?" call-to-action on failed quest reviews so learners can jump back in immediately

## Testing
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68e063884aec832fbde2eb8ca9e54028