### PR TITLE
Add follow-up quest creation from mentor feedback

### DIFF
--- a/components/HistoryView.tsx
+++ b/components/HistoryView.tsx
@@ -39,9 +39,17 @@ const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifa
 interface HistoryViewProps {
   onBack: () => void;
   onResumeConversation: (conversation: SavedConversation) => void;
+  onCreateQuestFromNextSteps: (
+    steps: string[],
+    context?: { questTitle?: string; characterName?: string }
+  ) => void;
 }
 
-const HistoryView: React.FC<HistoryViewProps> = ({ onBack, onResumeConversation }) => {
+const HistoryView: React.FC<HistoryViewProps> = ({
+  onBack,
+  onResumeConversation,
+  onCreateQuestFromNextSteps,
+}) => {
   const [history, setHistory] = useState<SavedConversation[]>([]);
   const [selectedConversation, setSelectedConversation] = useState<SavedConversation | null>(null);
 
@@ -144,6 +152,18 @@ const HistoryView: React.FC<HistoryViewProps> = ({ onBack, onResumeConversation 
                             <li key={item}>{item}</li>
                           ))}
                         </ul>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            onCreateQuestFromNextSteps(selectedConversation.questAssessment!.improvements, {
+                              questTitle: selectedConversation.questTitle,
+                              characterName: selectedConversation.characterName,
+                            })
+                          }
+                          className="mt-3 inline-flex items-center gap-2 rounded-lg border border-amber-500/50 bg-amber-900/30 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-amber-100 hover:bg-amber-800/40"
+                        >
+                          Build a follow-up quest
+                        </button>
                       </div>
                     )}
                   </div>

--- a/components/QuestCreator.tsx
+++ b/components/QuestCreator.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { GoogleGenAI, Type } from '@google/genai';
 import type { Character, PersonaData, Quest } from '../types';
 import { AMBIENCE_LIBRARY, AVAILABLE_VOICES } from '../constants';
@@ -18,6 +18,7 @@ interface QuestCreatorProps {
   onBack: () => void;
   onQuestReady: (quest: Quest, character: Character) => void;
   onCharacterCreated: (character: Character) => void;
+  initialGoal?: string;
 }
 
 /** Pretty, branded SVG fallback if portrait generation fails */
@@ -52,12 +53,18 @@ const QuestCreator: React.FC<QuestCreatorProps> = ({
   onBack,
   onQuestReady,
   onCharacterCreated,
+  initialGoal,
 }) => {
-  const [goal, setGoal] = useState('');
+  const [goal, setGoal] = useState(initialGoal ?? '');
   const [prefs, setPrefs] = useState({ difficulty: 'auto', style: 'auto', time: 'auto' });
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const hasPrefilledGoal = Boolean(initialGoal && initialGoal.trim());
+
+  useEffect(() => {
+    setGoal(initialGoal ?? '');
+  }, [initialGoal]);
 
   const findCharacterByName = (name: string): Character | null => {
     const lower = name.trim().toLowerCase();
@@ -368,6 +375,12 @@ Return JSON with:
         {error && (
           <div className="bg-red-900/50 border border-red-700 text-red-300 p-3 rounded-lg mb-6">
             {error}
+          </div>
+        )}
+
+        {hasPrefilledGoal && !error && (
+          <div className="mb-4 rounded-lg border border-teal-700 bg-teal-900/40 p-3 text-sm text-teal-100">
+            Loaded from your mentor's next steps. Refine or add details before generating the follow-up quest.
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- add a formatter that seeds the quest creator with a goal derived from quest review next steps
- surface "turn into a quest" actions on the home recap card and the history detail view so next steps can launch the quest creator
- let the quest creator accept an initial goal and show a note when the form is prefilled by mentor feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e080a5e588832fbfab7468767c58cb