### PR TITLE
feat: announce quest completion and deliver mastery quiz

### DIFF
--- a/hooks/useGeminiLive.ts
+++ b/hooks/useGeminiLive.ts
@@ -273,7 +273,33 @@ export const useGeminiLive = (
 
             let finalSystemInstruction = baseInstruction;
             if (activeQuest) {
-                finalSystemInstruction = `YOUR CURRENT MISSION: As a mentor, your primary goal is to guide the student to understand the following: "${activeQuest.objective}". Tailor your questions and explanations to lead them towards this goal.\n\n---\n\n${baseInstruction}`;
+                const focusPointsList = (activeQuest.focusPoints ?? [])
+                    .map((point, index) => `${index + 1}. ${point}`)
+                    .join('\n');
+
+                const questHeader = `YOUR CURRENT MISSION: As a mentor, your primary goal is to guide the student to understand the following: "${activeQuest.objective}". Tailor your questions and explanations to lead them towards this goal.`;
+
+                const questFocusSection = focusPointsList
+                    ? `QUEST FOCUS POINTS:\n${focusPointsList}`
+                    : '';
+
+                const questCompletionProtocol = [
+                    'QUEST COMPLETION PROTOCOL:',
+                    '1. Actively keep track of each focus point above and guide the learner through all of them during the quest.',
+                    '2. As soon as every focus point has been covered and the learner demonstrates understanding (or requests to finish), pause instruction and clearly say that the quest curriculum is complete before continuing.',
+                    '3. Immediately transition into a short 3-question mastery quiz that checks the quest objective and focus points. Ask one question at a time, wait for the learner’s answer, and adapt follow-up questions if they struggle.',
+                    '4. After the quiz, deliver supportive feedback summarizing their performance, reinforce any corrections, and invite them to reflect or request the next quest. Do not introduce new curriculum material unless they explicitly ask for it.',
+                ].join('\n');
+
+                finalSystemInstruction = [
+                    questHeader,
+                    questFocusSection,
+                    questCompletionProtocol,
+                    '---',
+                    baseInstruction,
+                ]
+                    .filter(section => section && section.trim().length > 0)
+                    .join('\n\n');
             }
 
             const sessionResumptionConfig: SessionResumptionConfig = {};

--- a/tests/hooks/useGeminiLive.test.ts
+++ b/tests/hooks/useGeminiLive.test.ts
@@ -269,5 +269,8 @@ describe('useGeminiLive', () => {
 
         expect(systemInstruction).toContain(mockQuest.objective);
         expect(systemInstruction).toContain('system-instruction');
+        expect(systemInstruction).toContain('QUEST COMPLETION PROTOCOL');
+        expect(systemInstruction).toContain('3-question mastery quiz');
+        expect(systemInstruction).toContain('Asking questions');
     });
 });


### PR DESCRIPTION
## Summary
- expand quest-specific system prompts to list focus points and require explicit curriculum completion announcements followed by a mastery quiz
- verify quest prompts mention the completion protocol, quiz requirement, and focus points in the Gemini Live hook tests

## Testing
- npm test

## Related Issues
- Resolves #109
- Resolves #110

------
https://chatgpt.com/codex/tasks/task_e_68e2dfb53aac832f9297c530fdb46b7c