### PR TITLE
Fix microphone streaming with AudioWorklet fallback

### DIFF
--- a/audio/worklets/microphone-processor.ts
+++ b/audio/worklets/microphone-processor.ts
@@ -1,0 +1,14 @@
+class MicrophoneProcessor extends AudioWorkletProcessor {
+  process(inputs: Float32Array[][]) {
+    const input = inputs[0];
+    if (input && input[0]) {
+      const channelData = input[0];
+      const chunk = channelData.slice();
+      this.port.postMessage(chunk, [chunk.buffer]);
+    }
+    return true;
+  }
+}
+
+registerProcessor('microphone-processor', MicrophoneProcessor);
+export {};


### PR DESCRIPTION
## Summary
- replace the deprecated ScriptProcessor microphone capture with an AudioWorklet-based pipeline
- add a resilient fallback to ScriptProcessorNode when the AudioWorklet API is unavailable (e.g., during tests)
- share audio frames through a dedicated microphone worklet module for Gemini streaming

## Testing
- `npm run test -- --run`

## Related Issues
- N/A

## Environment Variables
- No changes

------
https://chatgpt.com/codex/tasks/task_e_68e2f164513c832f954ead7249b6e819