### PR TITLE
feat: seed quest creator from next steps

### DIFF
--- a/components/HistoryView.tsx
+++ b/components/HistoryView.tsx
@@ -39,9 +39,14 @@ const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifa
 interface HistoryViewProps {
   onBack: () => void;
   onResumeConversation: (conversation: SavedConversation) => void;
+  onCreateQuestFromNextSteps: (options: {
+    improvements: string[];
+    questTitle?: string | null;
+    mentorName?: string | null;
+  }) => void;
 }
 
-const HistoryView: React.FC<HistoryViewProps> = ({ onBack, onResumeConversation }) => {
+const HistoryView: React.FC<HistoryViewProps> = ({ onBack, onResumeConversation, onCreateQuestFromNextSteps }) => {
   const [history, setHistory] = useState<SavedConversation[]>([]);
   const [selectedConversation, setSelectedConversation] = useState<SavedConversation | null>(null);
 
@@ -144,6 +149,18 @@ const HistoryView: React.FC<HistoryViewProps> = ({ onBack, onResumeConversation 
                             <li key={item}>{item}</li>
                           ))}
                         </ul>
+                        <button
+                          onClick={() =>
+                            onCreateQuestFromNextSteps({
+                              improvements: selectedConversation.questAssessment?.improvements ?? [],
+                              questTitle: selectedConversation.questTitle,
+                              mentorName: selectedConversation.characterName,
+                            })
+                          }
+                          className="mt-3 inline-flex items-center justify-center rounded-lg bg-amber-600/90 px-4 py-2 text-sm font-semibold text-black transition-colors hover:bg-amber-500"
+                        >
+                          Turn next steps into a new quest
+                        </button>
                       </div>
                     )}
                   </div>

--- a/components/QuestCreator.tsx
+++ b/components/QuestCreator.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { GoogleGenAI, Type } from '@google/genai';
 import type { Character, PersonaData, Quest } from '../types';
 import { AMBIENCE_LIBRARY, AVAILABLE_VOICES } from '../constants';
@@ -18,6 +18,7 @@ interface QuestCreatorProps {
   onBack: () => void;
   onQuestReady: (quest: Quest, character: Character) => void;
   onCharacterCreated: (character: Character) => void;
+  seedGoal?: string | null;
 }
 
 /** Pretty, branded SVG fallback if portrait generation fails */
@@ -52,12 +53,21 @@ const QuestCreator: React.FC<QuestCreatorProps> = ({
   onBack,
   onQuestReady,
   onCharacterCreated,
+  seedGoal,
 }) => {
   const [goal, setGoal] = useState('');
   const [prefs, setPrefs] = useState({ difficulty: 'auto', style: 'auto', time: 'auto' });
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState('');
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (seedGoal !== undefined) {
+      setGoal(seedGoal ?? '');
+    }
+  }, [seedGoal]);
+
+  const hasSeedGoal = Boolean(seedGoal && seedGoal.trim());
 
   const findCharacterByName = (name: string): Character | null => {
     const lower = name.trim().toLowerCase();
@@ -368,6 +378,12 @@ Return JSON with:
         {error && (
           <div className="bg-red-900/50 border border-red-700 text-red-300 p-3 rounded-lg mb-6">
             {error}
+          </div>
+        )}
+
+        {hasSeedGoal && (
+          <div className="mb-4 rounded-lg border border-amber-700 bg-amber-900/40 p-3 text-sm text-amber-100">
+            Loaded next steps from your quest feedback. Edit the goal below if you want to refine the focus.
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- add a follow-up action on the landing quest review card that funnels "Next Steps" feedback into the quest creator
- wire conversation history quest reviews with a shortcut to spawn a new quest from their improvement bullets
- update the quest creator to accept pre-seeded goals, reset between launches, and surface a banner when feedback is loaded

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e080a5e588832fbfab7468767c58cb