### PR TITLE
feat: enforce default language selection for conversations

### DIFF
--- a/App.test.tsx
+++ b/App.test.tsx
@@ -107,6 +107,10 @@ describe('App', () => {
       portraitUrl: 'http://example.com/portrait.png',
       ambienceTag: 'none',
       suggestedPrompts: [],
+      bio: 'A test persona for unit tests.',
+      timeframe: 'timeless',
+      expertise: 'testing',
+      passion: 'ensuring quality',
     };
 
     // Set up localStorage with the custom character

--- a/App.tsx
+++ b/App.tsx
@@ -21,7 +21,7 @@ import QuestIcon from './components/icons/QuestIcon';
 import QuestCreator from './components/QuestCreator'; // NEW
 import QuestQuiz from './components/QuestQuiz';
 
-import { CHARACTERS, QUESTS } from './constants';
+import { CHARACTERS, QUESTS, DEFAULT_LANGUAGE_CODE } from './constants';
 
 const CUSTOM_CHARACTERS_KEY = 'school-of-the-ancients-custom-characters';
 const HISTORY_KEY = 'school-of-the-ancients-history';
@@ -29,6 +29,7 @@ const COMPLETED_QUESTS_KEY = 'school-of-the-ancients-completed-quests';
 const CUSTOM_QUESTS_KEY = 'school-of-the-ancients-custom-quests';
 const ACTIVE_QUEST_KEY = 'school-of-the-ancients-active-quest-id';
 const LAST_QUIZ_RESULT_KEY = 'school-of-the-ancients-last-quiz-result';
+const PREFERRED_LANGUAGE_KEY = 'school-of-the-ancients-preferred-language';
 
 // ---- Local storage helpers -------------------------------------------------
 
@@ -136,6 +137,24 @@ const saveActiveQuestId = (questId: string | null) => {
   }
 };
 
+const loadPreferredLanguageCode = (): string => {
+  try {
+    const stored = localStorage.getItem(PREFERRED_LANGUAGE_KEY);
+    return stored || DEFAULT_LANGUAGE_CODE;
+  } catch (error) {
+    console.error('Failed to load preferred language:', error);
+    return DEFAULT_LANGUAGE_CODE;
+  }
+};
+
+const savePreferredLanguageCode = (code: string) => {
+  try {
+    localStorage.setItem(PREFERRED_LANGUAGE_KEY, code);
+  } catch (error) {
+    console.error('Failed to persist preferred language:', error);
+  }
+};
+
 const updateCharacterQueryParam = (characterId: string, mode: 'push' | 'replace') => {
   try {
     const params = new URLSearchParams(window.location.search);
@@ -168,6 +187,12 @@ const App: React.FC = () => {
   const [environmentImageUrl, setEnvironmentImageUrl] = useState<string | null>(null);
   const [activeQuest, setActiveQuest] = useState<Quest | null>(null);
   const [resumeConversationId, setResumeConversationId] = useState<string | null>(null);
+  const [preferredLanguageCode, setPreferredLanguageCode] = useState<string>(() => {
+    if (typeof window === 'undefined') {
+      return DEFAULT_LANGUAGE_CODE;
+    }
+    return loadPreferredLanguageCode();
+  });
 
   // end-conversation save/AI-eval flag
   const [isSaving, setIsSaving] = useState(false);
@@ -233,6 +258,10 @@ const App: React.FC = () => {
       return current;
     });
   }, [customQuests, customCharacters]);
