### PR TITLE
feat: add delete option for custom quests

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -255,6 +255,30 @@ const App: React.FC = () => {
     }
   };
 
+  const handleDeleteQuest = (questId: string) => {
+    if (!window.confirm('Are you sure you want to delete this quest? This cannot be undone.')) {
+      return;
+    }
+
+    setCustomQuests((prev) => {
+      const updated = prev.filter((quest) => quest.id !== questId);
+      saveCustomQuests(updated);
+      return updated;
+    });
+
+    setCompletedQuests((prev) => {
+      const updated = prev.filter((id) => id !== questId);
+      saveCompletedQuests(updated);
+      return updated;
+    });
+
+    setInProgressQuestIds((prev) => prev.filter((id) => id !== questId));
+
+    if (activeQuest?.id === questId) {
+      setActiveQuest(null);
+    }
+  };
+
   // NEW: handle a freshly-generated quest & mentor from QuestCreator
   const startGeneratedQuest = (quest: Quest, mentor: Character) => {
     setCustomQuests((prev) => {
@@ -501,6 +525,8 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
             completedQuestIds={completedQuests}
             onCreateQuest={() => setView('questCreator')}
             inProgressQuestIds={inProgressQuestIds}
+            onDeleteQuest={handleDeleteQuest}
+            customQuestIds={customQuests.map((quest) => quest.id)}
           />
         );
       }

--- a/components/QuestsView.tsx
+++ b/components/QuestsView.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import type { Quest, Character } from '../types';
 import QuestIcon from './icons/QuestIcon';
+import TrashIcon from './icons/TrashIcon';
 
 interface QuestsViewProps {
   quests: Quest[];
@@ -11,6 +12,8 @@ interface QuestsViewProps {
   onBack: () => void;
   onCreateQuest: () => void;
   inProgressQuestIds: string[];
+  onDeleteQuest: (questId: string) => void;
+  customQuestIds: string[];
 }
 
 const QuestsView: React.FC<QuestsViewProps> = ({
@@ -21,6 +24,8 @@ const QuestsView: React.FC<QuestsViewProps> = ({
   onBack,
   onCreateQuest,
   inProgressQuestIds,
+  onDeleteQuest,
+  customQuestIds,
 }) => {
   return (
     <div className="max-w-4xl mx-auto animate-fade-in">
@@ -81,6 +86,7 @@ const QuestsView: React.FC<QuestsViewProps> = ({
             if (!character) return null;
             const isCompleted = completedQuestIds.includes(quest.id);
             const isInProgress = inProgressQuestIds.includes(quest.id);
+            const isCustomQuest = customQuestIds.includes(quest.id);
             const cardStatusClass = isCompleted
               ? 'border-emerald-600/80 shadow-lg shadow-emerald-900/40'
               : isInProgress
@@ -102,6 +108,18 @@ const QuestsView: React.FC<QuestsViewProps> = ({
                 key={quest.id}
                 className={`bg-gray-800/50 p-5 rounded-lg border flex flex-col text-center transition-colors duration-300 ${cardStatusClass}`}
               >
+                {isCustomQuest && (
+                  <div className="flex justify-end">
+                    <button
+                      type="button"
+                      onClick={() => onDeleteQuest(quest.id)}
+                      className="group inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-red-300/80 hover:text-red-200"
+                    >
+                      <TrashIcon className="w-4 h-4 text-red-400/80 group-hover:text-red-300" />
+                      Delete Quest
+                    </button>
+                  </div>
+                )}
                 <img src={character.portraitUrl} alt={character.name} className="w-24 h-24 rounded-full mx-auto mb-4 border-2 border-amber-300" />
                 <h3 className="font-bold text-xl text-amber-300">{quest.title}</h3>
                 <p className="text-sm text-gray-400 mt-1">with {character.name}</p>


### PR DESCRIPTION
## Summary
- add a delete control for custom learning quests with a confirmation prompt
- synchronize quest removal with saved progress and active quest state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e073b85248832f964d8ac8eecc7013