### PR TITLE
feat: allow visitors to provide their own api key

### DIFF
--- a/App.test.tsx
+++ b/App.test.tsx
@@ -47,6 +47,9 @@ const mockLocalStorage = (() => {
     setItem: (key: string, value: string) => {
       store[key] = value.toString();
     },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
     clear: () => {
       store = {};
     },
@@ -71,6 +74,7 @@ Object.defineProperty(window, 'history', {
 describe('App', () => {
   beforeEach(() => {
     mockLocalStorage.clear();
+    mockLocalStorage.setItem('school-of-the-ancients-api-key', 'test-api-key');
     vi.clearAllMocks();
 
     // Mock browser APIs

--- a/README.md
+++ b/README.md
@@ -109,10 +109,7 @@ School of the Ancients is a modern web application that pairs immersive visuals 
    ```bash
    npm install
    ```
-3. Create a `.env` file in the project root and add your Gemini credentials:
-   ```bash
-   GEMINI_API_KEY=your_api_key_here
-   ```
+3. Start the development server (see below) and, once the app loads in your browser, paste your Gemini API key into the banner at the top of the page. The key is saved to localStorage in that browser only so every visitor can supply their own credentials.
 
 ### Running Locally
 
@@ -123,6 +120,8 @@ npm run dev
 ```
 
 Visit the printed URL (defaults to http://localhost:3000) and grant the browser microphone access when prompted.
+
+When the interface loads, use the “Gemini API key” form in the hero banner to supply your key. You can clear or replace it at any time; the key never leaves your browser. (Optional) Keep a `.env` file locally if you want a convenient place to copy your key from during development, but it is no longer read automatically by the app.
 
 ### Building for Production
 
@@ -137,7 +136,7 @@ Deploy the contents of `dist/` to your static hosting platform of choice.
 
 ## Development Tips
 
-- Vite exposes `process.env.API_KEY` and `process.env.GEMINI_API_KEY` based on the `GEMINI_API_KEY` entry in your `.env` file. Be sure not to commit this file.
+- The header banner persists the Gemini API key in `localStorage`. Clearing browser storage or switching devices will require re-entering the key.
 - Shared UI components live in `components/`, while feature views are registered in `App.tsx`.
 - Hooks such as `useGeminiLive` encapsulate audio capture, streaming, and playback logic.
 - Tailwind utility classes handle layout; extend the Tailwind config before introducing custom CSS.
@@ -151,7 +150,7 @@ Deploy the contents of `dist/` to your static hosting platform of choice.
 
 ## Troubleshooting
 
-- **"API_KEY not set" errors**: Ensure your `.env` file is present and you restarted `npm run dev` after adding it.
+- **"API key not set" messages**: Paste your Gemini API key into the header banner and click **Save key**. Each browser stores the key locally.
 - **Microphone permissions**: Clear browser permissions if you accidentally deny access; audio capture is required for real-time chat.
 - **Slow or missing visuals**: Imagen requests can take a few seconds. Watch the developer console for network errors if images do not appear.
 

--- a/components/CharacterCreator.tsx
+++ b/components/CharacterCreator.tsx
@@ -6,6 +6,7 @@ import { HISTORICAL_FIGURES_SUGGESTIONS } from '../suggestions';
 import DiceIcon from './icons/DiceIcon';
 
 interface CharacterCreatorProps {
+  apiKey: string | null;
   onCharacterCreated: (character: Character) => void;
   onBack: () => void;
 }
@@ -37,7 +38,7 @@ function makeFallbackAvatar(name: string, title?: string) {
   return `data:image/svg+xml;charset=utf-8,${svg}`;
 }
 
-const CharacterCreator: React.FC<CharacterCreatorProps> = ({ onCharacterCreated, onBack }) => {
+const CharacterCreator: React.FC<CharacterCreatorProps> = ({ apiKey, onCharacterCreated, onBack }) => {
   const [name, setName] = useState('');
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState('');
@@ -112,8 +113,12 @@ If you are not at least 80% confident in their historicity, set verified to fals
       setLoading(true);
       setMsg('Verifying historical figure…');
 
-      if (!process.env.API_KEY) throw new Error('API_KEY not set.');
-      const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+      if (!apiKey) {
+        setError('Add your Gemini API key in the header to generate new mentors.');
+        setLoading(false);
+        return;
+      }
+      const ai = new GoogleGenAI({ apiKey });
 
       const verification = await verifyHistoricalFigure(ai, clean);
 

--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -17,6 +17,7 @@ const HISTORY_KEY = 'school-of-the-ancients-history';
 
 interface ConversationViewProps {
   character: Character;
+  apiKey: string;
   onEndConversation: (transcript: ConversationTurn[], sessionId: string) => void;
   environmentImageUrl: string | null;
   onEnvironmentUpdate: (url: string | null) => void;
@@ -102,6 +103,7 @@ const ArtifactDisplay: React.FC<{ artifact: NonNullable<ConversationTurn['artifa
 
 const ConversationView: React.FC<ConversationViewProps> = ({
   character,
+  apiKey,
   onEndConversation,
   environmentImageUrl,
   onEnvironmentUpdate,
@@ -288,8 +290,10 @@ const ConversationView: React.FC<ConversationViewProps> = ({
     setIsGeneratingVisual(true);
     setGenerationMessage(`Entering ${description}...`);
     try {
-      if (!process.env.API_KEY) throw new Error("API_KEY not set.");
-      const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+      if (!apiKey) {
+        throw new Error('API key not set.');
+      }
+      const ai = new GoogleGenAI({ apiKey });
       
       const imagePromise = ai.models.generateImages({
         model: 'imagen-4.0-generate-001',
@@ -337,7 +341,7 @@ const ConversationView: React.FC<ConversationViewProps> = ({
         }));
       }
     } catch (err) {
-      console.error("Failed to generate environment:", err);
+      console.error('Failed to generate environment:', err);
       setTranscript(prev => prev.map(turn => {
         if (turn.artifact?.id === environmentArtifactId) {
             const newTurn = { ...turn };
@@ -350,7 +354,7 @@ const ConversationView: React.FC<ConversationViewProps> = ({
     } finally {
       setIsGeneratingVisual(false);
     }
-  }, [onEnvironmentUpdate, character, changeAmbienceTrack]);
+  }, [apiKey, onEnvironmentUpdate, character, changeAmbienceTrack]);
 
   const handleArtifactDisplay = useCallback(async (name: string, description: string) => {
     const artifactId = `artifact_${Date.now()}`;
@@ -366,8 +370,10 @@ const ConversationView: React.FC<ConversationViewProps> = ({
     setGenerationMessage(`Creating ${name}...`);
 
     try {
-        if (!process.env.API_KEY) throw new Error("API_KEY not set.");
-        const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+        if (!apiKey) {
+          throw new Error('API key not set.');
+        }
+        const ai = new GoogleGenAI({ apiKey });
         const response = await ai.models.generateImages({
             model: 'imagen-4.0-generate-001',
             prompt: `A detailed, clear image of: a "${name}". ${description}. The artifact should be rendered in a style authentic to ${character.name}'s era and work (e.g., a da Vinci sketch, a 19th-century diagram, a classical Greek sculpture). Present it on a simple, non-distracting background like aged parchment or a museum display.`,
@@ -395,7 +401,7 @@ const ConversationView: React.FC<ConversationViewProps> = ({
             }));
         }
     } catch (err) {
-      console.error("Failed to generate artifact:", err);
+      console.error('Failed to generate artifact:', err);
       setTranscript(prev => prev.map(turn => {
         if (turn.artifact?.id === artifactId) {
           const newTurn = { ...turn };
@@ -408,7 +414,7 @@ const ConversationView: React.FC<ConversationViewProps> = ({
     } finally {
         setIsGeneratingVisual(false);
     }
-  }, [character]);
+  }, [apiKey, character]);
 
 
   const {
@@ -426,14 +432,17 @@ const ConversationView: React.FC<ConversationViewProps> = ({
     handleEnvironmentChange,
     handleArtifactDisplay,
     activeQuest,
+    apiKey,
   );
 
   const updateDynamicSuggestions = useCallback(async (currentTranscript: ConversationTurn[]) => {
     if (currentTranscript.length === 0) return;
     setIsFetchingSuggestions(true);
     try {
-        if (!process.env.API_KEY) throw new Error("API_KEY not set.");
-        const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+        if (!apiKey) {
+          throw new Error('API key not set.');
+        }
+        const ai = new GoogleGenAI({ apiKey });
 
         const contextTranscript = currentTranscript.slice(-4).map(turn => `${turn.speakerName}: ${turn.text}`).join('\n');
 
@@ -471,11 +480,11 @@ ${contextTranscript}
         }
 
     } catch (err) {
-        console.error("Failed to fetch dynamic suggestions:", err);
+        console.error('Failed to fetch dynamic suggestions:', err);
     } finally {
         setIsFetchingSuggestions(false);
     }
-  }, [character.name]);
+  }, [apiKey, character.name]);
 
   const requestDynamicSuggestions = useCallback(() => {
     updateDynamicSuggestions(transcript);

--- a/components/QuestQuiz.tsx
+++ b/components/QuestQuiz.tsx
@@ -7,6 +7,7 @@ interface QuestQuizProps {
   assessment?: QuestAssessment | null;
   onExit: () => void;
   onComplete: (result: QuizResult) => void;
+  apiKey: string | null;
 }
 
 const PASS_THRESHOLD = 0.6;
@@ -50,7 +51,7 @@ const validateQuestions = (data: unknown): QuizQuestion[] => {
     .slice(0, MAX_QUESTIONS);
 };
 
-const QuestQuiz: React.FC<QuestQuizProps> = ({ quest, assessment, onExit, onComplete }) => {
+const QuestQuiz: React.FC<QuestQuizProps> = ({ quest, assessment, onExit, onComplete, apiKey }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [questions, setQuestions] = useState<QuizQuestion[]>([]);
@@ -138,14 +139,14 @@ const QuestQuiz: React.FC<QuestQuizProps> = ({ quest, assessment, onExit, onComp
       setIsLoading(true);
       resetState();
 
-      if (!process.env.API_KEY) {
+      if (!apiKey) {
         setQuestions(buildFallbackQuestions());
         setIsLoading(false);
         return;
       }
 
       try {
-        const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+        const ai = new GoogleGenAI({ apiKey });
         const prompt = `You are an expert tutor creating a short mastery quiz. Design ${questionCount} multiple-choice questions (3-4 answer choices each) to evaluate whether a learner has mastered the quest "${quest.title}". The quest objective is: "${quest.objective}". Focus on these key learning points: ${quest.focusPoints.join('; ')}. Each question must test one learning point.
 
 Return JSON with this schema:
@@ -213,7 +214,7 @@ Ensure questions are rigorous but clear, avoid trick questions, and keep the ans
     return () => {
       isCancelled = true;
     };
-  }, [buildFallbackQuestions, questionCount, quest.focusPoints, quest.objective, quest.title, refreshToken, resetState]);
+  }, [apiKey, buildFallbackQuestions, questionCount, quest.focusPoints, quest.objective, quest.title, refreshToken, resetState]);
 
   const handleSelect = (questionId: string, optionIndex: number) => {
     setAnswers((prev) => ({ ...prev, [questionId]: optionIndex }));

--- a/hooks/useGeminiLive.ts
+++ b/hooks/useGeminiLive.ts
@@ -127,6 +127,7 @@ export const useGeminiLive = (
     onEnvironmentChangeRequest: (description: string) => void,
     onArtifactDisplayRequest: (name: string, description: string) => void,
     activeQuest: Quest | null,
+    apiKey: string | null,
 ) => {
     const [connectionState, setConnectionState] = useState<ConnectionState>(ConnectionState.IDLE);
     const [userTranscription, setUserTranscription] = useState<string>('');
@@ -301,14 +302,14 @@ export const useGeminiLive = (
     const connect = useCallback(async () => {
         setConnectionState(ConnectionState.CONNECTING);
 
-        if (!process.env.API_KEY) {
-            console.error("API_KEY environment variable not set.");
+        if (!apiKey) {
+            console.error('Gemini API key not set.');
             setConnectionState(ConnectionState.ERROR);
             return;
         }
 
         try {
-            const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+            const ai = new GoogleGenAI({ apiKey });
 
             const sanitizedAccent = voiceAccent?.trim();
             let baseInstruction = systemInstruction.trim();

--- a/tests/components/CharacterCreator.test.tsx
+++ b/tests/components/CharacterCreator.test.tsx
@@ -30,13 +30,23 @@ vi.mock('../../suggestions', () => ({
 const mockOnCharacterCreated = vi.fn();
 const mockOnBack = vi.fn();
 
+const renderCreator = (overrideProps = {}) =>
+  render(
+    <CharacterCreator
+      apiKey="test-api-key"
+      onCharacterCreated={mockOnCharacterCreated}
+      onBack={mockOnBack}
+      {...overrideProps}
+    />
+  );
+
 describe('CharacterCreator', () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
 
     it('should render the form and allow typing a name', () => {
-        render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+        renderCreator();
 
         const input = screen.getByPlaceholderText('Begin typing a historical figure…');
         fireEvent.change(input, { target: { value: 'Socrates' } });
@@ -45,7 +55,7 @@ describe('CharacterCreator', () => {
     });
 
     it('should show suggestions on input focus and filter them', async () => {
-        render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+        renderCreator();
         const user = userEvent.setup();
 
         const input = screen.getByPlaceholderText('Begin typing a historical figure…');
@@ -62,7 +72,7 @@ describe('CharacterCreator', () => {
     });
 
     it('should fill input when a suggestion is clicked', async () => {
-        render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+        renderCreator();
         const user = userEvent.setup();
 
         const input = screen.getByPlaceholderText('Begin typing a historical figure…');
@@ -75,13 +85,13 @@ describe('CharacterCreator', () => {
     });
 
     it('should call onBack when the back button is clicked', () => {
-        render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+        renderCreator();
         fireEvent.click(screen.getByRole('button', { name: 'Back' }));
         expect(mockOnBack).toHaveBeenCalled();
     });
 
     it('should show an error if the name is empty on creation', async () => {
-        render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+        renderCreator();
         fireEvent.click(screen.getByRole('button', { name: 'Create Ancient' }));
 
         expect(await screen.findByText('Enter a historical figure’s name.')).toBeInTheDocument();
@@ -109,7 +119,7 @@ describe('CharacterCreator', () => {
 
         mockGenerateImages.mockImplementationOnce(() => new Promise(res => setTimeout(() => res({ generatedImages: [{ image: { imageBytes: 'fake-portrait-data' } }] }), 10)));
 
-        render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+        renderCreator();
 
         const input = screen.getByPlaceholderText('Begin typing a historical figure…');
         await user.type(input, 'Socrates');
@@ -137,7 +147,7 @@ describe('CharacterCreator', () => {
             text: JSON.stringify({ verified: false, summary: 'Could not verify', era: '' }),
         });
 
-        render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+        renderCreator();
         const user = userEvent.setup();
 
         const input = screen.getByPlaceholderText('Begin typing a historical figure…');
@@ -155,7 +165,7 @@ describe('CharacterCreator', () => {
     it('should handle API errors during creation', async () => {
         mockGenerateContent.mockRejectedValue(new Error('API is down'));
 
-        render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+        renderCreator();
         const user = userEvent.setup();
 
         const input = screen.getByPlaceholderText('Begin typing a historical figure…');

--- a/tests/components/ConversationView.test.tsx
+++ b/tests/components/ConversationView.test.tsx
@@ -70,8 +70,13 @@ const mockOnEnvironmentUpdate = vi.fn();
 const renderComponent = (props = {}) => {
     return render(
         <ConversationView
-            character={mockCharacter} onEndConversation={mockOnEndConversation}
-            onEnvironmentUpdate={mockOnEnvironmentUpdate} activeQuest={null} isSaving={false} {...props}
+            character={mockCharacter}
+            apiKey="test-api-key"
+            onEndConversation={mockOnEndConversation}
+            onEnvironmentUpdate={mockOnEnvironmentUpdate}
+            activeQuest={null}
+            isSaving={false}
+            {...props}
         />
     );
 };

--- a/tests/components/QuestCreator.test.tsx
+++ b/tests/components/QuestCreator.test.tsx
@@ -45,13 +45,25 @@ const mockExistingCharacters: Character[] = [
     }
 ];
 
+const renderQuestCreator = (overrideProps = {}) =>
+  render(
+    <QuestCreator
+      characters={[]}
+      onBack={mockOnBack}
+      onQuestReady={mockOnQuestReady}
+      onCharacterCreated={mockOnCharacterCreated}
+      apiKey="test-api-key"
+      {...overrideProps}
+    />
+  );
+
 describe('QuestCreator', () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
 
     it('should render the form with a text area and select fields', () => {
-        render(<QuestCreator characters={[]} onBack={mockOnBack} onQuestReady={mockOnQuestReady} onCharacterCreated={mockOnCharacterCreated} />);
+        renderQuestCreator();
 
         expect(screen.getByPlaceholderText(/e.g., "Understand backpropagation/)).toBeInTheDocument();
         expect(screen.getByRole('combobox', { name: 'Difficulty' })).toBeInTheDocument();
@@ -62,7 +74,7 @@ describe('QuestCreator', () => {
 
     it('should show an error if the goal is empty on creation', async () => {
         const user = userEvent.setup();
-        render(<QuestCreator characters={[]} onBack={mockOnBack} onQuestReady={mockOnQuestReady} onCharacterCreated={mockOnCharacterCreated} />);
+        renderQuestCreator();
 
         await user.click(screen.getByRole('button', { name: 'Create Quest' }));
 
@@ -79,7 +91,7 @@ describe('QuestCreator', () => {
             .mockResolvedValueOnce({ text: JSON.stringify({ title: 'The Idealist', bio: 'I write dialogues.', greeting: 'Welcome.', timeframe: '4th century BC', expertise: 'Metaphysics', passion: 'Forms', systemInstruction: 'Act as Plato.', suggestedPrompts: ['What is virtue?'], voiceName: 'en-US-Standard-B', voiceAccent: 'en-US', ambienceTag: 'academy' }) });
         mockGenerateImages.mockResolvedValueOnce({ generatedImages: [{ image: { imageBytes: 'fake-portrait-data' } }] });
 
-        render(<QuestCreator characters={mockExistingCharacters} onBack={mockOnBack} onQuestReady={mockOnQuestReady} onCharacterCreated={mockOnCharacterCreated} />);
+        renderQuestCreator({ characters: mockExistingCharacters });
 
         await user.type(screen.getByPlaceholderText(/e.g., "Understand backpropagation/), 'Learn about justice');
         await user.click(screen.getByRole('button', { name: 'Create Quest' }));
@@ -102,7 +114,7 @@ describe('QuestCreator', () => {
             .mockResolvedValueOnce({ text: JSON.stringify({ title: 'The Examined Life', description: 'A quest about self-knowledge.', objective: 'Know thyself.', focusPoints: ['Socratic method'], duration: '10-15 min', mentorName: 'Socrates' }) })
             .mockResolvedValueOnce({ text: JSON.stringify({ mentorName: 'Socrates' }) });
 
-        render(<QuestCreator characters={mockExistingCharacters} onBack={mockOnBack} onQuestReady={mockOnQuestReady} onCharacterCreated={mockOnCharacterCreated} />);
+        renderQuestCreator({ characters: mockExistingCharacters });
 
         await user.type(screen.getByPlaceholderText(/e.g., "Understand backpropagation/), 'Learn to question everything');
         await user.click(screen.getByRole('button', { name: 'Create Quest' }));
@@ -121,7 +133,7 @@ describe('QuestCreator', () => {
         const errorMessage = 'This goal is not specific enough.';
         mockGenerateContent.mockResolvedValueOnce({ text: JSON.stringify({ meaningful: false, reason: errorMessage }) });
 
-        render(<QuestCreator characters={[]} onBack={mockOnBack} onQuestReady={mockOnQuestReady} onCharacterCreated={mockOnCharacterCreated} />);
+        renderQuestCreator();
 
         await user.type(screen.getByPlaceholderText(/e.g., "Understand backpropagation/), 'asdfasdf');
         await user.click(screen.getByRole('button', { name: 'Create Quest' }));
@@ -134,7 +146,7 @@ describe('QuestCreator', () => {
         const user = userEvent.setup();
         mockGenerateContent.mockRejectedValue(new Error('Network Error'));
 
-        render(<QuestCreator characters={[]} onBack={mockOnBack} onQuestReady={mockOnQuestReady} onCharacterCreated={mockOnCharacterCreated} />);
+        renderQuestCreator();
 
         await user.type(screen.getByPlaceholderText(/e.g., "Understand backpropagation/), 'Learn about APIs');
         await user.click(screen.getByRole('button', { name: 'Create Quest' }));

--- a/tests/hooks/useGeminiLive.test.ts
+++ b/tests/hooks/useGeminiLive.test.ts
@@ -74,6 +74,7 @@ const mockQuest: Quest = {
     focusPoints: ['Asking questions', 'Challenging assumptions'],
     characterId: 'socrates',
 };
+const mockApiKey = 'test-api-key';
 
 describe('useGeminiLive', () => {
     beforeEach(() => {
@@ -88,7 +89,7 @@ describe('useGeminiLive', () => {
 
     it('should initialize with CONNECTING state and transition to LISTENING', async () => {
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null, mockApiKey)
         );
 
         expect(result.current.connectionState).toBe(ConnectionState.CONNECTING);
@@ -102,7 +103,7 @@ describe('useGeminiLive', () => {
 
     it('should handle sending a text message', async () => {
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null, mockApiKey)
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -130,7 +131,7 @@ describe('useGeminiLive', () => {
         });
 
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null, mockApiKey)
         );
 
         await act(async () => {
@@ -171,7 +172,7 @@ describe('useGeminiLive', () => {
         });
 
         renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null, mockApiKey)
         );
 
         await act(async () => {
@@ -189,7 +190,7 @@ describe('useGeminiLive', () => {
 
     it('should toggle microphone and update connection state', async () => {
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null, mockApiKey)
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -214,7 +215,7 @@ describe('useGeminiLive', () => {
 
     it('should handle disconnect properly', async () => {
         const { result, unmount } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null, mockApiKey)
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -241,7 +242,7 @@ describe('useGeminiLive', () => {
         });
 
         const { result } = renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null, mockApiKey)
         );
 
         await waitFor(() => expect(result.current.connectionState).toBe(ConnectionState.LISTENING));
@@ -257,7 +258,7 @@ describe('useGeminiLive', () => {
 
     it('should include quest objective in system instructions if a quest is active', async () => {
         renderHook(() =>
-            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, mockQuest)
+            useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, mockQuest, mockApiKey)
         );
 
         await waitFor(() => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,21 +1,16 @@
 /// <reference types="vitest" />
 
 import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, '.', '');
+export default defineConfig(() => {
     return {
       server: {
         port: 3000,
         host: '0.0.0.0',
       },
       plugins: [react()],
-      define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
-      },
       resolve: {
         alias: {
           '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
## Summary
- add an in-app Gemini API key form that stores each visitor's key locally and gates conversations until provided
- update Gemini-powered components, hooks, and tests to rely on the visitor-provided key instead of build-time environment variables
- refresh documentation and tooling to reflect the new bring-your-own-key flow

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e31a468e98832f8584794434585e1d