### PR TITLE
fix: migrate Gemini Live audio capture to audio worklet

### DIFF
--- a/audio/pcm-processor.worklet.ts
+++ b/audio/pcm-processor.worklet.ts
@@ -1,0 +1,23 @@
+/// <reference lib="webworker" />
+
+class PCMProcessor extends AudioWorkletProcessor {
+    process(inputs: Float32Array[][]): boolean {
+        const [input] = inputs;
+        if (!input || input.length === 0) {
+            return true;
+        }
+
+        const channelData = input[0];
+        if (!channelData || channelData.length === 0) {
+            return true;
+        }
+
+        const copy = channelData.slice();
+        this.port.postMessage(copy, [copy.buffer]);
+        return true;
+    }
+}
+
+registerProcessor('pcm-processor', PCMProcessor);
+
+export {};

--- a/tests/hooks/useGeminiLive.test.ts
+++ b/tests/hooks/useGeminiLive.test.ts
@@ -41,27 +41,39 @@ Object.defineProperty(navigator, 'mediaDevices', {
   writable: true,
 });
 
-const mockScriptProcessor = {
-  connect: vi.fn(),
-  disconnect: vi.fn(),
-  onaudioprocess: null,
-};
-
 const mockAudioContext = {
   createMediaStreamSource: vi.fn(() => ({
     connect: vi.fn(),
     disconnect: vi.fn(),
   })),
-  createScriptProcessor: vi.fn(() => mockScriptProcessor),
+  createGain: vi.fn(() => ({
+    gain: { value: 1 },
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  })),
   destination: {},
   close: vi.fn(() => Promise.resolve()),
   resume: vi.fn(),
   suspend: vi.fn(),
   sampleRate: 16000,
+  audioWorklet: {
+    addModule: vi.fn(() => Promise.resolve()),
+  },
 };
 
 // @ts-expect-error - Mocking AudioContext
 window.AudioContext = vi.fn(() => mockAudioContext);
+
+class MockAudioWorkletNode {
+  port = {
+    onmessage: null as ((event: MessageEvent<Float32Array>) => void) | null,
+  };
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+
+// @ts-expect-error - Mocking AudioWorkletNode
+window.AudioWorkletNode = MockAudioWorkletNode;
 
 const mockOnTurnComplete = vi.fn();
 const mockOnEnvironmentChangeRequest = vi.fn();


### PR DESCRIPTION
## Summary
- replace the ScriptProcessorNode capture path in `useGeminiLive` with an `AudioWorkletNode` and silent gain routing
- add a PCM audio worklet processor that forwards microphone frames to the Gemini Live session
- update the hook unit tests to mock the audio worklet APIs

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e2f164513c832f954ead7249b6e819