### PR TITLE
feat: allow deleting custom quests

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -255,6 +255,30 @@ const App: React.FC = () => {
     }
   };
 
+  const handleDeleteQuest = (questId: string) => {
+    setCustomQuests((prev) => {
+      const updated = prev.filter((quest) => quest.id !== questId);
+      if (updated.length !== prev.length) {
+        saveCustomQuests(updated);
+        return updated;
+      }
+      return prev;
+    });
+
+    setCompletedQuests((prev) => {
+      if (!prev.includes(questId)) {
+        return prev;
+      }
+      const updated = prev.filter((id) => id !== questId);
+      saveCompletedQuests(updated);
+      return updated;
+    });
+
+    setInProgressQuestIds((prev) => prev.filter((id) => id !== questId));
+
+    setActiveQuest((prev) => (prev?.id === questId ? null : prev));
+  };
+
   // NEW: handle a freshly-generated quest & mentor from QuestCreator
   const startGeneratedQuest = (quest: Quest, mentor: Character) => {
     setCustomQuests((prev) => {
@@ -501,6 +525,8 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
             completedQuestIds={completedQuests}
             onCreateQuest={() => setView('questCreator')}
             inProgressQuestIds={inProgressQuestIds}
+            onDeleteQuest={handleDeleteQuest}
+            deletableQuestIds={customQuests.map((quest) => quest.id)}
           />
         );
       }

--- a/components/QuestsView.tsx
+++ b/components/QuestsView.tsx
@@ -11,6 +11,8 @@ interface QuestsViewProps {
   onBack: () => void;
   onCreateQuest: () => void;
   inProgressQuestIds: string[];
+  onDeleteQuest: (questId: string) => void;
+  deletableQuestIds: string[];
 }
 
 const QuestsView: React.FC<QuestsViewProps> = ({
@@ -21,6 +23,8 @@ const QuestsView: React.FC<QuestsViewProps> = ({
   onBack,
   onCreateQuest,
   inProgressQuestIds,
+  onDeleteQuest,
+  deletableQuestIds,
 }) => {
   return (
     <div className="max-w-4xl mx-auto animate-fade-in">
@@ -81,6 +85,7 @@ const QuestsView: React.FC<QuestsViewProps> = ({
             if (!character) return null;
             const isCompleted = completedQuestIds.includes(quest.id);
             const isInProgress = inProgressQuestIds.includes(quest.id);
+            const isDeletable = deletableQuestIds.includes(quest.id);
             const cardStatusClass = isCompleted
               ? 'border-emerald-600/80 shadow-lg shadow-emerald-900/40'
               : isInProgress
@@ -100,8 +105,20 @@ const QuestsView: React.FC<QuestsViewProps> = ({
             return (
               <div
                 key={quest.id}
-                className={`bg-gray-800/50 p-5 rounded-lg border flex flex-col text-center transition-colors duration-300 ${cardStatusClass}`}
+                className={`bg-gray-800/50 p-5 rounded-lg border flex flex-col text-center transition-colors duration-300 relative ${cardStatusClass}`}
               >
+                {isDeletable && (
+                  <button
+                    onClick={() => {
+                      if (window.confirm('Are you sure you want to delete this quest? This action cannot be undone.')) {
+                        onDeleteQuest(quest.id);
+                      }
+                    }}
+                    className="absolute top-3 right-3 text-xs uppercase tracking-wide text-red-300 hover:text-red-200"
+                  >
+                    Delete
+                  </button>
+                )}
                 <img src={character.portraitUrl} alt={character.name} className="w-24 h-24 rounded-full mx-auto mb-4 border-2 border-amber-300" />
                 <h3 className="font-bold text-xl text-amber-300">{quest.title}</h3>
                 <p className="text-sm text-gray-400 mt-1">with {character.name}</p>


### PR DESCRIPTION
## Summary
- add delete controls for user-created quests in the learning quests grid
- synchronize quest deletion with saved progress and active quest state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e073b85248832f964d8ac8eecc7013