### PR TITLE
feat: add gender metadata to voice catalog

### DIFF
--- a/components/CharacterCreator.tsx
+++ b/components/CharacterCreator.tsx
@@ -127,6 +127,9 @@ If you are not at least 80% confident in their historicity, set verified to fals
       setMsg('Researching historical figure…');
 
       const availableAmbienceTags = AMBIENCE_LIBRARY.map(a => a.tag).join(', ');
+      const voiceOptions = AVAILABLE_VOICES.map(
+        voice => `${voice.name} (${voice.gender}; ${voice.description})`
+      ).join('; ');
       const personaPrompt = `Based on the historical figure "${clean}", return JSON with:
 
         - title: A concise, descriptive title (e.g., The Father of Modern Physics).
@@ -137,7 +140,7 @@ If you are not at least 80% confident in their historicity, set verified to fals
         - passion: A short phrase describing their core motivation or passion.
         - systemInstruction: act as mentor; emphasize Socratic prompts; may call changeEnvironment() or displayArtifact() as function-only lines. The prompt must also specify a distinct, authentic-sounding accent based on their origin. The tone should match their personality.
         - suggestedPrompts: Three engaging, open-ended questions a user could ask this character. At least one should suggest using a visual ability (e.g., "Take me to...", "Show me...").
-        - voiceName: Based on their personality and historical context, suggest the most suitable voice from this list: ${AVAILABLE_VOICES.join(', ')}. Return only the name of the voice.
+        - voiceName: Based on their personality and historical context, suggest the most suitable voice from this list: ${voiceOptions}. Return only the name of the voice.
         - ambienceTag: Based on the character's typical environment, select the most fitting keyword from this list: ${availableAmbienceTags}.`;
 
       const personaResp = await ai.models.generateContent({

--- a/components/QuestCreator.tsx
+++ b/components/QuestCreator.tsx
@@ -76,6 +76,9 @@ const QuestCreator: React.FC<QuestCreatorProps> = ({
     const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
 
     const availableAmbienceTags = AMBIENCE_LIBRARY.map(a => a.tag).join(', ');
+    const voiceOptions = AVAILABLE_VOICES.map(
+      voice => `${voice.name} (${voice.gender}; ${voice.description})`
+    ).join('; ');
     const personaPrompt = `Based on the historical figure "${name}", return JSON with:
 - title: A concise, descriptive title (e.g., The Father of Modern Physics).
         - bio: A short, engaging biography in the first person.
@@ -85,7 +88,7 @@ const QuestCreator: React.FC<QuestCreatorProps> = ({
         - passion: A short phrase describing their core motivation or passion.
         - systemInstruction: act as mentor; emphasize Socratic prompts; may call changeEnvironment() or displayArtifact() as function-only lines. The prompt must also specify a distinct, authentic-sounding accent based on their origin. The tone should match their personality.
         - suggestedPrompts: Three engaging, open-ended questions a user could ask this character. At least one should suggest using a visual ability (e.g., "Take me to...", "Show me...").
-        - voiceName: Based on their personality and historical context, suggest the most suitable voice from this list: ${AVAILABLE_VOICES.join(', ')}. Return only the name of the voice.
+        - voiceName: Based on their personality and historical context, suggest the most suitable voice from this list: ${voiceOptions}. Return only the name of the voice.
         - ambienceTag: Based on the character's typical environment, select the most fitting keyword from this list: ${availableAmbienceTags}.`;
 
     const personaResp = await ai.models.generateContent({

--- a/constants.ts
+++ b/constants.ts
@@ -1,6 +1,32 @@
-import type { Character, Ambience, Quest } from './types';
+import type { Character, Ambience, Quest, VoiceProfile } from './types';
 
-export const AVAILABLE_VOICES = ['Zephyr', 'Puck', 'Charon', 'Kore', 'Fenrir'];
+export const AVAILABLE_VOICES: VoiceProfile[] = [
+  {
+    name: 'Zephyr',
+    gender: 'female',
+    description: 'an airy, expressive contralto suited to Hellenistic heroines',
+  },
+  {
+    name: 'Puck',
+    gender: 'male',
+    description: 'a warm, charismatic baritone with Renaissance Italian energy',
+  },
+  {
+    name: 'Charon',
+    gender: 'male',
+    description: 'a measured, resonant bass evoking classical Greek philosophers',
+  },
+  {
+    name: 'Kore',
+    gender: 'female',
+    description: 'a poised, upper-class English mezzo ideal for 19th-century scholars',
+  },
+  {
+    name: 'Fenrir',
+    gender: 'male',
+    description: 'a steady, authoritative tenor with continental European gravitas',
+  },
+];
 
 export const AMBIENCE_LIBRARY: Ambience[] = [
   {

--- a/tests/components/ConversationView.test.tsx
+++ b/tests/components/ConversationView.test.tsx
@@ -10,7 +10,9 @@ vi.mock('../../constants', () => ({
         { tag: 'agora', audioSrc: 'agora.mp3' },
         { tag: 'forest', audioSrc: 'forest.mp3' },
     ],
-    AVAILABLE_VOICES: ['socrates-voice'],
+    AVAILABLE_VOICES: [
+        { name: 'socrates-voice', gender: 'male', description: 'a thoughtful male timbre' },
+    ],
 }));
 
 const mockGenerateContent = vi.fn();

--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,10 @@
 
+export interface VoiceProfile {
+  name: string;
+  gender: 'male' | 'female';
+  description: string;
+}
+
 export interface Ambience {
   tag: string;
   description: string;


### PR DESCRIPTION
## Summary
- attach gender-aware metadata to the voice catalog so downstream prompts can reason about male and female options
- update persona generation prompts in the character and quest creators to surface the enriched voice descriptions
- adjust the ConversationView test shim to mock the new voice profile structure

## Testing
- npm run test

fixes https://github.com/School-of-the-Ancients/sota-beta/issues/103

------
https://chatgpt.com/codex/tasks/task_e_68e2083d58f4832f9f2189c289266615