### PR TITLE
feat: auto extend live sessions beyond 10 minutes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "v2-school-of-the-ancients",
       "version": "0.0.0",
       "dependencies": {
-        "@google/genai": "^1.21.0",
+        "@google/genai": "^1.22.0",
         "@supabase/supabase-js": "^2.58.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
@@ -985,9 +985,9 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.21.0.tgz",
-      "integrity": "sha512-k47DECR8BF9z7IJxQd3reKuH2eUnOH5NlJWSe+CKM6nbXx+wH3hmtWQxUQR9M8gzWW1EvFuRVgjQssEIreNZsw==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.22.0.tgz",
+      "integrity": "sha512-siETS3zTm3EGpTT4+BFc1z20xXBYfueD3gCYfxkOjuAKRk8lt8TJevDHi3zepn1oSI6NhG/LZvy0i+Q3qheObg==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.14.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@google/genai": "^1.21.0",
+    "@google/genai": "^1.22.0",
     "@supabase/supabase-js": "^2.58.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"


### PR DESCRIPTION
## Summary
- upgrade `@google/genai` to 1.22.0 to access the latest live session controls
- add automatic session resumption handling so goAway warnings trigger a reconnect and extend conversations past 10 minutes
- cover the session extension path with a dedicated unit test for the hook

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e2c3c0d43c832f823b8cc2d715dda8