### PR TITLE
feat: add quest completion guidance to mentor

### DIFF
--- a/hooks/useGeminiLive.ts
+++ b/hooks/useGeminiLive.ts
@@ -199,7 +199,19 @@ export const useGeminiLive = (
 
             let finalSystemInstruction = baseInstruction;
             if (activeQuest) {
-                finalSystemInstruction = `YOUR CURRENT MISSION: As a mentor, your primary goal is to guide the student to understand the following: "${activeQuest.objective}". Tailor your questions and explanations to lead them towards this goal.\n\n---\n\n${baseInstruction}`;
+                const focusChecklist = activeQuest.focusPoints
+                    .map((point, index) => `${index + 1}. ${point}`)
+                    .join('\n');
+
+                const questGuidanceSections = [
+                    `YOUR CURRENT MISSION: As a mentor, your primary goal is to guide the student to understand the following learning objective: "${activeQuest.objective}". Tailor your questions and explanations to lead them towards this goal.`,
+                    focusChecklist
+                        ? `QUEST ROADMAP: These are the specific focus areas you must cover and reference during the session. Mark your progress aloud so the student knows what has been explored and what remains:\n${focusChecklist}`
+                        : null,
+                    'QUEST COMPLETION PROTOCOL:\n- Throughout the session, explicitly acknowledge when a focus area has been covered and remind the student of the remaining items.\n- Once all focus areas have been addressed, conduct a brief "Quest Completion Check"—ask 2-3 targeted verbal quiz questions or mini-scenarios that confirm the student can articulate the learning objective.\n- After the check, clearly declare whether the quest is complete. If it is, celebrate completion and summarize the mastered focus areas. If not, specify which focus areas or ideas still need attention and guide the student back through them.'
+                ].filter(Boolean);
+
+                finalSystemInstruction = `${questGuidanceSections.join('\n\n')}\n\n---\n\n${baseInstruction}`;
             }
 
             const sessionPromise = ai.live.connect({

--- a/tests/hooks/useGeminiLive.test.ts
+++ b/tests/hooks/useGeminiLive.test.ts
@@ -187,6 +187,33 @@ describe('useGeminiLive', () => {
         expect(mockLiveSession.sendToolResponse).toHaveBeenCalled();
     });
 
+    it('augments the system instruction with quest roadmap and completion protocol', async () => {
+        renderHook(() =>
+            useGeminiLive(
+                'base-instruction',
+                'test-voice',
+                'en-US',
+                mockOnTurnComplete,
+                mockOnEnvironmentChangeRequest,
+                mockOnArtifactDisplayRequest,
+                mockQuest,
+            ),
+        );
+
+        await waitFor(() => {
+            expect(mockConnect).toHaveBeenCalled();
+        });
+
+        const latestCall = mockConnect.mock.calls[mockConnect.mock.calls.length - 1];
+        const { config } = latestCall[0];
+        expect(config.systemInstruction).toContain(mockQuest.objective);
+        mockQuest.focusPoints.forEach((point) => {
+            expect(config.systemInstruction).toContain(point);
+        });
+        expect(config.systemInstruction).toContain('Quest Completion Check');
+        expect(config.systemInstruction).toContain('QUEST ROADMAP');
+    });
+
     it('should toggle microphone and update connection state', async () => {
         const { result } = renderHook(() =>
             useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)


### PR DESCRIPTION
## Summary
- teach Gemini Live quests to call out focus-point progress, run a short verbal quiz, and declare completion when goals are met
- add a regression test that asserts quest sessions include the roadmap and completion protocol in their system instructions

## Testing
- npm run test

## Related Issues
- Closes #109

## Environment
- No changes

------
https://chatgpt.com/codex/tasks/task_e_68e20e2edb8c832fa1450d38edcd2277