### PR TITLE
Add OpenAI realtime provider support

### DIFF
--- a/App.test.tsx
+++ b/App.test.tsx
@@ -40,6 +40,17 @@ vi.mock('./hooks/useGeminiLive', () => ({
   })),
 }));
 
+vi.mock('./hooks/useOpenAiLive', () => ({
+  useOpenAiLive: vi.fn(() => ({
+    connectionState: ConnectionState.CONNECTED,
+    userTranscription: '',
+    modelTranscription: '',
+    isMicActive: true,
+    toggleMicrophone: vi.fn(),
+    sendTextMessage: vi.fn(),
+  })),
+}));
+
 const mockLocalStorage = (() => {
   let store: Record<string, string> = {};
   return {

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ School of the Ancients is a modern web application that pairs immersive visuals 
 - **Node.js** 20 or later
 - **npm** 10 or later (ships with modern Node releases)
 - A Google Gemini API key with access to the realtime and Imagen models
+- (Optional) An OpenAI API key with access to the Realtime API if you plan to use the OpenAI transport
 
 ### Installation
 
@@ -109,9 +110,10 @@ School of the Ancients is a modern web application that pairs immersive visuals 
    ```bash
    npm install
    ```
-3. Create a `.env` file in the project root and add your Gemini credentials:
+3. Create a `.env` file in the project root and add your credentials:
    ```bash
-   GEMINI_API_KEY=your_api_key_here
+   GEMINI_API_KEY=your_gemini_key_here
+   OPENAI_API_KEY=your_openai_key_here # required only if you enable the OpenAI Realtime provider
    ```
 
 ### Running Locally
@@ -139,7 +141,7 @@ Deploy the contents of `dist/` to your static hosting platform of choice.
 
 - Vite exposes `process.env.API_KEY` and `process.env.GEMINI_API_KEY` based on the `GEMINI_API_KEY` entry in your `.env` file. Be sure not to commit this file.
 - Shared UI components live in `components/`, while feature views are registered in `App.tsx`.
-- Hooks such as `useGeminiLive` encapsulate audio capture, streaming, and playback logic.
+- Hooks such as `useGeminiLive` and `useOpenAiLive` encapsulate audio capture, streaming, and playback logic.
 - Tailwind utility classes handle layout; extend the Tailwind config before introducing custom CSS.
 - No automated tests exist yet. If you add Vitest or other tooling, expose it through an `npm run test` script.
 
@@ -151,7 +153,7 @@ Deploy the contents of `dist/` to your static hosting platform of choice.
 
 ## Troubleshooting
 
-- **"API_KEY not set" errors**: Ensure your `.env` file is present and you restarted `npm run dev` after adding it.
+- **"API_KEY not set" errors**: Ensure your `.env` file is present and you restarted `npm run dev` after adding it. For OpenAI connections, verify `OPENAI_API_KEY` is also defined.
 - **Microphone permissions**: Clear browser permissions if you accidentally deny access; audio capture is required for real-time chat.
 - **Slow or missing visuals**: Imagen requests can take a few seconds. Watch the developer console for network errors if images do not appear.
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -17,7 +17,7 @@ This document outlines the engineering tasks required to implement the features 
 - `App.tsx`: To manage new views (`quests`), state (`activeQuest`), and integrate the new `HowToGuide`.
 - `ConversationView.tsx`: To integrate the `useAmbientAudio` hook, display the active quest, and trigger the conversation summary generation.
 - `HistoryView.tsx`: To display the new conversation summaries.
-- `hooks/useGeminiLive.ts`: To accept an `activeQuest` and modify the system instruction accordingly.
+- `hooks/useGeminiLive.ts` / `hooks/useOpenAiLive.ts`: To handle provider-specific realtime streaming while incorporating the active quest system instruction adjustments.
 - `types.ts`: To add `summary` and `ambience` to `SavedConversation` and `Character` interfaces, and define the `Quest` interface.
 - `constants.ts`: To define the list of available `QUESTS` and a new `AMBIENCE_LIBRARY`.
 - `components/CharacterSelector.tsx`: To add buttons for accessing the `QuestsView`.

--- a/hooks/audioUtils.ts
+++ b/hooks/audioUtils.ts
@@ -1,0 +1,61 @@
+import { Blob } from '@google/genai';
+
+export function encodeBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const len = bytes.byteLength;
+  for (let i = 0; i < len; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+export function decodeBase64(base64: string): Uint8Array {
+  const binaryString = atob(base64);
+  const len = binaryString.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export function float32ToPCM16(data: Float32Array): Int16Array {
+  const int16 = new Int16Array(data.length);
+  for (let i = 0; i < data.length; i++) {
+    const sample = Math.max(-1, Math.min(1, data[i]));
+    int16[i] = sample < 0 ? sample * 0x8000 : sample * 0x7fff;
+  }
+  return int16;
+}
+
+export function createGeminiRealtimeBlob(data: Float32Array): Blob {
+  const int16 = float32ToPCM16(data);
+  return {
+    data: encodeBase64(new Uint8Array(int16.buffer)),
+    mimeType: 'audio/pcm;rate=16000',
+  };
+}
+
+export function decodeBase64ToPCM16(base64: string): Int16Array {
+  const bytes = decodeBase64(base64);
+  return new Int16Array(bytes.buffer);
+}
+
+export function createAudioBufferFromPCM16(
+  data: Int16Array,
+  ctx: AudioContext,
+  sampleRate: number,
+  numChannels: number,
+): AudioBuffer {
+  const frameCount = data.length / numChannels;
+  const buffer = ctx.createBuffer(numChannels, frameCount, sampleRate);
+
+  for (let channel = 0; channel < numChannels; channel++) {
+    const channelData = buffer.getChannelData(channel);
+    for (let i = 0; i < frameCount; i++) {
+      channelData[i] = data[i * numChannels + channel] / 32768.0;
+    }
+  }
+
+  return buffer;
+}

--- a/hooks/realtimeTools.ts
+++ b/hooks/realtimeTools.ts
@@ -1,0 +1,101 @@
+import { FunctionDeclaration, Type } from '@google/genai';
+
+type JsonSchemaProperty = {
+  type: 'string';
+  description: string;
+};
+
+type JsonSchema = {
+  type: 'object';
+  description: string;
+  properties: Record<string, JsonSchemaProperty>;
+  required: string[];
+};
+
+const changeEnvironmentDescription =
+  "Changes the user's visual environment to a specified location or scene. Use this when the user says 'take me to', 'show me', 'go to', or similar phrases requesting a scene change, or when addressing the 'Operator' (e.g., 'Operator, take me to the Roman Forum').";
+
+const displayArtifactDescription =
+  "Generates and displays an image of a specific object, artifact, or concept being discussed. Use this when the character wants to 'show' something to the user, when the user asks to see something (e.g. 'show me the artifact'), or when addressing the 'Operator' (e.g., 'Operator, show me a diagram').";
+
+const changeEnvironmentProperties: Record<string, JsonSchemaProperty> = {
+  description: {
+    type: 'string',
+    description:
+      "A detailed description of the environment, e.g., 'the Egyptian pyramids at sunset' or 'Leonardo da Vinci's workshop'.",
+  },
+};
+
+const displayArtifactProperties: Record<string, JsonSchemaProperty> = {
+  name: {
+    type: 'string',
+    description: 'The name of the artifact, e.g., "flying machine" or "Mona Lisa".',
+  },
+  description: {
+    type: 'string',
+    description:
+      'A detailed prompt for the image generation model to create a visual representation of the artifact.',
+  },
+};
+
+export const changeEnvironmentFunctionDeclaration: FunctionDeclaration = {
+  name: 'changeEnvironment',
+  parameters: {
+    type: Type.OBJECT,
+    description: changeEnvironmentDescription,
+    properties: {
+      description: {
+        type: Type.STRING,
+        description:
+          "A detailed description of the environment, e.g., 'the Egyptian pyramids at sunset' or 'Leonardo da Vinci's workshop'.",
+      },
+    },
+    required: ['description'],
+  },
+};
+
+export const displayArtifactFunctionDeclaration: FunctionDeclaration = {
+  name: 'displayArtifact',
+  parameters: {
+    type: Type.OBJECT,
+    description: displayArtifactDescription,
+    properties: {
+      name: {
+        type: Type.STRING,
+        description: 'The name of the artifact, e.g., "flying machine" or "Mona Lisa".',
+      },
+      description: {
+        type: Type.STRING,
+        description:
+          'A detailed prompt for the image generation model to create a visual representation of the artifact.',
+      },
+    },
+    required: ['name', 'description'],
+  },
+};
+
+const changeEnvironmentSchema: JsonSchema = {
+  type: 'object',
+  description: changeEnvironmentDescription,
+  properties: changeEnvironmentProperties,
+  required: ['description'],
+};
+
+const displayArtifactSchema: JsonSchema = {
+  type: 'object',
+  description: displayArtifactDescription,
+  properties: displayArtifactProperties,
+  required: ['name', 'description'],
+};
+
+export const changeEnvironmentToolDefinition = {
+  name: 'changeEnvironment',
+  description: changeEnvironmentDescription,
+  parameters: changeEnvironmentSchema,
+};
+
+export const displayArtifactToolDefinition = {
+  name: 'displayArtifact',
+  description: displayArtifactDescription,
+  parameters: displayArtifactSchema,
+};

--- a/hooks/useOpenAiLive.ts
+++ b/hooks/useOpenAiLive.ts
@@ -1,0 +1,485 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { RealtimeClient } from '@openai/realtime-api-beta';
+import { ConnectionState, Quest } from '../types';
+import {
+  createAudioBufferFromPCM16,
+  float32ToPCM16,
+} from './audioUtils';
+import {
+  changeEnvironmentToolDefinition,
+  displayArtifactToolDefinition,
+} from './realtimeTools';
+
+const OPENAI_REALTIME_MODEL = 'gpt-4o-realtime-preview-2024-12-17';
+const OPENAI_SAMPLE_RATE = 24000;
+
+const OPENAI_VOICE_MAP: Record<string, 'alloy' | 'ash' | 'ballad' | 'coral' | 'echo' | 'sage' | 'shimmer' | 'verse'> = {
+  'charon': 'alloy',
+  'fenrir': 'ash',
+  'kore': 'sage',
+  'puck': 'verse',
+  'zephyr': 'shimmer',
+};
+
+function resolveOpenAiVoice(voiceName?: string, accent?: string) {
+  if (voiceName) {
+    const normalized = voiceName.trim().toLowerCase();
+    if (OPENAI_VOICE_MAP[normalized]) {
+      return OPENAI_VOICE_MAP[normalized];
+    }
+  }
+
+  if (accent) {
+    const normalizedAccent = accent.toLowerCase();
+    if (normalizedAccent.includes('british') || normalizedAccent.includes('uk')) {
+      return 'alloy';
+    }
+    if (normalizedAccent.includes('mediterranean') || normalizedAccent.includes('italian')) {
+      return 'coral';
+    }
+  }
+
+  return 'verse';
+}
+
+export const useOpenAiLive = (
+  systemInstruction: string,
+  voiceName: string,
+  voiceAccent: string | undefined,
+  onTurnComplete: (turn: { user: string; model: string }) => void,
+  onEnvironmentChangeRequest: (description: string) => void,
+  onArtifactDisplayRequest: (name: string, description: string) => void,
+  activeQuest: Quest | null,
+  enabled = true,
+) => {
+  const [connectionState, setConnectionState] = useState<ConnectionState>(ConnectionState.IDLE);
+  const [userTranscription, setUserTranscription] = useState('');
+  const [modelTranscription, setModelTranscription] = useState('');
+  const [isMicActive, setIsMicActive] = useState(true);
+
+  const clientRef = useRef<RealtimeClient | null>(null);
+  const inputAudioContextRef = useRef<AudioContext | null>(null);
+  const outputAudioContextRef = useRef<AudioContext | null>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const audioWorkletNodeRef = useRef<AudioWorkletNode | null>(null);
+  const scriptProcessorRef = useRef<ScriptProcessorNode | null>(null);
+  const mediaStreamSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const silentGainNodeRef = useRef<GainNode | null>(null);
+
+  const userTranscriptionRef = useRef('');
+  const modelTranscriptionRef = useRef('');
+  const isMicActiveRef = useRef(isMicActive);
+  const nextStartTimeRef = useRef(0);
+  const audioBufferSources = useRef<Set<AudioBufferSourceNode>>(new Set());
+
+  const onTurnCompleteRef = useRef(onTurnComplete);
+  onTurnCompleteRef.current = onTurnComplete;
+  const onEnvironmentChangeRequestRef = useRef(onEnvironmentChangeRequest);
+  onEnvironmentChangeRequestRef.current = onEnvironmentChangeRequest;
+  const onArtifactDisplayRequestRef = useRef(onArtifactDisplayRequest);
+  onArtifactDisplayRequestRef.current = onArtifactDisplayRequest;
+
+  useEffect(() => {
+    isMicActiveRef.current = isMicActive;
+  }, [isMicActive]);
+
+  const stopAllScheduledAudio = useCallback(() => {
+    for (const source of audioBufferSources.current.values()) {
+      try {
+        source.stop();
+      } catch (error) {
+        console.warn('Error stopping OpenAI audio source', error);
+      }
+      audioBufferSources.current.delete(source);
+    }
+    nextStartTimeRef.current = 0;
+  }, []);
+
+  const disconnect = useCallback(() => {
+    stopAllScheduledAudio();
+
+    clientRef.current?.disconnect();
+    clientRef.current = null;
+
+    mediaStreamRef.current?.getTracks().forEach(track => track.stop());
+
+    if (audioWorkletNodeRef.current && mediaStreamSourceRef.current) {
+      try {
+        mediaStreamSourceRef.current.disconnect(audioWorkletNodeRef.current);
+        if (silentGainNodeRef.current) {
+          audioWorkletNodeRef.current.disconnect(silentGainNodeRef.current);
+          silentGainNodeRef.current.disconnect();
+        } else {
+          audioWorkletNodeRef.current.disconnect();
+        }
+      } catch (error) {
+        // Ignore errors on disconnect
+      }
+    }
+
+    if (scriptProcessorRef.current && mediaStreamSourceRef.current) {
+      try {
+        mediaStreamSourceRef.current.disconnect(scriptProcessorRef.current);
+        scriptProcessorRef.current.disconnect();
+      } catch (error) {
+        // Ignore errors on disconnect
+      }
+    }
+
+    if (audioWorkletNodeRef.current) {
+      audioWorkletNodeRef.current.port.onmessage = null;
+    }
+
+    audioWorkletNodeRef.current = null;
+    scriptProcessorRef.current = null;
+    mediaStreamSourceRef.current = null;
+    silentGainNodeRef.current = null;
+
+    inputAudioContextRef.current?.close().catch(console.error);
+    outputAudioContextRef.current?.close().catch(console.error);
+
+    inputAudioContextRef.current = null;
+    outputAudioContextRef.current = null;
+    mediaStreamRef.current = null;
+
+    setConnectionState(ConnectionState.DISCONNECTED);
+  }, [stopAllScheduledAudio]);
+
+  const initializeMicrophone = useCallback(async (client: RealtimeClient) => {
+    inputAudioContextRef.current = new (window.AudioContext || (window as any).webkitAudioContext)({ sampleRate: 16000 });
+    outputAudioContextRef.current = new (window.AudioContext || (window as any).webkitAudioContext)({ sampleRate: OPENAI_SAMPLE_RATE });
+
+    mediaStreamRef.current = await navigator.mediaDevices.getUserMedia({ audio: true });
+
+    const source = inputAudioContextRef.current.createMediaStreamSource(mediaStreamRef.current);
+    mediaStreamSourceRef.current = source;
+
+    let initialized = false;
+    const audioWorklet = inputAudioContextRef.current.audioWorklet;
+    if (audioWorklet && typeof audioWorklet.addModule === 'function') {
+      try {
+        const workletModuleUrl = new URL('../audio/microphoneWorkletProcessor.js', import.meta.url);
+        await audioWorklet.addModule(workletModuleUrl);
+
+        const audioWorkletNode = new AudioWorkletNode(inputAudioContextRef.current, 'microphone-processor', {
+          numberOfInputs: 1,
+          numberOfOutputs: 1,
+          channelCount: 1,
+        });
+        audioWorkletNodeRef.current = audioWorkletNode;
+
+        audioWorkletNode.port.onmessage = (event) => {
+          const inputData = event.data as Float32Array | undefined;
+          if (!(inputData instanceof Float32Array) || !isMicActiveRef.current) {
+            return;
+          }
+
+          const pcm16 = float32ToPCM16(inputData);
+          try {
+            client.appendInputAudio(pcm16);
+          } catch (err) {
+            console.warn('Failed to append audio to OpenAI realtime buffer:', err);
+          }
+        };
+
+        if (isMicActiveRef.current) {
+          source.connect(audioWorkletNode);
+          if (!silentGainNodeRef.current) {
+            const silentGain = inputAudioContextRef.current.createGain();
+            silentGain.gain.value = 0;
+            audioWorkletNode.connect(silentGain);
+            silentGain.connect(inputAudioContextRef.current.destination);
+            silentGainNodeRef.current = silentGain;
+          }
+          setConnectionState(ConnectionState.LISTENING);
+        }
+
+        initialized = true;
+      } catch (error) {
+        console.warn('AudioWorkletNode unavailable for OpenAI realtime, falling back to ScriptProcessorNode:', error);
+      }
+    }
+
+    if (!initialized) {
+      const scriptProcessor = inputAudioContextRef.current.createScriptProcessor(4096, 1, 1);
+      scriptProcessorRef.current = scriptProcessor;
+
+      scriptProcessor.onaudioprocess = (audioProcessingEvent) => {
+        if (!isMicActiveRef.current) {
+          return;
+        }
+        const inputData = audioProcessingEvent.inputBuffer.getChannelData(0);
+        const pcm16 = float32ToPCM16(inputData);
+        try {
+          client.appendInputAudio(pcm16);
+        } catch (err) {
+          console.warn('Failed to append audio to OpenAI realtime buffer:', err);
+        }
+      };
+
+      if (isMicActiveRef.current) {
+        source.connect(scriptProcessor);
+        scriptProcessor.connect(inputAudioContextRef.current.destination);
+        setConnectionState(ConnectionState.LISTENING);
+      }
+    }
+  }, []);
+
+  const connect = useCallback(async () => {
+    if (!enabled) {
+      return;
+    }
+
+    setConnectionState(ConnectionState.CONNECTING);
+
+    if (!process.env.OPENAI_API_KEY) {
+      console.error('OPENAI_API_KEY environment variable not set.');
+      setConnectionState(ConnectionState.ERROR);
+      return;
+    }
+
+    const sanitizedAccent = voiceAccent?.trim();
+    let baseInstruction = systemInstruction.trim();
+    if (sanitizedAccent) {
+      const accentDirective = `Always speak using ${sanitizedAccent}, ensuring the accent, gender, and tone remain consistent. If your voice deviates from ${sanitizedAccent}, correct it immediately before continuing.`;
+      const normalizedInstruction = baseInstruction.toLowerCase();
+      if (!normalizedInstruction.includes(sanitizedAccent.toLowerCase())) {
+        baseInstruction = `${baseInstruction}\n\nVOICE ACCENT REQUIREMENT: ${accentDirective}`;
+      }
+    }
+
+    let finalSystemInstruction = baseInstruction;
+    if (activeQuest) {
+      finalSystemInstruction = `YOUR CURRENT MISSION: As a mentor, your primary goal is to guide the student to understand the following: "${activeQuest.objective}". Tailor your questions and explanations to lead them towards this goal.\n\nQUEST COMPLETION PROTOCOL:\n1. Explicitly track the quest's focus points and confirm each one with the learner.\n2. The moment the learner demonstrates mastery of every focus area, clearly announce that the quest curriculum is complete. Congratulate them, encourage a brief self-reflection, and invite them to end the session so they can take the mastery quiz.\n3. After declaring completion, avoid introducing new topics unless the learner requests a targeted review.\n\n---\n\n${baseInstruction}`;
+    }
+
+    try {
+      const client = new RealtimeClient({
+        apiKey: process.env.OPENAI_API_KEY,
+        dangerouslyAllowAPIKeyInBrowser: true,
+      });
+      clientRef.current = client;
+
+      client.on('conversation.updated', ({ item, delta }: any) => {
+        if (!item) {
+          return;
+        }
+
+        if (item.role === 'user') {
+          if (delta?.transcript) {
+            userTranscriptionRef.current += delta.transcript;
+            setUserTranscription(userTranscriptionRef.current);
+          } else if (delta?.text) {
+            userTranscriptionRef.current += delta.text;
+            setUserTranscription(userTranscriptionRef.current);
+          } else if (item.formatted?.transcript) {
+            userTranscriptionRef.current = item.formatted.transcript.trim();
+            setUserTranscription(userTranscriptionRef.current);
+          }
+        } else if (item.role === 'assistant') {
+          if (delta?.text) {
+            setConnectionState(ConnectionState.THINKING);
+            modelTranscriptionRef.current += delta.text;
+            setModelTranscription(modelTranscriptionRef.current);
+          }
+
+          if (delta?.transcript && !delta.text) {
+            setConnectionState(ConnectionState.THINKING);
+            modelTranscriptionRef.current += delta.transcript;
+            setModelTranscription(modelTranscriptionRef.current);
+          }
+
+          if (delta?.audio && outputAudioContextRef.current) {
+            setConnectionState(ConnectionState.SPEAKING);
+            const audioBuffer = createAudioBufferFromPCM16(delta.audio, outputAudioContextRef.current, OPENAI_SAMPLE_RATE, 1);
+            const source = outputAudioContextRef.current.createBufferSource();
+            source.buffer = audioBuffer;
+            source.connect(outputAudioContextRef.current.destination);
+
+            const currentTime = outputAudioContextRef.current.currentTime;
+            const startTime = Math.max(currentTime, nextStartTimeRef.current);
+            source.start(startTime);
+            nextStartTimeRef.current = startTime + audioBuffer.duration;
+
+            audioBufferSources.current.add(source);
+            source.onended = () => {
+              audioBufferSources.current.delete(source);
+              if (audioBufferSources.current.size === 0) {
+                setConnectionState(isMicActiveRef.current ? ConnectionState.LISTENING : ConnectionState.CONNECTED);
+              }
+            };
+          }
+        }
+      });
+
+      client.on('conversation.item.completed', ({ item }: any) => {
+        if (!item) {
+          return;
+        }
+
+        if (item.role === 'user') {
+          const finalUser = (item.formatted?.transcript?.trim?.() || item.formatted?.text || '').trim();
+          userTranscriptionRef.current = finalUser;
+          setUserTranscription(finalUser);
+        } else if (item.role === 'assistant') {
+          const finalModel = (item.formatted?.transcript?.trim?.() || item.formatted?.text || '').trim();
+          modelTranscriptionRef.current = finalModel;
+          setModelTranscription(finalModel);
+
+          if (userTranscriptionRef.current.trim() || finalModel.trim()) {
+            onTurnCompleteRef.current({
+              user: userTranscriptionRef.current,
+              model: finalModel,
+            });
+          }
+
+          userTranscriptionRef.current = '';
+          modelTranscriptionRef.current = '';
+          setUserTranscription('');
+          setModelTranscription('');
+
+          if (audioBufferSources.current.size === 0) {
+            setConnectionState(isMicActiveRef.current ? ConnectionState.LISTENING : ConnectionState.CONNECTED);
+          }
+        }
+      });
+
+      client.on('conversation.interrupted', stopAllScheduledAudio);
+      client.realtime.on('close', () => {
+        setConnectionState(ConnectionState.DISCONNECTED);
+      });
+
+      client.addTool(changeEnvironmentToolDefinition, async ({ description }: any) => {
+        if (typeof description === 'string') {
+          onEnvironmentChangeRequestRef.current(description);
+        }
+        return { status: 'ok' };
+      });
+
+      client.addTool(displayArtifactToolDefinition, async ({ name, description }: any) => {
+        if (typeof name === 'string' && typeof description === 'string') {
+          onArtifactDisplayRequestRef.current(name, description);
+        }
+        return { status: 'ok' };
+      });
+
+      await client.realtime.connect({ model: OPENAI_REALTIME_MODEL });
+      client.updateSession({
+        instructions: finalSystemInstruction,
+        voice: resolveOpenAiVoice(voiceName, voiceAccent),
+        input_audio_transcription: { model: 'whisper-1' },
+        turn_detection: { type: 'server_vad' },
+        modalities: ['text', 'audio'],
+      });
+      await client.waitForSessionCreated();
+
+      await initializeMicrophone(client);
+    } catch (error) {
+      console.error('Failed to connect to OpenAI Realtime:', error);
+      setConnectionState(ConnectionState.ERROR);
+      disconnect();
+    }
+  }, [
+    activeQuest,
+    disconnect,
+    enabled,
+    initializeMicrophone,
+    stopAllScheduledAudio,
+    systemInstruction,
+    voiceAccent,
+    voiceName,
+  ]);
+
+  const toggleMicrophone = useCallback(() => {
+    setIsMicActive(prevIsActive => {
+      const nextIsActive = !prevIsActive;
+      const source = mediaStreamSourceRef.current;
+      const workletNode = audioWorkletNodeRef.current;
+      const scriptProcessorNode = scriptProcessorRef.current;
+      const context = inputAudioContextRef.current;
+
+      if (!source || (!workletNode && !scriptProcessorNode) || !context) {
+        return nextIsActive;
+      }
+
+      try {
+        if (nextIsActive) {
+          if (workletNode) {
+            source.connect(workletNode);
+            if (!silentGainNodeRef.current) {
+              const silentGain = context.createGain();
+              silentGain.gain.value = 0;
+              workletNode.connect(silentGain);
+              silentGain.connect(context.destination);
+              silentGainNodeRef.current = silentGain;
+            }
+          }
+
+          if (scriptProcessorNode) {
+            source.connect(scriptProcessorNode);
+            try {
+              scriptProcessorNode.connect(context.destination);
+            } catch (connectError) {
+              // Ignore if already connected
+            }
+          }
+          setConnectionState(ConnectionState.LISTENING);
+        } else {
+          if (workletNode) {
+            source.disconnect(workletNode);
+          }
+
+          if (scriptProcessorNode) {
+            try {
+              source.disconnect(scriptProcessorNode);
+              scriptProcessorNode.disconnect();
+            } catch (disconnectError) {
+              // Ignore when already disconnected
+            }
+          }
+          setConnectionState(ConnectionState.CONNECTED);
+        }
+      } catch (error) {
+        // Ignore errors, e.g., if already disconnected
+      }
+
+      return nextIsActive;
+    });
+  }, []);
+
+  const sendTextMessage = useCallback((text: string) => {
+    if (!text.trim()) return;
+
+    onTurnCompleteRef.current({ user: text, model: '' });
+    userTranscriptionRef.current = '';
+
+    setConnectionState(ConnectionState.THINKING);
+
+    const client = clientRef.current;
+    if (!client) {
+      console.warn('OpenAI realtime client not connected.');
+      return;
+    }
+
+    try {
+      client.sendUserMessageContent([{ type: 'input_text', text }]);
+    } catch (error) {
+      console.error('Error sending text message to OpenAI Realtime:', error);
+      setConnectionState(ConnectionState.ERROR);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      disconnect();
+      return;
+    }
+
+    connect();
+    return () => {
+      disconnect();
+    };
+  }, [connect, disconnect, enabled]);
+
+  return { connectionState, userTranscription, modelTranscription, isMicActive, toggleMicrophone, sendTextMessage };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@google/genai": "^1.22.0",
+        "@openai/realtime-api-beta": "github:openai/openai-realtime-api-beta#main",
         "@supabase/supabase-js": "^2.58.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
@@ -1081,6 +1082,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@openai/realtime-api-beta": {
+      "version": "0.0.0",
+      "resolved": "git+ssh://git@github.com/openai/openai-realtime-api-beta.git#a5cb94824f625423858ebacb9f769226ca98945f",
+      "license": "MIT",
+      "dependencies": {
+        "ws": "^8.18.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.22.0",
+    "@openai/realtime-api-beta": "github:openai/openai-realtime-api-beta#main",
     "@supabase/supabase-js": "^2.58.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"

--- a/tests/hooks/useGeminiLive.test.ts
+++ b/tests/hooks/useGeminiLive.test.ts
@@ -212,6 +212,31 @@ describe('useGeminiLive', () => {
         expect(result.current.connectionState).toBe(ConnectionState.LISTENING);
     });
 
+    it('disconnects when disabled', async () => {
+        const { rerender } = renderHook(
+            ({ enabled }: { enabled: boolean }) =>
+                useGeminiLive(
+                    'system-instruction',
+                    'test-voice',
+                    'en-US',
+                    mockOnTurnComplete,
+                    mockOnEnvironmentChangeRequest,
+                    mockOnArtifactDisplayRequest,
+                    null,
+                    enabled,
+                ),
+            { initialProps: { enabled: true } },
+        );
+
+        await waitFor(() => expect(mockConnect).toHaveBeenCalled());
+
+        rerender({ enabled: false });
+
+        await waitFor(() => {
+            expect(mockLiveSession.close).toHaveBeenCalled();
+        });
+    });
+
     it('should handle disconnect properly', async () => {
         const { result, unmount } = renderHook(() =>
             useGeminiLive('system-instruction', 'test-voice', 'en-US', mockOnTurnComplete, mockOnEnvironmentChangeRequest, mockOnArtifactDisplayRequest, null)

--- a/tests/hooks/useOpenAiLive.test.ts
+++ b/tests/hooks/useOpenAiLive.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useOpenAiLive } from '../../hooks/useOpenAiLive';
+import { ConnectionState, Quest } from '../../types';
+
+const mockRealtimeConnect = vi.fn(() => Promise.resolve());
+const mockUpdateSession = vi.fn();
+const mockWaitForSessionCreated = vi.fn(() => Promise.resolve());
+const mockAddTool = vi.fn();
+const mockAppendInputAudio = vi.fn();
+const mockSendUserMessageContent = vi.fn();
+const mockDisconnect = vi.fn();
+
+const mockMediaStream = {
+  getTracks: vi.fn(() => [{ stop: vi.fn() }]),
+};
+
+const mockGetUserMedia = vi.fn(() => Promise.resolve(mockMediaStream));
+
+Object.defineProperty(navigator, 'mediaDevices', {
+  value: {
+    getUserMedia: mockGetUserMedia,
+  },
+  writable: true,
+});
+
+const mockScriptProcessor = {
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  onaudioprocess: null as ((event: any) => void) | null,
+};
+
+const mockAudioContext = {
+  createMediaStreamSource: vi.fn(() => ({
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  })),
+  createScriptProcessor: vi.fn(() => mockScriptProcessor),
+  createGain: vi.fn(() => ({ gain: { value: 0 }, connect: vi.fn() })),
+  destination: {},
+  close: vi.fn(() => Promise.resolve()),
+  resume: vi.fn(),
+  suspend: vi.fn(),
+  currentTime: 0,
+};
+
+// @ts-expect-error - Mocking AudioContext
+window.AudioContext = vi.fn(() => mockAudioContext);
+
+const clientHandlers: Record<string, (payload: any) => void> = {};
+vi.mock('@openai/realtime-api-beta', () => ({
+  RealtimeClient: class {
+    realtime = {
+      connect: mockRealtimeConnect,
+      on: vi.fn((event: string, handler: (payload: any) => void) => {
+        if (event === 'close') {
+          clientHandlers[`realtime.${event}`] = handler;
+        }
+      }),
+    };
+
+    appendInputAudio = mockAppendInputAudio;
+    sendUserMessageContent = mockSendUserMessageContent;
+    updateSession = mockUpdateSession;
+    waitForSessionCreated = mockWaitForSessionCreated;
+    addTool = mockAddTool;
+    disconnect = mockDisconnect;
+
+    on(event: string, handler: (payload: any) => void) {
+      clientHandlers[event] = handler;
+    }
+  },
+}));
+
+const mockOnTurnComplete = vi.fn();
+const mockOnEnvironmentChangeRequest = vi.fn();
+const mockOnArtifactDisplayRequest = vi.fn();
+
+const mockQuest: Quest = {
+  id: 'quest-1',
+  title: 'Quest Title',
+  objective: 'Understand something important.',
+  description: 'A test quest.',
+  focusPoints: ['Point A', 'Point B'],
+  duration: '10 minutes',
+  characterId: 'char-1',
+};
+
+describe('useOpenAiLive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(clientHandlers).forEach(key => delete clientHandlers[key]);
+    process.env.OPENAI_API_KEY = 'test-openai-key';
+
+    mockRealtimeConnect.mockImplementation(() => Promise.resolve());
+    mockWaitForSessionCreated.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it('initializes connection and transitions to LISTENING', async () => {
+    const { result } = renderHook(() =>
+      useOpenAiLive(
+        'system instruction',
+        'test-voice',
+        'en-US',
+        mockOnTurnComplete,
+        mockOnEnvironmentChangeRequest,
+        mockOnArtifactDisplayRequest,
+        mockQuest,
+      ),
+    );
+
+    expect(result.current.connectionState).toBe(ConnectionState.CONNECTING);
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe(ConnectionState.LISTENING);
+    });
+
+    expect(mockRealtimeConnect).toHaveBeenCalled();
+    expect(mockUpdateSession).toHaveBeenCalled();
+  });
+
+  it('sends text messages through the realtime client', async () => {
+    const { result } = renderHook(() =>
+      useOpenAiLive(
+        'system instruction',
+        'test-voice',
+        'en-US',
+        mockOnTurnComplete,
+        mockOnEnvironmentChangeRequest,
+        mockOnArtifactDisplayRequest,
+        null,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe(ConnectionState.LISTENING);
+    });
+
+    act(() => {
+      result.current.sendTextMessage('Hello OpenAI');
+    });
+
+    expect(mockSendUserMessageContent).toHaveBeenCalledWith([{ type: 'input_text', text: 'Hello OpenAI' }]);
+  });
+
+  it('updates transcription when receiving conversation updates', async () => {
+    const { result } = renderHook(() =>
+      useOpenAiLive(
+        'system instruction',
+        'test-voice',
+        'en-US',
+        mockOnTurnComplete,
+        mockOnEnvironmentChangeRequest,
+        mockOnArtifactDisplayRequest,
+        null,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe(ConnectionState.LISTENING);
+    });
+
+    await act(async () => {
+      clientHandlers['conversation.updated']?.({
+        item: { role: 'assistant', formatted: { text: '' } },
+        delta: { text: 'Hello there' },
+      });
+    });
+
+    expect(result.current.modelTranscription).toContain('Hello there');
+
+    await act(async () => {
+      clientHandlers['conversation.item.completed']?.({
+        item: { role: 'assistant', formatted: { text: 'Hello there' } },
+      });
+    });
+
+    expect(mockOnTurnComplete).toHaveBeenCalledWith({ user: '', model: 'Hello there' });
+  });
+
+  it('disconnects when disabled', async () => {
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useOpenAiLive(
+          'system instruction',
+          'test-voice',
+          'en-US',
+          mockOnTurnComplete,
+          mockOnEnvironmentChangeRequest,
+          mockOnArtifactDisplayRequest,
+          null,
+          enabled,
+        ),
+      { initialProps: { enabled: true } },
+    );
+
+    await waitFor(() => {
+      expect(mockRealtimeConnect).toHaveBeenCalled();
+    });
+
+    rerender({ enabled: false });
+
+    await waitFor(() => {
+      expect(mockDisconnect).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add an OpenAI realtime hook alongside shared audio tooling for Gemini
- expose a provider toggle in the conversation view and document the new configuration
- expand automated coverage for the OpenAI provider path

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e2fc881e60832fab0024fa57b04a69