### PR TITLE
feat: create follow-up quests from history insights

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -96,3 +96,22 @@ export interface Quest {
   duration: string;
   focusPoints: string[];
 }
+
+export interface QuestPrefillContext {
+  conversationId: string;
+  characterName: string;
+  questTitle?: string;
+  timestamp: number;
+}
+
+export interface QuestPrefill {
+  goal: string;
+  focusPoints?: string[];
+  mentorName?: string;
+  context?: QuestPrefillContext;
+  insights?: {
+    nextSteps: string[];
+    takeaways: string[];
+    overview?: string;
+  };
+}


### PR DESCRIPTION
## Summary
- allow learners to select quest "next steps" and key takeaways from saved conversations and draft a follow-up quest
- pass conversation insight context into the quest creator, including mentor preference and focus areas
- add a reusable quest prefill type and route quest creation flows through the new insight hand-off

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e07b3c4dc4832fa56c8cb3a033ec06