### PR TITLE
fix: migrate microphone capture to audio worklet

### DIFF
--- a/audio/microphoneWorkletProcessor.js
+++ b/audio/microphoneWorkletProcessor.js
@@ -1,0 +1,15 @@
+class MicrophoneProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    if (!inputs || inputs.length === 0 || inputs[0].length === 0) {
+      return true;
+    }
+
+    const inputChannelData = inputs[0][0];
+    if (inputChannelData) {
+      this.port.postMessage(inputChannelData.slice());
+    }
+    return true;
+  }
+}
+
+registerProcessor('microphone-processor', MicrophoneProcessor);


### PR DESCRIPTION
## Summary
- stream microphone audio through an AudioWorkletNode and preserve ScriptProcessorNode as a fallback for older environments
- add a dedicated worklet processor module to forward PCM frames to the live session
- harden microphone toggle and teardown flows to disconnect the new processing graph cleanly

## Testing
- npm run test -- --run

fixes https://github.com/School-of-the-Ancients/sota-beta/issues/158

------
https://chatgpt.com/codex/tasks/task_e_68e2f164513c832f954ead7249b6e819