### PR TITLE
Add configurable language selection for live conversations

### DIFF
--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -4,7 +4,7 @@ import type { Character, ConversationTurn, SavedConversation, Quest } from '../t
 import { useGeminiLive } from '../hooks/useGeminiLive';
 import { useAmbientAudio } from '../hooks/useAmbientAudio';
 import { ConnectionState } from '../types';
-import { AMBIENCE_LIBRARY } from '../constants';
+import { AMBIENCE_LIBRARY, SUPPORTED_LANGUAGES } from '../constants';
 import MicrophoneIcon from './icons/MicrophoneIcon';
 import MicrophoneOffIcon from './icons/MicrophoneOffIcon';
 import WaveformIcon from './icons/WaveformIcon';
@@ -23,6 +23,8 @@ interface ConversationViewProps {
   activeQuest: Quest | null;
   isSaving: boolean;
   resumeConversationId?: string | null;
+  languageCode: string;
+  onLanguageChange: (code: string) => void;
 }
 
 const loadConversations = (): SavedConversation[] => {
@@ -108,6 +110,8 @@ const ConversationView: React.FC<ConversationViewProps> = ({
   activeQuest,
   isSaving,
   resumeConversationId,
+  languageCode,
+  onLanguageChange,
 }) => {
   const [transcript, setTranscript] = useState<ConversationTurn[]>([]);
   const [textInput, setTextInput] = useState('');
@@ -422,6 +426,7 @@ const ConversationView: React.FC<ConversationViewProps> = ({
     character.systemInstruction,
     character.voiceName,
     character.voiceAccent,
+    languageCode,
     handleTurnComplete,
     handleEnvironmentChange,
     handleArtifactDisplay,
@@ -574,7 +579,28 @@ ${contextTranscript}
             </div>
             <h2 className="text-2xl sm:text-3xl font-bold text-amber-200 mt-8">{character.name}</h2>
             <p className="text-gray-400 italic">{character.title}</p>
-            
+
+            <div className="mt-6 w-full max-w-xs text-left">
+                <label htmlFor="language-select" className="block text-sm font-semibold text-amber-200 mb-2">
+                    Speech language
+                </label>
+                <select
+                    id="language-select"
+                    value={languageCode}
+                    onChange={(event) => onLanguageChange(event.target.value)}
+                    className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-amber-400"
+                >
+                    {SUPPORTED_LANGUAGES.map((language) => (
+                        <option key={language.code} value={language.code}>
+                            {language.label}
+                        </option>
+                    ))}
+                </select>
+                <p className="mt-1 text-xs text-gray-400">
+                    Controls both transcription and the character&apos;s spoken responses.
+                </p>
+            </div>
+
             {activeQuest && (
                 <div className="mt-4 p-4 w-full max-w-xs bg-amber-900/40 border border-amber-800/80 rounded-lg text-left animate-fade-in space-y-3">
                     <div>

--- a/constants.ts
+++ b/constants.ts
@@ -1,4 +1,4 @@
-import type { Character, Ambience, Quest, VoiceProfile } from './types';
+import type { Character, Ambience, Quest, VoiceProfile, LanguageOption } from './types';
 
 // Voice metadata mirrors the Chirp 3: HD voice catalog genders published by Google.
 // https://cloud.google.com/text-to-speech/docs/chirp3-hd#voice_options
@@ -153,6 +153,16 @@ export const AVAILABLE_VOICES: VoiceProfile[] = [
     gender: 'female',
     description: 'a sparkling soprano radiating vibrant Levantine brightness',
   },
+];
+
+export const DEFAULT_LANGUAGE_CODE = 'en-US';
+
+export const SUPPORTED_LANGUAGES: LanguageOption[] = [
+  { code: 'en-US', label: 'English (United States)' },
+  { code: 'en-GB', label: 'English (United Kingdom)' },
+  { code: 'es-ES', label: 'Spanish (Spain)' },
+  { code: 'fr-FR', label: 'French (France)' },
+  { code: 'de-DE', label: 'German (Germany)' },
 ];
 
 export const AMBIENCE_LIBRARY: Ambience[] = [

--- a/tests/components/ConversationView.test.tsx
+++ b/tests/components/ConversationView.test.tsx
@@ -13,6 +13,10 @@ vi.mock('../../constants', () => ({
     AVAILABLE_VOICES: [
         { name: 'socrates-voice', gender: 'male', description: 'a thoughtful male timbre' },
     ],
+    SUPPORTED_LANGUAGES: [
+        { code: 'en-US', label: 'English (United States)' },
+    ],
+    DEFAULT_LANGUAGE_CODE: 'en-US',
 }));
 
 const mockGenerateContent = vi.fn();
@@ -37,7 +41,7 @@ const useGeminiLiveMock = vi.fn();
 
 vi.mock('../../hooks/useGeminiLive', () => ({
   useGeminiLive: vi.fn((
-    sysInstruction, voice, accent,
+    sysInstruction, voice, accent, language,
     onTurnComplete, onEnvironmentChange, onArtifactDisplay
   ) => {
     onTurnCompleteCallback = onTurnComplete;

--- a/tests/hooks/useGeminiLive.test.ts
+++ b/tests/hooks/useGeminiLive.test.ts
@@ -88,7 +88,7 @@ describe('useGeminiLive', () => {
 
     it('should initialize with CONNECTING state and transition to LISTENING', async () => {
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', undefined, 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         expect(result.current.connectionState).toBe(ConnectionState.CONNECTING);
@@ -102,7 +102,7 @@ describe('useGeminiLive', () => {
 
     it('should handle sending a text message', async () => {
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', undefined, 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -130,7 +130,7 @@ describe('useGeminiLive', () => {
         });
 
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', undefined, 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await act(async () => {
@@ -171,7 +171,7 @@ describe('useGeminiLive', () => {
         });
 
         renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', undefined, 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await act(async () => {
@@ -189,7 +189,7 @@ describe('useGeminiLive', () => {
 
     it('should toggle microphone and update connection state', async () => {
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', undefined, 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -214,7 +214,7 @@ describe('useGeminiLive', () => {
 
     it('should handle disconnect properly', async () => {
         const { result, unmount } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', undefined, 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -241,7 +241,7 @@ describe('useGeminiLive', () => {
         });
 
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', undefined, 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -257,7 +257,7 @@ describe('useGeminiLive', () => {
 
     it('should include quest objective in system instructions if a quest is active', async () => {
         renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, mockQuest)
+            useGeminiLive('system-instruction', 'test-voice', undefined, 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, mockQuest)
         );
 
         await waitFor(() => {

--- a/types.ts
+++ b/types.ts
@@ -5,6 +5,11 @@ export interface VoiceProfile {
   description: string;
 }
 
+export interface LanguageOption {
+  code: string;
+  label: string;
+}
+
 export interface Ambience {
   tag: string;
   description: string;


### PR DESCRIPTION
## Summary
- add a reusable list of supported languages and expose a preferred language setting in app state
- surface a speech language selector in the conversation view and thread it through the Gemini live hook
- send the chosen language to Gemini for speech and transcription while updating tests for the new API

## Testing
- `npm run test`

## Screenshots
![Language selection dropdown](browser:/invocations/yyxoklba/artifacts/artifacts/language-selection.png)

Closes #107.

------
https://chatgpt.com/codex/tasks/task_e_68e2eab6fcac832f9cd8f7dc8426d723