### PR TITLE
feat: add language selector for live conversations

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -1,4 +1,17 @@
-import type { Character, Ambience, Quest, VoiceProfile } from './types';
+import type { Character, Ambience, Quest, VoiceProfile, LanguageOption } from './types';
+
+// Language availability aligns with Gemini Live + Chirp 3 HD coverage.
+// https://cloud.google.com/text-to-speech/docs/chirp3-hd#language_availability
+// https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash#live-api-native-audio
+export const SUPPORTED_LANGUAGES: LanguageOption[] = [
+  { code: 'en-US', label: 'English (United States)' },
+  { code: 'en-GB', label: 'English (United Kingdom)' },
+  { code: 'es-ES', label: 'Spanish (Spain)' },
+  { code: 'fr-FR', label: 'French (France)' },
+  { code: 'de-DE', label: 'German (Germany)' },
+];
+
+export const DEFAULT_LANGUAGE_CODE = SUPPORTED_LANGUAGES[0].code;
 
 // Voice metadata mirrors the Chirp 3: HD voice catalog genders published by Google.
 // https://cloud.google.com/text-to-speech/docs/chirp3-hd#voice_options

--- a/tests/components/ConversationView.test.tsx
+++ b/tests/components/ConversationView.test.tsx
@@ -13,6 +13,11 @@ vi.mock('../../constants', () => ({
     AVAILABLE_VOICES: [
         { name: 'socrates-voice', gender: 'male', description: 'a thoughtful male timbre' },
     ],
+    SUPPORTED_LANGUAGES: [
+        { code: 'en-US', label: 'English (United States)' },
+        { code: 'en-GB', label: 'English (United Kingdom)' },
+    ],
+    DEFAULT_LANGUAGE_CODE: 'en-US',
 }));
 
 const mockGenerateContent = vi.fn();
@@ -37,8 +42,8 @@ const useGeminiLiveMock = vi.fn();
 
 vi.mock('../../hooks/useGeminiLive', () => ({
   useGeminiLive: vi.fn((
-    sysInstruction, voice, accent,
-    onTurnComplete, onEnvironmentChange, onArtifactDisplay
+    sysInstruction, voice, accent, languageCode,
+    onTurnComplete, onEnvironmentChange, onArtifactDisplay,
   ) => {
     onTurnCompleteCallback = onTurnComplete;
     onEnvironmentChangeRequestCallback = onEnvironmentChange;

--- a/tests/hooks/useGeminiLive.test.ts
+++ b/tests/hooks/useGeminiLive.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useGeminiLive } from '../../hooks/useGeminiLive';
+import { DEFAULT_LANGUAGE_CODE } from '../../constants';
 import { ConnectionState, Quest } from '../../types';
 
 // Mock @google/genai
@@ -88,7 +89,7 @@ describe('useGeminiLive', () => {
 
     it('should initialize with CONNECTING state and transition to LISTENING', async () => {
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'Attic accent', DEFAULT_LANGUAGE_CODE, mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         expect(result.current.connectionState).toBe(ConnectionState.CONNECTING);
@@ -102,7 +103,7 @@ describe('useGeminiLive', () => {
 
     it('should handle sending a text message', async () => {
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'Attic accent', DEFAULT_LANGUAGE_CODE, mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -119,6 +120,22 @@ describe('useGeminiLive', () => {
         });
     });
 
+    it('should pass the selected language to the live session config', async () => {
+        renderHook(() =>
+            useGeminiLive('system-instruction', 'test-voice', 'Attic accent', DEFAULT_LANGUAGE_CODE, mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+        );
+
+        await waitFor(() => expect(mockConnect).toHaveBeenCalled());
+
+        const lastCall = mockConnect.mock.calls[mockConnect.mock.calls.length - 1][0];
+        expect(lastCall.config.inputAudioTranscription).toEqual({ languageCode: DEFAULT_LANGUAGE_CODE });
+        expect(lastCall.config.outputAudioTranscription).toEqual({ languageCode: DEFAULT_LANGUAGE_CODE });
+        expect(lastCall.config.speechConfig).toMatchObject({
+            languageCode: DEFAULT_LANGUAGE_CODE,
+            voiceConfig: { prebuiltVoiceConfig: { voiceName: 'test-voice' } },
+        });
+    });
+
     it('should handle incoming transcriptions and turn completion', async () => {
         let openCallback: () => void;
         let messageCallback: (msg: any) => void;
@@ -130,7 +147,7 @@ describe('useGeminiLive', () => {
         });
 
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'Attic accent', DEFAULT_LANGUAGE_CODE, mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await act(async () => {
@@ -171,7 +188,7 @@ describe('useGeminiLive', () => {
         });
 
         renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'Attic accent', DEFAULT_LANGUAGE_CODE, mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await act(async () => {
@@ -189,7 +206,7 @@ describe('useGeminiLive', () => {
 
     it('should toggle microphone and update connection state', async () => {
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'Attic accent', DEFAULT_LANGUAGE_CODE, mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -214,7 +231,7 @@ describe('useGeminiLive', () => {
 
     it('should handle disconnect properly', async () => {
         const { result, unmount } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'Attic accent', DEFAULT_LANGUAGE_CODE, mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -241,7 +258,7 @@ describe('useGeminiLive', () => {
         });
 
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'Attic accent', DEFAULT_LANGUAGE_CODE, mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -257,7 +274,7 @@ describe('useGeminiLive', () => {
 
     it('should include quest objective in system instructions if a quest is active', async () => {
         renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, mockQuest)
+            useGeminiLive('system-instruction', 'test-voice', 'Attic accent', DEFAULT_LANGUAGE_CODE, mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, mockQuest)
         );
 
         await waitFor(() => {

--- a/types.ts
+++ b/types.ts
@@ -5,6 +5,11 @@ export interface VoiceProfile {
   description: string;
 }
 
+export interface LanguageOption {
+  code: string;
+  label: string;
+}
+
 export interface Ambience {
   tag: string;
   description: string;


### PR DESCRIPTION
## Summary
- add a configurable language list and default to constants for reuse
- persist the selected language and show a dropdown in the conversation view
- send the language code through the Gemini Live session config and update tests accordingly

## Testing
- npm run test -- tests/hooks/useGeminiLive.test.ts
- npm run test -- tests/components/ConversationView.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e2eab6fcac832f9cd8f7dc8426d723