### PR TITLE
Add quest creation shortcut from next steps feedback

### DIFF
--- a/components/HistoryView.tsx
+++ b/components/HistoryView.tsx
@@ -39,9 +39,14 @@ const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifa
 interface HistoryViewProps {
   onBack: () => void;
   onResumeConversation: (conversation: SavedConversation) => void;
+  onCreateQuestFromNextSteps: (improvements: string[], questTitle?: string) => void;
 }
 
-const HistoryView: React.FC<HistoryViewProps> = ({ onBack, onResumeConversation }) => {
+const HistoryView: React.FC<HistoryViewProps> = ({
+  onBack,
+  onResumeConversation,
+  onCreateQuestFromNextSteps,
+}) => {
   const [history, setHistory] = useState<SavedConversation[]>([]);
   const [selectedConversation, setSelectedConversation] = useState<SavedConversation | null>(null);
 
@@ -144,6 +149,19 @@ const HistoryView: React.FC<HistoryViewProps> = ({ onBack, onResumeConversation 
                             <li key={item}>{item}</li>
                           ))}
                         </ul>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            onCreateQuestFromNextSteps(
+                              selectedConversation.questAssessment?.improvements ?? [],
+                              selectedConversation.questTitle
+                            );
+                            setSelectedConversation(null);
+                          }}
+                          className="mt-3 inline-flex items-center text-sm font-semibold text-amber-200 hover:text-amber-100 hover:underline focus:outline-none"
+                        >
+                          Turn next steps into a new quest
+                        </button>
                       </div>
                     )}
                   </div>

--- a/components/QuestCreator.tsx
+++ b/components/QuestCreator.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { GoogleGenAI, Type } from '@google/genai';
 import type { Character, PersonaData, Quest } from '../types';
 import { AMBIENCE_LIBRARY, AVAILABLE_VOICES } from '../constants';
@@ -18,6 +18,7 @@ interface QuestCreatorProps {
   onBack: () => void;
   onQuestReady: (quest: Quest, character: Character) => void;
   onCharacterCreated: (character: Character) => void;
+  initialGoal?: string;
 }
 
 /** Pretty, branded SVG fallback if portrait generation fails */
@@ -52,12 +53,17 @@ const QuestCreator: React.FC<QuestCreatorProps> = ({
   onBack,
   onQuestReady,
   onCharacterCreated,
+  initialGoal,
 }) => {
-  const [goal, setGoal] = useState('');
+  const [goal, setGoal] = useState(initialGoal ?? '');
   const [prefs, setPrefs] = useState({ difficulty: 'auto', style: 'auto', time: 'auto' });
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState('');
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setGoal(initialGoal ?? '');
+  }, [initialGoal]);
 
   const findCharacterByName = (name: string): Character | null => {
     const lower = name.trim().toLowerCase();


### PR DESCRIPTION
## Summary
- allow opening the quest creator with goals seeded from quest feedback next steps
- add quick actions on the dashboard and history detail views to convert next steps into a new quest
- ensure the quest creator goal field reflects the seeded guidance when launching follow-up quests

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e080a5e588832fbfab7468767c58cb