### PR TITLE
feat: enable resuming saved conversations

### DIFF
--- a/components/HistoryView.tsx
+++ b/components/HistoryView.tsx
@@ -38,9 +38,10 @@ const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifa
 
 interface HistoryViewProps {
   onBack: () => void;
+  onResumeConversation: (conversation: SavedConversation) => void;
 }
 
-const HistoryView: React.FC<HistoryViewProps> = ({ onBack }) => {
+const HistoryView: React.FC<HistoryViewProps> = ({ onBack, onResumeConversation }) => {
   const [history, setHistory] = useState<SavedConversation[]>([]);
   const [selectedConversation, setSelectedConversation] = useState<SavedConversation | null>(null);
 
@@ -173,9 +174,20 @@ const HistoryView: React.FC<HistoryViewProps> = ({ onBack }) => {
             ))}
           </div>
           <div className="flex flex-col sm:flex-row gap-4 mt-6">
-            <button onClick={() => setSelectedConversation(null)} className="bg-amber-600 hover:bg-amber-500 text-black font-bold py-2 px-6 rounded-lg transition-colors">
-              Back to History
-            </button>
+            <div className="flex flex-col sm:flex-row gap-3">
+              <button
+                onClick={() => setSelectedConversation(null)}
+                className="bg-amber-600 hover:bg-amber-500 text-black font-bold py-2 px-6 rounded-lg transition-colors"
+              >
+                Back to History
+              </button>
+              <button
+                onClick={() => onResumeConversation(selectedConversation)}
+                className="bg-emerald-600/80 hover:bg-emerald-500 text-white font-bold py-2 px-6 rounded-lg transition-colors border border-emerald-500/70"
+              >
+                Resume Conversation
+              </button>
+            </div>
             <button onClick={handleDownload} className="flex items-center justify-center gap-2 bg-blue-800/70 hover:bg-blue-700 text-white font-bold py-2 px-6 rounded-lg transition-colors">
               <DownloadIcon className="w-5 h-5" />
               Download Study Guide
@@ -219,6 +231,12 @@ const HistoryView: React.FC<HistoryViewProps> = ({ onBack }) => {
               </div>
               <div className="flex gap-2 self-end sm:self-center">
                 <button onClick={() => setSelectedConversation(conv)} className="bg-blue-800/70 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg transition-colors">View</button>
+                <button
+                  onClick={() => onResumeConversation(conv)}
+                  className="bg-emerald-700/80 hover:bg-emerald-600 text-white font-bold py-2 px-4 rounded-lg transition-colors"
+                >
+                  Resume
+                </button>
                 <button onClick={() => handleDelete(conv.id)} className="bg-red-800/70 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-lg transition-colors">Delete</button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add resume actions to the history list and detail views so past chats can be reopened
- track the conversation id in App state and hydrate ConversationView with saved transcripts
- ensure quest/environment context is restored when continuing a previous session

## Screenshots
![History resume button](browser:/invocations/qwqghpxm/artifacts/artifacts/history-resume.png)

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68e06caf38b8832fbb5a348d99c82041