### PR TITLE
Implement automatic Gemini Live session extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "v2-school-of-the-ancients",
       "version": "0.0.0",
       "dependencies": {
-        "@google/genai": "^1.21.0",
+        "@google/genai": "^1.22.0",
         "@supabase/supabase-js": "^2.58.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
@@ -985,9 +985,9 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.21.0.tgz",
-      "integrity": "sha512-k47DECR8BF9z7IJxQd3reKuH2eUnOH5NlJWSe+CKM6nbXx+wH3hmtWQxUQR9M8gzWW1EvFuRVgjQssEIreNZsw==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.22.0.tgz",
+      "integrity": "sha512-siETS3zTm3EGpTT4+BFc1z20xXBYfueD3gCYfxkOjuAKRk8lt8TJevDHi3zepn1oSI6NhG/LZvy0i+Q3qheObg==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.14.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@google/genai": "^1.21.0",
+    "@google/genai": "^1.22.0",
     "@supabase/supabase-js": "^2.58.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"


### PR DESCRIPTION
## Summary
- enable session resumption for Gemini Live calls and capture goAway warnings to detect impending session expiry
- add an automatic reconnection path that reuses the latest resumption handle to extend conversations beyond ten minutes while preserving mic state
- bump `@google/genai` to v1.22.0 to access the session resumption features used for extension

## Related Issues
- Fixes #105

## Environment Variables
- None

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68e2c3c0d43c832f823b8cc2d715dda8