+
+  useEffect(() => {
+    savePreferredLanguageCode(preferredLanguageCode);
+  }, [preferredLanguageCode]);
 
   const syncQuestProgress = useCallback(() => {
     const history = loadConversations();
@@ -752,6 +781,8 @@ Focus only on the student's contributions. Mark passed=true only if the learner 
             activeQuest={activeQuest}
             isSaving={isSaving} // pass saving state
             resumeConversationId={resumeConversationId}
+            preferredLanguageCode={preferredLanguageCode}
+            onPreferredLanguageChange={setPreferredLanguageCode}
           />
         ) : null;
       case 'history':

--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -4,7 +4,7 @@ import type { Character, ConversationTurn, SavedConversation, Quest } from '../t
 import { useGeminiLive } from '../hooks/useGeminiLive';
 import { useAmbientAudio } from '../hooks/useAmbientAudio';
 import { ConnectionState } from '../types';
-import { AMBIENCE_LIBRARY } from '../constants';
+import { AMBIENCE_LIBRARY, SUPPORTED_LANGUAGES } from '../constants';
 import MicrophoneIcon from './icons/MicrophoneIcon';
 import MicrophoneOffIcon from './icons/MicrophoneOffIcon';
 import WaveformIcon from './icons/WaveformIcon';
@@ -23,6 +23,8 @@ interface ConversationViewProps {
   activeQuest: Quest | null;
   isSaving: boolean;
   resumeConversationId?: string | null;
+  preferredLanguageCode: string;
+  onPreferredLanguageChange: (code: string) => void;
 }
 
 const loadConversations = (): SavedConversation[] => {
@@ -108,6 +110,8 @@ const ConversationView: React.FC<ConversationViewProps> = ({
   activeQuest,
   isSaving,
   resumeConversationId,
+  preferredLanguageCode,
+  onPreferredLanguageChange,
 }) => {
   const [transcript, setTranscript] = useState<ConversationTurn[]>([]);
   const [textInput, setTextInput] = useState('');
@@ -115,6 +119,17 @@ const ConversationView: React.FC<ConversationViewProps> = ({
   const [isFetchingSuggestions, setIsFetchingSuggestions] = useState(false);
   const [isGeneratingVisual, setIsGeneratingVisual] = useState(false);
   const [generationMessage, setGenerationMessage] = useState('');
+  const selectedLanguage = useMemo(
+    () => SUPPORTED_LANGUAGES.find((option) => option.code === preferredLanguageCode),
+    [preferredLanguageCode],
+  );
+  const selectedLanguageLabel = selectedLanguage?.label ?? 'English (United States)';
+  const handleLanguageChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      onPreferredLanguageChange(event.target.value);
+    },
+    [onPreferredLanguageChange],
+  );
 
   const initialAudioSrc = AMBIENCE_LIBRARY.find(a => a.tag === character.ambienceTag)?.audioSrc ?? null;
   const { isMuted: isAmbienceMuted, toggleMute: toggleAmbienceMute, changeTrack: changeAmbienceTrack } = useAmbientAudio(initialAudioSrc);
@@ -422,6 +437,8 @@ const ConversationView: React.FC<ConversationViewProps> = ({
     character.systemInstruction,
     character.voiceName,
     character.voiceAccent,
+    preferredLanguageCode,
+    selectedLanguageLabel,
     handleTurnComplete,
     handleEnvironmentChange,
     handleArtifactDisplay,
@@ -574,7 +591,28 @@ ${contextTranscript}
             </div>
             <h2 className="text-2xl sm:text-3xl font-bold text-amber-200 mt-8">{character.name}</h2>
             <p className="text-gray-400 italic">{character.title}</p>
-            
+
+            <div className="mt-6 w-full max-w-xs text-left">
+              <label htmlFor="language-select" className="block text-sm font-semibold text-amber-200 mb-2">
+                Preferred language
+              </label>
+              <select
+                id="language-select"
+                value={preferredLanguageCode}
+                onChange={handleLanguageChange}
+                className="w-full bg-gray-800/70 border border-gray-600 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-400"
+              >
+                {SUPPORTED_LANGUAGES.map((option) => (
+                  <option key={option.code} value={option.code}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <p className="mt-2 text-xs text-gray-400">
+                Responses and transcripts stay in {selectedLanguageLabel} unless you ask otherwise.
+              </p>
+            </div>
+
             {activeQuest && (
                 <div className="mt-4 p-4 w-full max-w-xs bg-amber-900/40 border border-amber-800/80 rounded-lg text-left animate-fade-in space-y-3">
                     <div>

--- a/constants.ts
+++ b/constants.ts
@@ -1,5 +1,27 @@
 import type { Character, Ambience, Quest, VoiceProfile } from './types';
 
+// Default spoken language matches the transcription and synthesis defaults for Gemini Live.
+export const DEFAULT_LANGUAGE_CODE = 'en-US';
+
+// Supported language codes follow the Gemini Live and Chirp 3 HD language availability docs.
+// https://cloud.google.com/text-to-speech/docs/chirp3-hd#language_availability
+// https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash#live-api-native-audio
+export const SUPPORTED_LANGUAGES = [
+  { code: 'en-US', label: 'English (United States)' },
+  { code: 'en-GB', label: 'English (United Kingdom)' },
+  { code: 'en-AU', label: 'English (Australia)' },
+  { code: 'es-ES', label: 'Spanish (Spain)' },
+  { code: 'es-US', label: 'Spanish (United States)' },
+  { code: 'fr-FR', label: 'French (France)' },
+  { code: 'de-DE', label: 'German (Germany)' },
+  { code: 'it-IT', label: 'Italian (Italy)' },
+  { code: 'pt-BR', label: 'Portuguese (Brazil)' },
+  { code: 'pt-PT', label: 'Portuguese (Portugal)' },
+  { code: 'hi-IN', label: 'Hindi (India)' },
+  { code: 'ja-JP', label: 'Japanese (Japan)' },
+  { code: 'ko-KR', label: 'Korean (South Korea)' },
+];
+
 // Voice metadata mirrors the Chirp 3: HD voice catalog genders published by Google.
 // https://cloud.google.com/text-to-speech/docs/chirp3-hd#voice_options
 export const AVAILABLE_VOICES: VoiceProfile[] = [

--- a/tests/hooks/useGeminiLive.test.ts
+++ b/tests/hooks/useGeminiLive.test.ts
@@ -88,7 +88,7 @@ describe('useGeminiLive', () => {
 
     it('should initialize with CONNECTING state and transition to LISTENING', async () => {
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', 'en-US', 'English (United States)', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         expect(result.current.connectionState).toBe(ConnectionState.CONNECTING);
@@ -102,7 +102,7 @@ describe('useGeminiLive', () => {
 
     it('should handle sending a text message', async () => {
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', 'en-US', 'English (United States)', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -130,7 +130,7 @@ describe('useGeminiLive', () => {
         });
 
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', 'en-US', 'English (United States)', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await act(async () => {
@@ -171,7 +171,7 @@ describe('useGeminiLive', () => {
         });
 
         renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', 'en-US', 'English (United States)', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await act(async () => {
@@ -189,7 +189,7 @@ describe('useGeminiLive', () => {
 
     it('should toggle microphone and update connection state', async () => {
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', 'en-US', 'English (United States)', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -214,7 +214,7 @@ describe('useGeminiLive', () => {
 
     it('should handle disconnect properly', async () => {
         const { result, unmount } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', 'en-US', 'English (United States)', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -241,7 +241,7 @@ describe('useGeminiLive', () => {
         });
 
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', 'en-US', 'English (United States)', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -257,7 +257,7 @@ describe('useGeminiLive', () => {
 
     it('should include quest objective in system instructions if a quest is active', async () => {
         renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, mockQuest)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', 'en-US', 'English (United States)', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, mockQuest)
         );
 
         await waitFor(() => {
@@ -269,5 +269,8 @@ describe('useGeminiLive', () => {
 
         expect(systemInstruction).toContain(mockQuest.objective);
         expect(systemInstruction).toContain('system-instruction');
+        expect(lastCall[0].config.inputAudioTranscription).toEqual(expect.objectContaining({ languageCode: 'en-US' }));
+        expect(lastCall[0].config.outputAudioTranscription).toEqual(expect.objectContaining({ languageCode: 'en-US' }));
+        expect(lastCall[0].config.speechConfig?.languageCode).toBe('en-US');
     });
 });


### PR DESCRIPTION
## Summary
- add a supported language catalog and persist the user’s preferred live session language
- update the conversation view and Gemini hook to honor the selected language for speech, transcription, and system prompts
- extend component and hook tests to cover the new language selection behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2eab6fcac832f9cd8f7dc8426d723