### PR TITLE
feat: add openai realtime provider toggle

### DIFF
--- a/App.test.tsx
+++ b/App.test.tsx
@@ -29,8 +29,8 @@ vi.mock('@google/genai', () => {
   };
 });
 
-vi.mock('./hooks/useGeminiLive', () => ({
-  useGeminiLive: vi.fn(() => ({
+vi.mock('./hooks/useRealtimeSession', () => ({
+  useRealtimeSession: vi.fn(() => ({
     connectionState: ConnectionState.CONNECTED,
     userTranscription: '',
     modelTranscription: '',

--- a/README.md
+++ b/README.md
@@ -109,9 +109,15 @@ School of the Ancients is a modern web application that pairs immersive visuals 
    ```bash
    npm install
    ```
-3. Create a `.env` file in the project root and add your Gemini credentials:
+3. Create a `.env` file in the project root and add your Gemini credentials (and optional OpenAI realtime settings):
    ```bash
    GEMINI_API_KEY=your_api_key_here
+   # Optional if you plan to use the OpenAI realtime toggle
+   OPENAI_API_KEY=your_openai_api_key
+   OPENAI_REALTIME_MODEL=gpt-4o-realtime-preview-2024-12-17
+   # Provide a custom websocket host if proxying via your own edge worker
+   # OPENAI_REALTIME_URL=wss://api.openai.com/v1/realtime
+   # OPENAI_ORG_ID=your_org_id_if_required
    ```
 
 ### Running Locally
@@ -137,9 +143,9 @@ Deploy the contents of `dist/` to your static hosting platform of choice.
 
 ## Development Tips
 
-- Vite exposes `process.env.API_KEY` and `process.env.GEMINI_API_KEY` based on the `GEMINI_API_KEY` entry in your `.env` file. Be sure not to commit this file.
+- Vite exposes `process.env.API_KEY` and `process.env.GEMINI_API_KEY` based on the `GEMINI_API_KEY` entry in your `.env` file. When present, OpenAI credentials surface as `process.env.OPENAI_API_KEY`, `process.env.OPENAI_REALTIME_MODEL`, and related variables. Be sure not to commit this file.
 - Shared UI components live in `components/`, while feature views are registered in `App.tsx`.
-- Hooks such as `useGeminiLive` encapsulate audio capture, streaming, and playback logic.
+- Hooks such as `useRealtimeSession` encapsulate audio capture, streaming, and playback logic across Gemini and OpenAI realtime providers.
 - Tailwind utility classes handle layout; extend the Tailwind config before introducing custom CSS.
 - No automated tests exist yet. If you add Vitest or other tooling, expose it through an `npm run test` script.
 
@@ -152,6 +158,7 @@ Deploy the contents of `dist/` to your static hosting platform of choice.
 ## Troubleshooting
 
 - **"API_KEY not set" errors**: Ensure your `.env` file is present and you restarted `npm run dev` after adding it.
+- **"OPENAI_API_KEY environment variable not set" errors**: Either populate the OpenAI fields in your `.env` file or switch the realtime provider toggle back to Gemini.
 - **Microphone permissions**: Clear browser permissions if you accidentally deny access; audio capture is required for real-time chat.
 - **Slow or missing visuals**: Imagen requests can take a few seconds. Watch the developer console for network errors if images do not appear.
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -18,6 +18,7 @@ This document outlines the engineering tasks required to implement the features 
 - `ConversationView.tsx`: To integrate the `useAmbientAudio` hook, display the active quest, and trigger the conversation summary generation.
 - `HistoryView.tsx`: To display the new conversation summaries.
 - `hooks/useGeminiLive.ts`: To accept an `activeQuest` and modify the system instruction accordingly.
+- `hooks/useRealtimeSession.ts`: To delegate between Gemini and OpenAI realtime providers without duplicating consumer logic.
 - `types.ts`: To add `summary` and `ambience` to `SavedConversation` and `Character` interfaces, and define the `Quest` interface.
 - `constants.ts`: To define the list of available `QUESTS` and a new `AMBIENCE_LIBRARY`.
 - `components/CharacterSelector.tsx`: To add buttons for accessing the `QuestsView`.

--- a/hooks/audioUtils.ts
+++ b/hooks/audioUtils.ts
@@ -1,0 +1,56 @@
+import type { Blob as GeminiBlob } from '@google/genai';
+
+export function encodeBytes(bytes: Uint8Array): string {
+  let binary = '';
+  const len = bytes.byteLength;
+  for (let i = 0; i < len; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+export function decodeBase64(base64: string): Uint8Array {
+  const binaryString = atob(base64);
+  const len = binaryString.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export async function decodePcm16ToAudioBuffer(
+  data: Uint8Array,
+  ctx: AudioContext,
+  sampleRate: number,
+  numChannels: number,
+): Promise<AudioBuffer> {
+  const dataInt16 = new Int16Array(data.buffer);
+  const frameCount = dataInt16.length / numChannels;
+  const buffer = ctx.createBuffer(numChannels, frameCount, sampleRate);
+
+  for (let channel = 0; channel < numChannels; channel++) {
+    const channelData = buffer.getChannelData(channel);
+    for (let i = 0; i < frameCount; i++) {
+      channelData[i] = dataInt16[i * numChannels + channel] / 32768.0;
+    }
+  }
+  return buffer;
+}
+
+export function float32ToPcm16Base64(data: Float32Array): string {
+  const l = data.length;
+  const int16 = new Int16Array(l);
+  for (let i = 0; i < l; i++) {
+    const clipped = Math.max(-1, Math.min(1, data[i]));
+    int16[i] = clipped * 32768;
+  }
+  return encodeBytes(new Uint8Array(int16.buffer));
+}
+
+export function createGeminiBlob(data: Float32Array): GeminiBlob {
+  return {
+    data: float32ToPcm16Base64(data),
+    mimeType: 'audio/pcm;rate=16000',
+  };
+}

--- a/hooks/useOpenAiRealtime.ts
+++ b/hooks/useOpenAiRealtime.ts
@@ -1,0 +1,557 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ConnectionState, Quest } from '../types';
+import { decodeBase64, decodePcm16ToAudioBuffer, float32ToPcm16Base64 } from './audioUtils';
+
+type TurnUpdate = { user: string; model: string };
+
+type ToolCallBuffer = {
+  name: string;
+  buffer: string;
+};
+
+const OPENAI_AUDIO_SAMPLE_RATE = 24000;
+const AUDIO_COMMIT_INTERVAL_MS = 650;
+
+export const useOpenAiRealtime = (
+  systemInstruction: string,
+  voiceName: string,
+  voiceAccent: string | undefined,
+  onTurnComplete: (turn: TurnUpdate) => void,
+  onEnvironmentChangeRequest: (description: string) => void,
+  onArtifactDisplayRequest: (name: string, description: string) => void,
+  activeQuest: Quest | null,
+) => {
+  const [connectionState, setConnectionState] = useState<ConnectionState>(ConnectionState.IDLE);
+  const [userTranscription, setUserTranscription] = useState('');
+  const [modelTranscription, setModelTranscription] = useState('');
+  const [isMicActive, setIsMicActive] = useState(true);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const inputAudioContextRef = useRef<AudioContext | null>(null);
+  const outputAudioContextRef = useRef<AudioContext | null>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const audioWorkletNodeRef = useRef<AudioWorkletNode | null>(null);
+  const scriptProcessorRef = useRef<ScriptProcessorNode | null>(null);
+  const mediaStreamSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const silentGainNodeRef = useRef<GainNode | null>(null);
+
+  const nextStartTimeRef = useRef(0);
+  const audioBufferSources = useRef<Set<AudioBufferSourceNode>>(new Set());
+
+  const pendingAudioMsRef = useRef(0);
+  const audioCommitTimeoutRef = useRef<number | null>(null);
+
+  const userTranscriptionRef = useRef('');
+  const modelTranscriptionRef = useRef('');
+  const isMicActiveRef = useRef(isMicActive);
+
+  const onTurnCompleteRef = useRef(onTurnComplete);
+  const onEnvironmentChangeRequestRef = useRef(onEnvironmentChangeRequest);
+  const onArtifactDisplayRequestRef = useRef(onArtifactDisplayRequest);
+
+  const toolCallBuffersRef = useRef<Map<string, ToolCallBuffer>>(new Map());
+
+  onTurnCompleteRef.current = onTurnComplete;
+  onEnvironmentChangeRequestRef.current = onEnvironmentChangeRequest;
+  onArtifactDisplayRequestRef.current = onArtifactDisplayRequest;
+
+  useEffect(() => {
+    isMicActiveRef.current = isMicActive;
+  }, [isMicActive]);
+
+  const clearCommitTimer = useCallback(() => {
+    if (audioCommitTimeoutRef.current !== null) {
+      window.clearTimeout(audioCommitTimeoutRef.current);
+      audioCommitTimeoutRef.current = null;
+    }
+  }, []);
+
+  const disconnect = useCallback(() => {
+    clearCommitTimer();
+
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+
+    mediaStreamRef.current?.getTracks().forEach(track => track.stop());
+
+    if (audioWorkletNodeRef.current && mediaStreamSourceRef.current) {
+      try {
+        mediaStreamSourceRef.current.disconnect(audioWorkletNodeRef.current);
+        if (silentGainNodeRef.current) {
+          audioWorkletNodeRef.current.disconnect(silentGainNodeRef.current);
+          silentGainNodeRef.current.disconnect();
+        } else {
+          audioWorkletNodeRef.current.disconnect();
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    if (scriptProcessorRef.current && mediaStreamSourceRef.current) {
+      try {
+        mediaStreamSourceRef.current.disconnect(scriptProcessorRef.current);
+        scriptProcessorRef.current.disconnect();
+      } catch {
+        // ignore
+      }
+    }
+
+    if (audioWorkletNodeRef.current) {
+      audioWorkletNodeRef.current.port.onmessage = null;
+    }
+
+    audioWorkletNodeRef.current = null;
+    scriptProcessorRef.current = null;
+    mediaStreamSourceRef.current = null;
+    silentGainNodeRef.current = null;
+
+    inputAudioContextRef.current?.close().catch(() => undefined);
+    outputAudioContextRef.current?.close().catch(() => undefined);
+
+    inputAudioContextRef.current = null;
+    outputAudioContextRef.current = null;
+    mediaStreamRef.current = null;
+
+    audioBufferSources.current.forEach(source => {
+      try {
+        source.stop();
+      } catch {
+        // ignore
+      }
+    });
+    audioBufferSources.current.clear();
+
+    setConnectionState(ConnectionState.DISCONNECTED);
+  }, [clearCommitTimer]);
+
+  const flushPendingAudio = useCallback(() => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
+    ws.send(JSON.stringify({
+      type: 'response.create',
+      response: {
+        modalities: ['text', 'audio'],
+        audio: { voice: voiceName },
+      },
+    }));
+    pendingAudioMsRef.current = 0;
+    clearCommitTimer();
+  }, [clearCommitTimer, voiceName]);
+
+  const scheduleCommit = useCallback(() => {
+    clearCommitTimer();
+    audioCommitTimeoutRef.current = window.setTimeout(() => {
+      flushPendingAudio();
+    }, AUDIO_COMMIT_INTERVAL_MS);
+  }, [clearCommitTimer, flushPendingAudio]);
+
+  const toggleMicrophone = useCallback(() => {
+    setIsMicActive(prev => {
+      const next = !prev;
+      const source = mediaStreamSourceRef.current;
+      const workletNode = audioWorkletNodeRef.current;
+      const scriptProcessorNode = scriptProcessorRef.current;
+      const context = inputAudioContextRef.current;
+
+      if (!source || (!workletNode && !scriptProcessorNode) || !context) {
+        return next;
+      }
+
+      try {
+        if (next) {
+          if (workletNode) {
+            source.connect(workletNode);
+            if (!silentGainNodeRef.current) {
+              const silentGain = context.createGain();
+              silentGain.gain.value = 0;
+              workletNode.connect(silentGain);
+              silentGain.connect(context.destination);
+              silentGainNodeRef.current = silentGain;
+            }
+          }
+
+          if (scriptProcessorNode) {
+            source.connect(scriptProcessorNode);
+            try {
+              scriptProcessorNode.connect(context.destination);
+            } catch {
+              // ignore duplicate connections
+            }
+          }
+
+          setConnectionState(ConnectionState.LISTENING);
+        } else {
+          if (workletNode) {
+            source.disconnect(workletNode);
+          }
+
+          if (scriptProcessorNode) {
+            try {
+              source.disconnect(scriptProcessorNode);
+              scriptProcessorNode.disconnect();
+            } catch {
+              // ignore
+            }
+          }
+
+          setConnectionState(ConnectionState.CONNECTED);
+        }
+      } catch {
+        // ignore
+      }
+
+      return next;
+    });
+  }, []);
+
+  const handleToolCallCompleted = useCallback((callId: string, tool: { name: string; arguments?: unknown }) => {
+    if (!tool || tool.name !== 'changeEnvironment' && tool.name !== 'displayArtifact') {
+      return;
+    }
+
+    if (tool.name === 'changeEnvironment' && tool.arguments && typeof (tool.arguments as any).description === 'string') {
+      onEnvironmentChangeRequestRef.current((tool.arguments as any).description);
+    }
+
+    if (tool.name === 'displayArtifact' && tool.arguments) {
+      const args = tool.arguments as any;
+      if (typeof args.name === 'string' && typeof args.description === 'string') {
+        onArtifactDisplayRequestRef.current(args.name, args.description);
+      }
+    }
+
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({
+        type: 'conversation.item.create',
+        item: {
+          type: 'tool_result',
+          call_id: callId,
+          content: [{ type: 'output_text', text: 'ok, action started' }],
+        },
+      }));
+      ws.send(JSON.stringify({ type: 'response.create' }));
+    }
+  }, []);
+
+  const connect = useCallback(async () => {
+    setConnectionState(ConnectionState.CONNECTING);
+
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      console.error('OPENAI_API_KEY environment variable not set.');
+      setConnectionState(ConnectionState.ERROR);
+      return;
+    }
+
+    const realtimeBaseUrl = process.env.OPENAI_REALTIME_URL || 'wss://api.openai.com/v1/realtime';
+    const model = process.env.OPENAI_REALTIME_MODEL || 'gpt-4o-realtime-preview-2024-12-17';
+
+    const url = `${realtimeBaseUrl}?model=${encodeURIComponent(model)}`;
+    const protocols = ['realtime', `openai-insecure-api-key.${apiKey}`];
+    if (process.env.OPENAI_ORG_ID) {
+      protocols.push(`openai-insecure-org-id.${process.env.OPENAI_ORG_ID}`);
+    }
+
+    try {
+      const ws = new WebSocket(url, protocols);
+      wsRef.current = ws;
+
+      ws.addEventListener('open', async () => {
+        try {
+          setConnectionState(ConnectionState.CONNECTED);
+
+          inputAudioContextRef.current = new (window.AudioContext || (window as any).webkitAudioContext)({ sampleRate: 16000 });
+          outputAudioContextRef.current = new (window.AudioContext || (window as any).webkitAudioContext)({ sampleRate: OPENAI_AUDIO_SAMPLE_RATE });
+
+          mediaStreamRef.current = await navigator.mediaDevices.getUserMedia({ audio: true });
+          const source = inputAudioContextRef.current.createMediaStreamSource(mediaStreamRef.current);
+          mediaStreamSourceRef.current = source;
+
+          const sanitizedAccent = voiceAccent?.trim();
+          let baseInstruction = systemInstruction.trim();
+          if (sanitizedAccent) {
+            const accentDirective = `Always speak using ${sanitizedAccent}, ensuring the accent, gender, and tone remain consistent.`;
+            if (!baseInstruction.toLowerCase().includes(sanitizedAccent.toLowerCase())) {
+              baseInstruction = `${baseInstruction}\n\nVOICE ACCENT REQUIREMENT: ${accentDirective}`;
+            }
+          }
+
+          let finalSystemInstruction = baseInstruction;
+          if (activeQuest) {
+            finalSystemInstruction = `YOUR CURRENT MISSION: As a mentor, your primary goal is to guide the student to understand the following: "${activeQuest.objective}". Tailor your questions and explanations to lead them towards this goal.\n\nQUEST COMPLETION PROTOCOL:\n1. Explicitly track the quest's focus points and confirm each one with the learner.\n2. The moment the learner demonstrates mastery of every focus area, clearly announce that the quest curriculum is complete. Congratulate them, encourage a brief self-reflection, and invite them to end the session so they can take the mastery quiz.\n3. After declaring completion, avoid introducing new topics unless the learner requests a targeted review.\n\n---\n\n${baseInstruction}`;
+          }
+
+          ws.send(JSON.stringify({
+            type: 'session.update',
+            session: {
+              instructions: finalSystemInstruction,
+              voice: voiceName,
+              input_audio_format: { type: 'pcm16', sample_rate: 16000, channels: 1 },
+              output_audio_format: { type: 'pcm16', sample_rate: OPENAI_AUDIO_SAMPLE_RATE, channels: 1 },
+            },
+          }));
+
+          let initialized = false;
+          const audioWorklet = inputAudioContextRef.current.audioWorklet;
+          if (audioWorklet && typeof audioWorklet.addModule === 'function') {
+            try {
+              const workletModuleUrl = new URL('../audio/microphoneWorkletProcessor.js', import.meta.url);
+              await audioWorklet.addModule(workletModuleUrl);
+
+              const audioWorkletNode = new AudioWorkletNode(inputAudioContextRef.current, 'microphone-processor', {
+                numberOfInputs: 1,
+                numberOfOutputs: 1,
+                channelCount: 1,
+              });
+              audioWorkletNodeRef.current = audioWorkletNode;
+
+              audioWorkletNode.port.onmessage = (event) => {
+                const inputData = event.data as Float32Array | undefined;
+                if (!(inputData instanceof Float32Array)) {
+                  return;
+                }
+
+                if (!isMicActiveRef.current) {
+                  return;
+                }
+
+                const wsInstance = wsRef.current;
+                if (!wsInstance || wsInstance.readyState !== WebSocket.OPEN) {
+                  return;
+                }
+
+                const base64 = float32ToPcm16Base64(inputData);
+                wsInstance.send(JSON.stringify({ type: 'input_audio_buffer.append', audio: base64 }));
+
+                const chunkDurationMs = (inputData.length / 16000) * 1000;
+                pendingAudioMsRef.current += chunkDurationMs;
+                if (pendingAudioMsRef.current >= AUDIO_COMMIT_INTERVAL_MS) {
+                  flushPendingAudio();
+                } else {
+                  scheduleCommit();
+                }
+              };
+
+              if (isMicActiveRef.current) {
+                source.connect(audioWorkletNode);
+                if (!silentGainNodeRef.current) {
+                  const silentGain = inputAudioContextRef.current.createGain();
+                  silentGain.gain.value = 0;
+                  audioWorkletNode.connect(silentGain);
+                  silentGain.connect(inputAudioContextRef.current.destination);
+                  silentGainNodeRef.current = silentGain;
+                }
+                setConnectionState(ConnectionState.LISTENING);
+              }
+
+              initialized = true;
+            } catch (error) {
+              console.warn('AudioWorkletNode unavailable, falling back to ScriptProcessorNode:', error);
+            }
+          }
+
+          if (!initialized) {
+            const scriptProcessor = inputAudioContextRef.current.createScriptProcessor(4096, 1, 1);
+            scriptProcessorRef.current = scriptProcessor;
+
+            scriptProcessor.onaudioprocess = (audioProcessingEvent) => {
+              if (!isMicActiveRef.current) {
+                return;
+              }
+
+              const inputData = audioProcessingEvent.inputBuffer.getChannelData(0);
+              const wsInstance = wsRef.current;
+              if (!wsInstance || wsInstance.readyState !== WebSocket.OPEN) {
+                return;
+              }
+
+              const base64 = float32ToPcm16Base64(inputData);
+              wsInstance.send(JSON.stringify({ type: 'input_audio_buffer.append', audio: base64 }));
+
+              const chunkDurationMs = (inputData.length / 16000) * 1000;
+              pendingAudioMsRef.current += chunkDurationMs;
+              if (pendingAudioMsRef.current >= AUDIO_COMMIT_INTERVAL_MS) {
+                flushPendingAudio();
+              } else {
+                scheduleCommit();
+              }
+            };
+
+            if (isMicActiveRef.current) {
+              source.connect(scriptProcessor);
+              scriptProcessor.connect(inputAudioContextRef.current.destination);
+              setConnectionState(ConnectionState.LISTENING);
+            }
+          }
+        } catch (error) {
+          console.error('Failed to initialize OpenAI realtime session audio pipeline:', error);
+          setConnectionState(ConnectionState.ERROR);
+        }
+      });
+
+      ws.addEventListener('message', async (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          switch (data.type) {
+            case 'response.input_text.delta': {
+              const nextInput = userTranscriptionRef.current + (data.delta ?? '');
+              userTranscriptionRef.current = nextInput;
+              setUserTranscription(nextInput);
+              break;
+            }
+            case 'response.output_text.delta': {
+              setConnectionState(ConnectionState.THINKING);
+              const nextOutput = modelTranscriptionRef.current + (data.delta ?? '');
+              modelTranscriptionRef.current = nextOutput;
+              setModelTranscription(nextOutput);
+              break;
+            }
+            case 'response.output_audio.delta': {
+              if (!outputAudioContextRef.current || !data.delta) {
+                break;
+              }
+              setConnectionState(ConnectionState.SPEAKING);
+              const audioData = decodeBase64(data.delta);
+              const audioBuffer = await decodePcm16ToAudioBuffer(audioData, outputAudioContextRef.current, OPENAI_AUDIO_SAMPLE_RATE, 1);
+              const source = outputAudioContextRef.current.createBufferSource();
+              source.buffer = audioBuffer;
+              source.connect(outputAudioContextRef.current.destination);
+
+              const currentTime = outputAudioContextRef.current.currentTime;
+              const startTime = Math.max(currentTime, nextStartTimeRef.current);
+              source.start(startTime);
+              nextStartTimeRef.current = startTime + audioBuffer.duration;
+
+              audioBufferSources.current.add(source);
+              source.onended = () => {
+                audioBufferSources.current.delete(source);
+                if (audioBufferSources.current.size === 0) {
+                  setConnectionState(isMicActiveRef.current ? ConnectionState.LISTENING : ConnectionState.CONNECTED);
+                }
+              };
+              break;
+            }
+            case 'response.output_tool_call.delta': {
+              const callId = data.call_id as string;
+              if (!callId) break;
+              const buffer = toolCallBuffersRef.current.get(callId) ?? { name: data.name ?? '', buffer: '' };
+              if (typeof data.name === 'string') {
+                buffer.name = data.name;
+              }
+              if (data.delta?.partial_json) {
+                buffer.buffer += data.delta.partial_json;
+              }
+              toolCallBuffersRef.current.set(callId, buffer);
+              break;
+            }
+            case 'response.output_tool_call.completed': {
+              const callId = data.call_id as string;
+              if (!callId) break;
+              const buffer = toolCallBuffersRef.current.get(callId);
+              toolCallBuffersRef.current.delete(callId);
+              if (!buffer) break;
+              try {
+                const parsedArgs = buffer.buffer ? JSON.parse(buffer.buffer) : {};
+                handleToolCallCompleted(callId, { name: buffer.name, arguments: parsedArgs });
+              } catch (error) {
+                console.warn('Failed to parse tool call arguments', error);
+              }
+              break;
+            }
+            case 'response.completed': {
+              clearCommitTimer();
+              pendingAudioMsRef.current = 0;
+              const userText = userTranscriptionRef.current.trim();
+              const modelText = modelTranscriptionRef.current.trim();
+              if (userText || modelText) {
+                onTurnCompleteRef.current({ user: userText, model: modelText });
+              }
+              userTranscriptionRef.current = '';
+              modelTranscriptionRef.current = '';
+              setUserTranscription('');
+              setModelTranscription('');
+              setConnectionState(isMicActiveRef.current ? ConnectionState.LISTENING : ConnectionState.CONNECTED);
+              break;
+            }
+            case 'error': {
+              console.error('OpenAI realtime error event:', data);
+              setConnectionState(ConnectionState.ERROR);
+              break;
+            }
+            default:
+              break;
+          }
+        } catch (error) {
+          console.error('Failed to process OpenAI realtime event:', error);
+        }
+      });
+
+      ws.addEventListener('close', () => {
+        setConnectionState(ConnectionState.DISCONNECTED);
+      });
+
+      ws.addEventListener('error', (event) => {
+        console.error('OpenAI realtime WebSocket error:', event);
+        setConnectionState(ConnectionState.ERROR);
+      });
+    } catch (error) {
+      console.error('Failed to connect to OpenAI realtime API:', error);
+      setConnectionState(ConnectionState.ERROR);
+    }
+  }, [activeQuest, flushPendingAudio, handleToolCallCompleted, scheduleCommit, systemInstruction, voiceAccent, voiceName]);
+
+  const sendTextMessage = useCallback((text: string) => {
+    if (!text.trim()) return;
+
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      console.warn('Realtime connection is not ready for text messages.');
+      return;
+    }
+
+    onTurnCompleteRef.current({ user: text, model: '' });
+    userTranscriptionRef.current = '';
+
+    setConnectionState(ConnectionState.THINKING);
+
+    ws.send(JSON.stringify({
+      type: 'conversation.item.create',
+      item: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text }],
+      },
+    }));
+    ws.send(JSON.stringify({
+      type: 'response.create',
+      response: {
+        modalities: ['text', 'audio'],
+        audio: { voice: voiceName },
+      },
+    }));
+  }, [voiceName]);
+
+  useEffect(() => {
+    connect();
+    return () => {
+      disconnect();
+    };
+  }, [connect, disconnect]);
+
+  return useMemo(() => ({
+    connectionState,
+    userTranscription,
+    modelTranscription,
+    isMicActive,
+    toggleMicrophone,
+    sendTextMessage,
+  }), [connectionState, isMicActive, modelTranscription, toggleMicrophone, sendTextMessage, userTranscription]);
+};

--- a/hooks/useRealtimeSession.ts
+++ b/hooks/useRealtimeSession.ts
@@ -1,0 +1,31 @@
+import { useMemo } from 'react';
+import { useGeminiLive } from './useGeminiLive';
+import { useOpenAiRealtime } from './useOpenAiRealtime';
+import type { Quest, RealtimeProvider } from '../types';
+
+type TurnUpdateHandler = (turn: { user: string; model: string }) => void;
+
+type RealtimeHookResult = ReturnType<typeof useGeminiLive>;
+
+type SharedArgs = [
+  systemInstruction: string,
+  voiceName: string,
+  voiceAccent: string | undefined,
+  onTurnComplete: TurnUpdateHandler,
+  onEnvironmentChangeRequest: (description: string) => void,
+  onArtifactDisplayRequest: (name: string, description: string) => void,
+  activeQuest: Quest | null,
+];
+
+const providers: Record<RealtimeProvider, (...args: SharedArgs) => RealtimeHookResult> = {
+  gemini: useGeminiLive,
+  openai: useOpenAiRealtime,
+};
+
+export const useRealtimeSession = (
+  provider: RealtimeProvider,
+  ...args: SharedArgs
+): RealtimeHookResult => {
+  const hook = useMemo(() => providers[provider], [provider]);
+  return hook(...args);
+};

--- a/tests/hooks/useRealtimeSession.test.ts
+++ b/tests/hooks/useRealtimeSession.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useRealtimeSession } from '../../hooks/useRealtimeSession';
+
+const geminiResult = {
+  connectionState: 'gemini',
+  userTranscription: '',
+  modelTranscription: '',
+  isMicActive: true,
+  toggleMicrophone: vi.fn(),
+  sendTextMessage: vi.fn(),
+};
+
+const openAiResult = {
+  connectionState: 'openai',
+  userTranscription: '',
+  modelTranscription: '',
+  isMicActive: true,
+  toggleMicrophone: vi.fn(),
+  sendTextMessage: vi.fn(),
+};
+
+const useGeminiLiveMock = vi.fn(() => geminiResult);
+const useOpenAiRealtimeMock = vi.fn(() => openAiResult);
+
+vi.mock('../../hooks/useGeminiLive', () => ({
+  useGeminiLive: (...args: unknown[]) => useGeminiLiveMock(...args),
+}));
+
+vi.mock('../../hooks/useOpenAiRealtime', () => ({
+  useOpenAiRealtime: (...args: unknown[]) => useOpenAiRealtimeMock(...args),
+}));
+
+describe('useRealtimeSession', () => {
+  const baseArgs: [string, string, string | undefined, (turn: { user: string; model: string }) => void, (description: string) => void, (name: string, description: string) => void, null] = [
+    'instruction',
+    'voice',
+    'accent',
+    vi.fn(),
+    vi.fn(),
+    vi.fn(),
+    null,
+  ];
+
+  it('delegates to the Gemini hook when provider is gemini', () => {
+    const { result } = renderHook(() => useRealtimeSession('gemini', ...baseArgs));
+    expect(result.current).toBe(geminiResult);
+    expect(useGeminiLiveMock).toHaveBeenCalledTimes(1);
+    expect(useGeminiLiveMock).toHaveBeenCalledWith(...baseArgs);
+    expect(useOpenAiRealtimeMock).not.toHaveBeenCalled();
+  });
+
+  it('delegates to the OpenAI hook when provider is openai', () => {
+    const { result } = renderHook(() => useRealtimeSession('openai', ...baseArgs));
+    expect(result.current).toBe(openAiResult);
+    expect(useOpenAiRealtimeMock).toHaveBeenCalledTimes(1);
+    expect(useOpenAiRealtimeMock).toHaveBeenCalledWith(...baseArgs);
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -53,6 +53,8 @@ export enum ConnectionState {
   DISCONNECTED = 'DISCONNECTED',
 }
 
+export type RealtimeProvider = 'gemini' | 'openai';
+
 export interface ConversationTurn {
   speaker: 'user' | 'model';
   speakerName: string;


### PR DESCRIPTION
## Summary
- add an OpenAI realtime hook alongside a provider-agnostic `useRealtimeSession` wrapper
- expose a Gemini/OpenAI dropdown in the conversation view and persist the chosen provider
- document the new configuration knobs and cover the provider selector with new unit tests

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e2fc881e60832fab0024fa57b04a69