### PR TITLE
feat: let visitors supply their own Gemini API key

### DIFF
--- a/App.test.tsx
+++ b/App.test.tsx
@@ -71,6 +71,7 @@ Object.defineProperty(window, 'history', {
 describe('App', () => {
   beforeEach(() => {
     mockLocalStorage.clear();
+    mockLocalStorage.setItem('school-of-the-ancients-api-key', 'test-key');
     vi.clearAllMocks();
 
     // Mock browser APIs

--- a/README.md
+++ b/README.md
@@ -109,10 +109,7 @@ School of the Ancients is a modern web application that pairs immersive visuals 
    ```bash
    npm install
    ```
-3. Create a `.env` file in the project root and add your Gemini credentials:
-   ```bash
-   GEMINI_API_KEY=your_api_key_here
-   ```
+3. Start the dev server (`npm run dev`) and, once the app loads, paste your Gemini API key into the "Gemini API key" banner at the top of the page. The key is saved only in your browser's local storage.
 
 ### Running Locally
 
@@ -137,7 +134,7 @@ Deploy the contents of `dist/` to your static hosting platform of choice.
 
 ## Development Tips
 
-- Vite exposes `process.env.API_KEY` and `process.env.GEMINI_API_KEY` based on the `GEMINI_API_KEY` entry in your `.env` file. Be sure not to commit this file.
+- Paste your Gemini API key into the in-app banner whenever you open a new browser or device. The key never leaves local storage.
 - Shared UI components live in `components/`, while feature views are registered in `App.tsx`.
 - Hooks such as `useGeminiLive` encapsulate audio capture, streaming, and playback logic.
 - Tailwind utility classes handle layout; extend the Tailwind config before introducing custom CSS.
@@ -151,7 +148,7 @@ Deploy the contents of `dist/` to your static hosting platform of choice.
 
 ## Troubleshooting
 
-- **"API_KEY not set" errors**: Ensure your `.env` file is present and you restarted `npm run dev` after adding it.
+- **"API key required" banner**: Enter a valid Gemini API key in the header form. The value is stored locally; clear it with the "Remove" button if you need to rotate keys.
 - **Microphone permissions**: Clear browser permissions if you accidentally deny access; audio capture is required for real-time chat.
 - **Slow or missing visuals**: Imagen requests can take a few seconds. Watch the developer console for network errors if images do not appear.
 

--- a/components/CharacterCreator.tsx
+++ b/components/CharacterCreator.tsx
@@ -8,6 +8,7 @@ import DiceIcon from './icons/DiceIcon';
 interface CharacterCreatorProps {
   onCharacterCreated: (character: Character) => void;
   onBack: () => void;
+  apiKey: string;
 }
 
 /** Pretty, branded SVG fallback if portrait generation fails */
@@ -37,7 +38,7 @@ function makeFallbackAvatar(name: string, title?: string) {
   return `data:image/svg+xml;charset=utf-8,${svg}`;
 }
 
-const CharacterCreator: React.FC<CharacterCreatorProps> = ({ onCharacterCreated, onBack }) => {
+const CharacterCreator: React.FC<CharacterCreatorProps> = ({ onCharacterCreated, onBack, apiKey }) => {
   const [name, setName] = useState('');
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState('');
@@ -108,12 +109,16 @@ If you are not at least 80% confident in their historicity, set verified to fals
     const clean = name.trim();
     if (!clean) return setError('Enter a historical figure’s name.');
 
+    if (!apiKey) {
+      setError('Add your Gemini API key to generate new mentors.');
+      return;
+    }
+
     try {
       setLoading(true);
       setMsg('Verifying historical figure…');
 
-      if (!process.env.API_KEY) throw new Error('API_KEY not set.');
-      const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+      const ai = new GoogleGenAI({ apiKey });
 
       const verification = await verifyHistoricalFigure(ai, clean);
 
@@ -263,6 +268,12 @@ If you are not at least 80% confident in their historicity, set verified to fals
           </div>
         )}
 
+        {!apiKey && (
+          <div className="mb-4 rounded-lg border border-amber-500/60 bg-amber-900/30 px-4 py-3 text-sm text-amber-100">
+            Paste your Gemini API key above to unlock character generation.
+          </div>
+        )}
+
         <label className="block text-sm font-medium text-gray-300 mb-2">Whom shall we invite to the academy?</label>
         <div className="relative mb-4" onFocus={() => setShowSuggestions(true)}>
           <input
@@ -316,7 +327,8 @@ If you are not at least 80% confident in their historicity, set verified to fals
 
         <button
           onClick={handleCreate}
-          className="w-full bg-amber-600 hover:bg-amber-500 text-black font-bold py-3 px-6 rounded-lg transition-colors text-lg"
+          disabled={!apiKey || loading}
+          className="w-full bg-amber-600 hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-50 text-black font-bold py-3 px-6 rounded-lg transition-colors text-lg"
         >
           Create Ancient
         </button>

--- a/components/QuestCreator.tsx
+++ b/components/QuestCreator.tsx
@@ -19,6 +19,7 @@ interface QuestCreatorProps {
   onQuestReady: (quest: Quest, character: Character) => void;
   onCharacterCreated: (character: Character) => void;
   initialGoal?: string;
+  apiKey: string;
 }
 
 /** Pretty, branded SVG fallback if portrait generation fails */
@@ -54,6 +55,7 @@ const QuestCreator: React.FC<QuestCreatorProps> = ({
   onQuestReady,
   onCharacterCreated,
   initialGoal,
+  apiKey,
 }) => {
   const [goal, setGoal] = useState(initialGoal ?? '');
   const [prefs, setPrefs] = useState({ difficulty: 'auto', style: 'auto', time: 'auto' });
@@ -72,8 +74,8 @@ const QuestCreator: React.FC<QuestCreatorProps> = ({
 
   /** Persona generator reused from your character creator, with a SAFE portrait step */
   const createPersonaFor = async (name: string): Promise<Character> => {
-    if (!process.env.API_KEY) throw new Error('API_KEY not set.');
-    const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+    if (!apiKey) throw new Error('Add your Gemini API key to create custom mentors.');
+    const ai = new GoogleGenAI({ apiKey });
 
     const availableAmbienceTags = AMBIENCE_LIBRARY.map(a => a.tag).join(', ');
     const voiceOptions = AVAILABLE_VOICES.map(
@@ -174,8 +176,8 @@ const QuestCreator: React.FC<QuestCreatorProps> = ({
   };
 
   const ensureMeaningfulGoal = async (cleanGoal: string) => {
-    if (!process.env.API_KEY) throw new Error('API_KEY not set.');
-    const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+    if (!apiKey) throw new Error('Add your Gemini API key to validate goals.');
+    const ai = new GoogleGenAI({ apiKey });
 
     const validationPrompt = `You are the Gatekeeper for a learning quest generator. Decide if the user's goal is specific, meaningful, and actionable. If the text is gibberish, a single repeated word, or otherwise not a legitimate learning objective, reject it.\n\nReturn JSON with { "meaningful": boolean, "reason": string }. Use meaningful=false for gibberish, nonsense, or empty goals.`;
 
@@ -244,14 +246,18 @@ const QuestCreator: React.FC<QuestCreatorProps> = ({
       return;
     }
 
+    if (!apiKey) {
+      setError('Add your Gemini API key to design custom quests.');
+      return;
+    }
+
     try {
       setLoading(true);
       setMsg('Designing your quest…');
 
       await ensureMeaningfulGoal(clean);
 
-      if (!process.env.API_KEY) throw new Error('API_KEY not set.');
-      const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+      const ai = new GoogleGenAI({ apiKey });
 
       const draftPrompt = `You are the Quest Architect. Convert this learner goal into a concise quest and pick the most appropriate historical mentor.
 
@@ -380,6 +386,12 @@ Return JSON with:
           </div>
         )}
 
+        {!apiKey && (
+          <div className="mb-6 rounded-lg border border-amber-500/60 bg-amber-900/30 px-4 py-3 text-sm text-amber-100">
+            Paste your Gemini API key above to enable AI quest generation.
+          </div>
+        )}
+
         {initialGoal && (
           <div className="mb-4 bg-teal-900/40 border border-teal-600/60 text-teal-100 text-sm px-4 py-3 rounded-lg">
             Prefilled from your mentor's next steps. Edit or expand the goal before creating a new quest.
@@ -446,7 +458,8 @@ Return JSON with:
 
         <button
           onClick={handleCreate}
-          className="w-full bg-amber-600 hover:bg-amber-500 text-black font-bold py-3 px-6 rounded-lg transition-colors text-lg"
+          disabled={!apiKey || loading}
+          className="w-full bg-amber-600 hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-50 text-black font-bold py-3 px-6 rounded-lg transition-colors text-lg"
         >
           Create Quest
         </button>

--- a/components/QuestQuiz.tsx
+++ b/components/QuestQuiz.tsx
@@ -7,6 +7,7 @@ interface QuestQuizProps {
   assessment?: QuestAssessment | null;
   onExit: () => void;
   onComplete: (result: QuizResult) => void;
+  apiKey: string;
 }
 
 const PASS_THRESHOLD = 0.6;
@@ -50,7 +51,7 @@ const validateQuestions = (data: unknown): QuizQuestion[] => {
     .slice(0, MAX_QUESTIONS);
 };
 
-const QuestQuiz: React.FC<QuestQuizProps> = ({ quest, assessment, onExit, onComplete }) => {
+const QuestQuiz: React.FC<QuestQuizProps> = ({ quest, assessment, onExit, onComplete, apiKey }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [questions, setQuestions] = useState<QuizQuestion[]>([]);
@@ -138,14 +139,14 @@ const QuestQuiz: React.FC<QuestQuizProps> = ({ quest, assessment, onExit, onComp
       setIsLoading(true);
       resetState();
 
-      if (!process.env.API_KEY) {
+      if (!apiKey) {
         setQuestions(buildFallbackQuestions());
         setIsLoading(false);
         return;
       }
 
       try {
-        const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+        const ai = new GoogleGenAI({ apiKey });
         const prompt = `You are an expert tutor creating a short mastery quiz. Design ${questionCount} multiple-choice questions (3-4 answer choices each) to evaluate whether a learner has mastered the quest "${quest.title}". The quest objective is: "${quest.objective}". Focus on these key learning points: ${quest.focusPoints.join('; ')}. Each question must test one learning point.
 
 Return JSON with this schema:
@@ -213,7 +214,7 @@ Ensure questions are rigorous but clear, avoid trick questions, and keep the ans
     return () => {
       isCancelled = true;
     };
-  }, [buildFallbackQuestions, questionCount, quest.focusPoints, quest.objective, quest.title, refreshToken, resetState]);
+  }, [apiKey, buildFallbackQuestions, questionCount, quest.focusPoints, quest.objective, quest.title, refreshToken, resetState]);
 
   const handleSelect = (questionId: string, optionIndex: number) => {
     setAnswers((prev) => ({ ...prev, [questionId]: optionIndex }));

--- a/hooks/useGeminiLive.ts
+++ b/hooks/useGeminiLive.ts
@@ -127,6 +127,7 @@ export const useGeminiLive = (
     onEnvironmentChangeRequest: (description: string) => void,
     onArtifactDisplayRequest: (name: string, description: string) => void,
     activeQuest: Quest | null,
+    apiKey: string | null,
 ) => {
     const [connectionState, setConnectionState] = useState<ConnectionState>(ConnectionState.IDLE);
     const [userTranscription, setUserTranscription] = useState<string>('');
@@ -299,16 +300,15 @@ export const useGeminiLive = (
     }, []);
 
     const connect = useCallback(async () => {
-        setConnectionState(ConnectionState.CONNECTING);
-
-        if (!process.env.API_KEY) {
-            console.error("API_KEY environment variable not set.");
-            setConnectionState(ConnectionState.ERROR);
+        if (!apiKey) {
+            setConnectionState(ConnectionState.IDLE);
             return;
         }
 
+        setConnectionState(ConnectionState.CONNECTING);
+
         try {
-            const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+            const ai = new GoogleGenAI({ apiKey });
 
             const sanitizedAccent = voiceAccent?.trim();
             let baseInstruction = systemInstruction.trim();
@@ -584,7 +584,7 @@ export const useGeminiLive = (
             console.error('Failed to connect to Gemini Live:', error);
             setConnectionState(ConnectionState.ERROR);
         }
-    }, [systemInstruction, voiceName, voiceAccent, activeQuest, disconnect]);
+    }, [systemInstruction, voiceName, voiceAccent, activeQuest, disconnect, apiKey]);
 
     useEffect(() => {
         connect();

--- a/tests/components/CharacterCreator.test.tsx
+++ b/tests/components/CharacterCreator.test.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -30,13 +31,24 @@ vi.mock('../../suggestions', () => ({
 const mockOnCharacterCreated = vi.fn();
 const mockOnBack = vi.fn();
 
+const renderCharacterCreator = (props: Partial<ComponentProps<typeof CharacterCreator>> = {}) => {
+    return render(
+        <CharacterCreator
+            onCharacterCreated={mockOnCharacterCreated}
+            onBack={mockOnBack}
+            apiKey="test-key"
+            {...props}
+        />
+    );
+};
+
 describe('CharacterCreator', () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
 
     it('should render the form and allow typing a name', () => {
-        render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+        renderCharacterCreator();
 
         const input = screen.getByPlaceholderText('Begin typing a historical figure…');
         fireEvent.change(input, { target: { value: 'Socrates' } });
@@ -45,7 +57,7 @@ describe('CharacterCreator', () => {
     });
 
     it('should show suggestions on input focus and filter them', async () => {
-        render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+        renderCharacterCreator();
         const user = userEvent.setup();
 
         const input = screen.getByPlaceholderText('Begin typing a historical figure…');
@@ -62,7 +74,7 @@ describe('CharacterCreator', () => {
     });
 
     it('should fill input when a suggestion is clicked', async () => {
-        render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+        renderCharacterCreator();
         const user = userEvent.setup();
 
         const input = screen.getByPlaceholderText('Begin typing a historical figure…');
@@ -75,13 +87,13 @@ describe('CharacterCreator', () => {
     });
 
     it('should call onBack when the back button is clicked', () => {
-        render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+        renderCharacterCreator();
         fireEvent.click(screen.getByRole('button', { name: 'Back' }));
         expect(mockOnBack).toHaveBeenCalled();
     });
 
     it('should show an error if the name is empty on creation', async () => {
-        render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+        renderCharacterCreator();
         fireEvent.click(screen.getByRole('button', { name: 'Create Ancient' }));
 
         expect(await screen.findByText('Enter a historical figure’s name.')).toBeInTheDocument();
@@ -109,7 +121,7 @@ describe('CharacterCreator', () => {
 
         mockGenerateImages.mockImplementationOnce(() => new Promise(res => setTimeout(() => res({ generatedImages: [{ image: { imageBytes: 'fake-portrait-data' } }] }), 10)));
 
-        render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+        renderCharacterCreator();
 
         const input = screen.getByPlaceholderText('Begin typing a historical figure…');
         await user.type(input, 'Socrates');
@@ -137,7 +149,7 @@ describe('CharacterCreator', () => {
             text: JSON.stringify({ verified: false, summary: 'Could not verify', era: '' }),
         });
 
-        render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+        renderCharacterCreator();
         const user = userEvent.setup();
 
         const input = screen.getByPlaceholderText('Begin typing a historical figure…');
@@ -155,7 +167,7 @@ describe('CharacterCreator', () => {
     it('should handle API errors during creation', async () => {
         mockGenerateContent.mockRejectedValue(new Error('API is down'));
 
-        render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+        renderCharacterCreator();
         const user = userEvent.setup();
 
         const input = screen.getByPlaceholderText('Begin typing a historical figure…');

--- a/tests/components/ConversationView.test.tsx
+++ b/tests/components/ConversationView.test.tsx
@@ -37,8 +37,14 @@ const useGeminiLiveMock = vi.fn();
 
 vi.mock('../../hooks/useGeminiLive', () => ({
   useGeminiLive: vi.fn((
-    sysInstruction, voice, accent,
-    onTurnComplete, onEnvironmentChange, onArtifactDisplay
+    sysInstruction,
+    voice,
+    accent,
+    onTurnComplete,
+    onEnvironmentChange,
+    onArtifactDisplay,
+    _activeQuest,
+    _apiKey
   ) => {
     onTurnCompleteCallback = onTurnComplete;
     onEnvironmentChangeRequestCallback = onEnvironmentChange;
@@ -71,7 +77,7 @@ const renderComponent = (props = {}) => {
     return render(
         <ConversationView
             character={mockCharacter} onEndConversation={mockOnEndConversation}
-            onEnvironmentUpdate={mockOnEnvironmentUpdate} activeQuest={null} isSaving={false} {...props}
+            onEnvironmentUpdate={mockOnEnvironmentUpdate} activeQuest={null} isSaving={false} apiKey="test-key" {...props}
         />
     );
 };

--- a/tests/components/QuestCreator.test.tsx
+++ b/tests/components/QuestCreator.test.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -45,13 +46,26 @@ const mockExistingCharacters: Character[] = [
     }
 ];
 
+const renderQuestCreator = (props: Partial<ComponentProps<typeof QuestCreator>> = {}) => {
+    return render(
+        <QuestCreator
+            characters={[]}
+            onBack={mockOnBack}
+            onQuestReady={mockOnQuestReady}
+            onCharacterCreated={mockOnCharacterCreated}
+            apiKey="test-key"
+            {...props}
+        />
+    );
+};
+
 describe('QuestCreator', () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
 
     it('should render the form with a text area and select fields', () => {
-        render(<QuestCreator characters={[]} onBack={mockOnBack} onQuestReady={mockOnQuestReady} onCharacterCreated={mockOnCharacterCreated} />);
+        renderQuestCreator();
 
         expect(screen.getByPlaceholderText(/e.g., "Understand backpropagation/)).toBeInTheDocument();
         expect(screen.getByRole('combobox', { name: 'Difficulty' })).toBeInTheDocument();
@@ -62,7 +76,7 @@ describe('QuestCreator', () => {
 
     it('should show an error if the goal is empty on creation', async () => {
         const user = userEvent.setup();
-        render(<QuestCreator characters={[]} onBack={mockOnBack} onQuestReady={mockOnQuestReady} onCharacterCreated={mockOnCharacterCreated} />);
+        renderQuestCreator();
 
         await user.click(screen.getByRole('button', { name: 'Create Quest' }));
 
@@ -79,7 +93,7 @@ describe('QuestCreator', () => {
             .mockResolvedValueOnce({ text: JSON.stringify({ title: 'The Idealist', bio: 'I write dialogues.', greeting: 'Welcome.', timeframe: '4th century BC', expertise: 'Metaphysics', passion: 'Forms', systemInstruction: 'Act as Plato.', suggestedPrompts: ['What is virtue?'], voiceName: 'en-US-Standard-B', voiceAccent: 'en-US', ambienceTag: 'academy' }) });
         mockGenerateImages.mockResolvedValueOnce({ generatedImages: [{ image: { imageBytes: 'fake-portrait-data' } }] });
 
-        render(<QuestCreator characters={mockExistingCharacters} onBack={mockOnBack} onQuestReady={mockOnQuestReady} onCharacterCreated={mockOnCharacterCreated} />);
+        renderQuestCreator({ characters: mockExistingCharacters });
 
         await user.type(screen.getByPlaceholderText(/e.g., "Understand backpropagation/), 'Learn about justice');
         await user.click(screen.getByRole('button', { name: 'Create Quest' }));
@@ -102,7 +116,7 @@ describe('QuestCreator', () => {
             .mockResolvedValueOnce({ text: JSON.stringify({ title: 'The Examined Life', description: 'A quest about self-knowledge.', objective: 'Know thyself.', focusPoints: ['Socratic method'], duration: '10-15 min', mentorName: 'Socrates' }) })
             .mockResolvedValueOnce({ text: JSON.stringify({ mentorName: 'Socrates' }) });
 
-        render(<QuestCreator characters={mockExistingCharacters} onBack={mockOnBack} onQuestReady={mockOnQuestReady} onCharacterCreated={mockOnCharacterCreated} />);
+        renderQuestCreator({ characters: mockExistingCharacters });
 
         await user.type(screen.getByPlaceholderText(/e.g., "Understand backpropagation/), 'Learn to question everything');
         await user.click(screen.getByRole('button', { name: 'Create Quest' }));
@@ -121,7 +135,7 @@ describe('QuestCreator', () => {
         const errorMessage = 'This goal is not specific enough.';
         mockGenerateContent.mockResolvedValueOnce({ text: JSON.stringify({ meaningful: false, reason: errorMessage }) });
 
-        render(<QuestCreator characters={[]} onBack={mockOnBack} onQuestReady={mockOnQuestReady} onCharacterCreated={mockOnCharacterCreated} />);
+        renderQuestCreator();
 
         await user.type(screen.getByPlaceholderText(/e.g., "Understand backpropagation/), 'asdfasdf');
         await user.click(screen.getByRole('button', { name: 'Create Quest' }));
@@ -134,7 +148,7 @@ describe('QuestCreator', () => {
         const user = userEvent.setup();
         mockGenerateContent.mockRejectedValue(new Error('Network Error'));
 
-        render(<QuestCreator characters={[]} onBack={mockOnBack} onQuestReady={mockOnQuestReady} onCharacterCreated={mockOnCharacterCreated} />);
+        renderQuestCreator();
 
         await user.type(screen.getByPlaceholderText(/e.g., "Understand backpropagation/), 'Learn about APIs');
         await user.click(screen.getByRole('button', { name: 'Create Quest' }));

--- a/tests/hooks/useGeminiLive.test.ts
+++ b/tests/hooks/useGeminiLive.test.ts
@@ -88,7 +88,7 @@ describe('useGeminiLive', () => {
 
     it('should initialize with CONNECTING state and transition to LISTENING', async () => {
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null, 'test-api-key')
         );
 
         expect(result.current.connectionState).toBe(ConnectionState.CONNECTING);
@@ -102,7 +102,7 @@ describe('useGeminiLive', () => {
 
     it('should handle sending a text message', async () => {
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null, 'test-api-key')
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -130,7 +130,7 @@ describe('useGeminiLive', () => {
         });
 
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null, 'test-api-key')
         );
 
         await act(async () => {
@@ -171,7 +171,7 @@ describe('useGeminiLive', () => {
         });
 
         renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null, 'test-api-key')
         );
 
         await act(async () => {
@@ -189,7 +189,7 @@ describe('useGeminiLive', () => {
 
     it('should toggle microphone and update connection state', async () => {
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null, 'test-api-key')
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -214,7 +214,7 @@ describe('useGeminiLive', () => {
 
     it('should handle disconnect properly', async () => {
         const { result, unmount } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null, 'test-api-key')
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -241,7 +241,7 @@ describe('useGeminiLive', () => {
         });
 
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null, 'test-api-key')
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -257,7 +257,7 @@ describe('useGeminiLive', () => {
 
     it('should include quest objective in system instructions if a quest is active', async () => {
         renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, mockQuest)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, mockQuest, 'test-api-key')
         );
 
         await waitFor(() => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,21 +1,16 @@
 /// <reference types="vitest" />
 
 import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, '.', '');
+export default defineConfig(() => {
     return {
       server: {
         port: 3000,
         host: '0.0.0.0',
       },
       plugins: [react()],
-      define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
-      },
       resolve: {
         alias: {
           '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
## Summary
- add a header banner that saves a visitor-supplied Gemini API key in local storage instead of relying on build-time env vars
- wire the user key through conversation, quest, quiz, and realtime hooks so AI-driven features are gated gracefully when no key is present
- refresh docs, configuration, and tests to cover the new key entry workflow

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e31a468e98832f8584794434585e1d