### PR TITLE
Add follow-up quest creation from conversation history

### DIFF
--- a/components/QuestCreator.tsx
+++ b/components/QuestCreator.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { GoogleGenAI, Type } from '@google/genai';
 import type { Character, PersonaData, Quest } from '../types';
 import { AMBIENCE_LIBRARY, AVAILABLE_VOICES } from '../constants';
@@ -18,6 +18,7 @@ interface QuestCreatorProps {
   onBack: () => void;
   onQuestReady: (quest: Quest, character: Character) => void;
   onCharacterCreated: (character: Character) => void;
+  initialGoal?: string;
 }
 
 /** Pretty, branded SVG fallback if portrait generation fails */
@@ -52,12 +53,17 @@ const QuestCreator: React.FC<QuestCreatorProps> = ({
   onBack,
   onQuestReady,
   onCharacterCreated,
+  initialGoal = '',
 }) => {
-  const [goal, setGoal] = useState('');
+  const [goal, setGoal] = useState(initialGoal);
   const [prefs, setPrefs] = useState({ difficulty: 'auto', style: 'auto', time: 'auto' });
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState('');
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setGoal(initialGoal);
+  }, [initialGoal]);
 
   const findCharacterByName = (name: string): Character | null => {
     const lower = name.trim().toLowerCase();

--- a/tests/components/QuestCreator.test.tsx
+++ b/tests/components/QuestCreator.test.tsx
@@ -60,6 +60,20 @@ describe('QuestCreator', () => {
         expect(screen.getByRole('button', { name: 'Create Quest' })).toBeInTheDocument();
     });
 
+    it('should preload the initial goal when provided', () => {
+        render(
+            <QuestCreator
+                characters={[]}
+                onBack={mockOnBack}
+                onQuestReady={mockOnQuestReady}
+                onCharacterCreated={mockOnCharacterCreated}
+                initialGoal="Strengthen my grasp of rhetorical devices"
+            />
+        );
+
+        expect(screen.getByDisplayValue('Strengthen my grasp of rhetorical devices')).toBeInTheDocument();
+    });
+
     it('should show an error if the goal is empty on creation', async () => {
         const user = userEvent.setup();
         render(<QuestCreator characters={[]} onBack={mockOnBack} onQuestReady={mockOnQuestReady} onCharacterCreated={mockOnCharacterCreated} />);


### PR DESCRIPTION
## Summary
- add a follow-up quest composer in conversation history that captures key takeaways or quest feedback and routes to quest creation
- seed the quest creator with history insights and remember the originating view when navigating back
- allow QuestCreator to accept an initial goal value and cover the behavior with a unit test

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e07b3c4dc4832fa56c8cb3a033ec06