### PR TITLE
Add quest creation workflow from history reflections

### DIFF
--- a/components/QuestCreator.tsx
+++ b/components/QuestCreator.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { GoogleGenAI, Type } from '@google/genai';
 import type { Character, PersonaData, Quest } from '../types';
 import { AMBIENCE_LIBRARY, AVAILABLE_VOICES } from '../constants';
@@ -18,6 +18,8 @@ interface QuestCreatorProps {
   onBack: () => void;
   onQuestReady: (quest: Quest, character: Character) => void;
   onCharacterCreated: (character: Character) => void;
+  initialGoal?: string;
+  prefillSource?: 'history' | null;
 }
 
 /** Pretty, branded SVG fallback if portrait generation fails */
@@ -52,12 +54,20 @@ const QuestCreator: React.FC<QuestCreatorProps> = ({
   onBack,
   onQuestReady,
   onCharacterCreated,
+  initialGoal,
+  prefillSource,
 }) => {
-  const [goal, setGoal] = useState('');
+  const [goal, setGoal] = useState(initialGoal ?? '');
   const [prefs, setPrefs] = useState({ difficulty: 'auto', style: 'auto', time: 'auto' });
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState('');
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setGoal(initialGoal ?? '');
+  }, [initialGoal]);
+
+  const hasPrefilledGoal = Boolean(initialGoal && initialGoal.trim().length > 0);
 
   const findCharacterByName = (name: string): Character | null => {
     const lower = name.trim().toLowerCase();
@@ -368,6 +378,16 @@ Return JSON with:
         {error && (
           <div className="bg-red-900/50 border border-red-700 text-red-300 p-3 rounded-lg mb-6">
             {error}
+          </div>
+        )}
+
+        {hasPrefilledGoal && (
+          <div className="bg-teal-900/40 border border-teal-700/50 text-teal-100 px-4 py-3 rounded-lg mb-4">
+            <p className="text-sm">
+              {prefillSource === 'history'
+                ? 'We pre-filled your learning goal with the next steps from your conversation. Edit the notes before creating your quest.'
+                : 'This goal has been pre-filled. Adjust it to match the quest you want to build.'}
+            </p>
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- add a follow-up quest drafting panel to saved conversation details with configurable notes
- funnel history notes into the quest creator and return users to history when backing out
- show contextual guidance when the quest creator is pre-filled from history reflections

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e07b3c4dc4832fa56c8cb3a033ec06