### PR TITLE
feat: replace local storage with Supabase-backed user data

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ School of the Ancients is a modern web application that pairs immersive visuals 
 - **Curated quest board** &mdash; Pick from ready-to-run quests, each linking a legendary mentor with a focused learning objective and estimated duration.
 - **Quest-aware conversations** &mdash; When a quest is active, the mentor keeps you on track, surfaces scene changes, and captures artifacts tied to the objective.
 - **Automatic mastery reviews** &mdash; Ending a quest triggers an AI assessment of your transcript, summarizing what you grasped, what evidence proves it, and what to revisit.
-- **Progress tracking** &mdash; Completed quest IDs persist in `localStorage`, powering progress meters and keeping your accomplishments pinned between sessions.
+- **Progress tracking** &mdash; Completed quest IDs and quest progress persist in Supabase, powering progress meters and keeping your accomplishments pinned between sessions.
 
 ### Custom Mentors & Quest Builder
 
@@ -63,7 +63,7 @@ School of the Ancients is a modern web application that pairs immersive visuals 
 
 ### Progression & Reflection
 
-- **Conversation history** &mdash; Sessions, transcripts, artifacts, and environments are stored in browser `localStorage` for later review or resuming quests.
+- **Conversation history** &mdash; Sessions, transcripts, artifacts, and environments are synced to Supabase for later review or resuming quests.
 - **Quest dossiers** &mdash; Each AI review summarizes mastery, highlights evidence, and recommends improvements so you can iterate on your learning plan.
 - **Responsive design** &mdash; Tailwind CSS keeps the UI beautiful and accessible on mobile, tablet, and desktop displays.
 
@@ -113,6 +113,7 @@ School of the Ancients is a modern web application that pairs immersive visuals 
    ```bash
    GEMINI_API_KEY=your_api_key_here
    ```
+4. Configure Supabase by following [`docs/SUPABASE_SETUP.md`](docs/SUPABASE_SETUP.md). At minimum you must supply `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` alongside the table described there.
 
 ### Running Locally
 

--- a/context/UserDataContext.tsx
+++ b/context/UserDataContext.tsx
@@ -1,0 +1,307 @@
+import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import type { Character, Quest, SavedConversation, QuizResult } from '../types';
+import { DEFAULT_USER_STATE, fetchUserState, persistUserState, type UserStateRecord } from '../services/userStateRepository';
+
+interface UserDataContextValue extends UserStateRecord {
+  isLoading: boolean;
+  isSyncing: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  upsertConversation: (conversation: SavedConversation) => void;
+  deleteConversation: (conversationId: string) => void;
+  setCompletedQuestIds: (questIds: string[]) => void;
+  markQuestCompleted: (questId: string) => void;
+  markQuestIncomplete: (questId: string) => void;
+  upsertCustomQuest: (quest: Quest) => void;
+  deleteCustomQuest: (questId: string) => void;
+  upsertCustomCharacter: (character: Character) => void;
+  deleteCustomCharacter: (characterId: string) => void;
+  setLastQuizResult: (result: QuizResult | null) => void;
+  setActiveQuestId: (questId: string | null) => void;
+}
+
+const UserDataContext = createContext<UserDataContextValue | undefined>(undefined);
+
+interface UserDataProviderProps {
+  userId: string | null;
+  children: ReactNode;
+}
+
+export const UserDataProvider: React.FC<UserDataProviderProps> = ({ userId, children }) => {
+  const [state, setState] = useState<UserStateRecord>(DEFAULT_USER_STATE);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isSyncing, setIsSyncing] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const initializedForUserRef = useRef<string | null>(null);
+
+  const syncState = useCallback(
+    async (nextState: UserStateRecord) => {
+      if (!userId) {
+        return;
+      }
+      setIsSyncing(true);
+      try {
+        await persistUserState(userId, nextState);
+        setError(null);
+      } catch (err) {
+        console.error('Failed to persist user state', err);
+        setError(err instanceof Error ? err.message : 'Failed to sync user data');
+      } finally {
+        setIsSyncing(false);
+      }
+    },
+    [userId],
+  );
+
+  const hydrate = useCallback(async () => {
+    if (!userId) {
+      setState(DEFAULT_USER_STATE);
+      setIsLoading(false);
+      setError(null);
+      initializedForUserRef.current = null;
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const data = await fetchUserState(userId);
+      if (data) {
+        setState(data);
+      } else {
+        setState(DEFAULT_USER_STATE);
+      }
+      setError(null);
+      initializedForUserRef.current = userId;
+    } catch (err) {
+      console.error('Failed to load user state', err);
+      setError(err instanceof Error ? err.message : 'Failed to load user data');
+      setState(DEFAULT_USER_STATE);
+      initializedForUserRef.current = userId;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId]);
+
+  React.useEffect(() => {
+    if (!userId) {
+      setState(DEFAULT_USER_STATE);
+      initializedForUserRef.current = null;
+      return;
+    }
+    if (initializedForUserRef.current === userId) {
+      return;
+    }
+    void hydrate();
+  }, [userId, hydrate]);
+
+  const updateState = useCallback(
+    (updater: (prev: UserStateRecord) => UserStateRecord) => {
+      setState((prev) => {
+        const next = updater(prev);
+        if (userId) {
+          void syncState(next);
+        }
+        return next;
+      });
+    },
+    [syncState, userId],
+  );
+
+  const upsertConversation = useCallback(
+    (conversation: SavedConversation) => {
+      updateState((prev) => {
+        const existingIndex = prev.conversations.findIndex((item) => item.id === conversation.id);
+        const conversations = existingIndex > -1
+          ? prev.conversations.map((item, index) => (index === existingIndex ? conversation : item))
+          : [conversation, ...prev.conversations];
+        return {
+          ...prev,
+          conversations,
+        };
+      });
+    },
+    [updateState],
+  );
+
+  const deleteConversation = useCallback(
+    (conversationId: string) => {
+      updateState((prev) => ({
+        ...prev,
+        conversations: prev.conversations.filter((conversation) => conversation.id !== conversationId),
+      }));
+    },
+    [updateState],
+  );
+
+  const setCompletedQuestIds = useCallback(
+    (questIds: string[]) => {
+      updateState((prev) => ({
+        ...prev,
+        completedQuestIds: Array.from(new Set(questIds)),
+      }));
+    },
+    [updateState],
+  );
+
+  const markQuestCompleted = useCallback(
+    (questId: string) => {
+      updateState((prev) => ({
+        ...prev,
+        completedQuestIds: prev.completedQuestIds.includes(questId)
+          ? prev.completedQuestIds
+          : [...prev.completedQuestIds, questId],
+      }));
+    },
+    [updateState],
+  );
+
+  const markQuestIncomplete = useCallback(
+    (questId: string) => {
+      updateState((prev) => ({
+        ...prev,
+        completedQuestIds: prev.completedQuestIds.filter((id) => id !== questId),
+      }));
+    },
+    [updateState],
+  );
+
+  const upsertCustomQuest = useCallback(
+    (quest: Quest) => {
+      updateState((prev) => {
+        const existingIndex = prev.customQuests.findIndex((item) => item.id === quest.id);
+        const customQuests = existingIndex > -1
+          ? prev.customQuests.map((item, index) => (index === existingIndex ? quest : item))
+          : [quest, ...prev.customQuests];
+        return {
+          ...prev,
+          customQuests,
+        };
+      });
+    },
+    [updateState],
+  );
+
+  const deleteCustomQuest = useCallback(
+    (questId: string) => {
+      updateState((prev) => ({
+        ...prev,
+        customQuests: prev.customQuests.filter((quest) => quest.id !== questId),
+        completedQuestIds: prev.completedQuestIds.filter((id) => id !== questId),
+        conversations: prev.conversations.filter((conversation) => conversation.questId !== questId),
+        activeQuestId: prev.activeQuestId === questId ? null : prev.activeQuestId,
+      }));
+    },
+    [updateState],
+  );
+
+  const upsertCustomCharacter = useCallback(
+    (character: Character) => {
+      updateState((prev) => {
+        const existingIndex = prev.customCharacters.findIndex((item) => item.id === character.id);
+        const customCharacters = existingIndex > -1
+          ? prev.customCharacters.map((item, index) => (index === existingIndex ? character : item))
+          : [character, ...prev.customCharacters];
+        return {
+          ...prev,
+          customCharacters,
+        };
+      });
+    },
+    [updateState],
+  );
+
+  const deleteCustomCharacter = useCallback(
+    (characterId: string) => {
+      updateState((prev) => ({
+        ...prev,
+        customCharacters: prev.customCharacters.filter((character) => character.id !== characterId),
+        customQuests: prev.customQuests.filter((quest) => quest.characterId !== characterId),
+        conversations: prev.conversations.filter((conversation) => conversation.characterId !== characterId),
+        completedQuestIds: prev.completedQuestIds.filter((questId) => {
+          const quest = prev.customQuests.find((item) => item.id === questId);
+          return quest ? quest.characterId !== characterId : true;
+        }),
+        activeQuestId: (() => {
+          if (!prev.activeQuestId) {
+            return prev.activeQuestId;
+          }
+          const activeQuest = prev.customQuests.find((quest) => quest.id === prev.activeQuestId);
+          if (activeQuest && activeQuest.characterId === characterId) {
+            return null;
+          }
+          return prev.activeQuestId;
+        })(),
+      }));
+    },
+    [updateState],
+  );
+
+  const setLastQuizResult = useCallback(
+    (result: QuizResult | null) => {
+      updateState((prev) => ({
+        ...prev,
+        lastQuizResult: result,
+      }));
+    },
+    [updateState],
+  );
+
+  const setActiveQuestId = useCallback(
+    (questId: string | null) => {
+      updateState((prev) => ({
+        ...prev,
+        activeQuestId: questId,
+      }));
+    },
+    [updateState],
+  );
+
+  const value = useMemo<UserDataContextValue>(
+    () => ({
+      ...state,
+      isLoading,
+      isSyncing,
+      error,
+      refresh: hydrate,
+      upsertConversation,
+      deleteConversation,
+      setCompletedQuestIds,
+      markQuestCompleted,
+      markQuestIncomplete,
+      upsertCustomQuest,
+      deleteCustomQuest,
+      upsertCustomCharacter,
+      deleteCustomCharacter,
+      setLastQuizResult,
+      setActiveQuestId,
+    }),
+    [
+      state,
+      isLoading,
+      isSyncing,
+      error,
+      hydrate,
+      upsertConversation,
+      deleteConversation,
+      setCompletedQuestIds,
+      markQuestCompleted,
+      markQuestIncomplete,
+      upsertCustomQuest,
+      deleteCustomQuest,
+      upsertCustomCharacter,
+      deleteCustomCharacter,
+      setLastQuizResult,
+      setActiveQuestId,
+    ],
+  );
+
+  return <UserDataContext.Provider value={value}>{children}</UserDataContext.Provider>;
+};
+
+export const useUserData = (): UserDataContextValue => {
+  const context = useContext(UserDataContext);
+  if (!context) {
+    throw new Error('useUserData must be used within a UserDataProvider');
+  }
+  return context;
+};

--- a/docs/SUPABASE_SETUP.md
+++ b/docs/SUPABASE_SETUP.md
@@ -1,0 +1,54 @@
+# Supabase Configuration
+
+School of the Ancients now persists user data with Supabase so conversations, quests, and progress follow learners across devices. Follow these steps to provision and connect the backend.
+
+## 1. Create a Supabase project
+1. Visit [supabase.com](https://supabase.com) and create a new project.
+2. Choose a strong password for the database and wait for provisioning to finish.
+3. In the project dashboard open **Project Settings → API**. Copy the **Project URL** and **anon public key** &mdash; you will add these to `.env` shortly.
+
+## 2. Define the `user_state` table
+The frontend expects a single JSON record per user that captures conversations, quests, and progress. Create the table using the SQL editor in Supabase (or psql):
+
+```sql
+create table if not exists public.user_state (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  state jsonb not null default '{}'::jsonb,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.user_state enable row level security;
+
+create policy "Users manage their own state"
+  on public.user_state
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+```
+
+> **Tip:** The table stores the entire serialized app state. Supabase handles JSONB efficiently, and schema migrations can reshape the payload over time.
+
+## 3. Configure environment variables
+Create (or update) your `.env` file in the repo root with the Gemini key plus Supabase credentials:
+
+```bash
+GEMINI_API_KEY=your_gemini_key
+VITE_SUPABASE_URL=https://your-project-ref.supabase.co
+VITE_SUPABASE_ANON_KEY=your-public-anon-key
+```
+
+Restart `npm run dev` after editing `.env` so Vite picks up the new variables.
+
+## 4. Test the connection
+1. Run `npm run dev` and visit the app.
+2. Click **Sign in** in the top-right corner. Create an account (Supabase email/password auth) or sign in with an existing user.
+3. Open the network tab; you should see `user_state` upsert calls as you finish conversations, create quests, or take quizzes.
+
+If the modal reports that Supabase is not configured, double-check the environment variables. Authentication will stay disabled until both values are present.
+
+## 5. Deploying
+When deploying, set the same environment variables on your hosting platform. The frontend uses Supabase's JavaScript client directly, so no additional proxy is required.
+
+---
+
+With Supabase wired up you can remove the old `localStorage` bootstrapping code and trust the backend to keep learner progress consistent across sessions.

--- a/hooks/useSupabaseAuth.ts
+++ b/hooks/useSupabaseAuth.ts
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { Session, AuthError } from '@supabase/supabase-js';
+import { supabase, isSupabaseConfigured } from '../lib/supabaseClient';
+
+type AuthMode = 'signIn' | 'signUp';
+
+export interface SupabaseAuthState {
+  session: Session | null;
+  isLoading: boolean;
+  error: string | null;
+  authMode: AuthMode;
+  setAuthMode: (mode: AuthMode) => void;
+  signIn: (email: string, password: string) => Promise<void>;
+  signUp: (email: string, password: string) => Promise<void>;
+  signOut: () => Promise<void>;
+  refreshSession: () => Promise<void>;
+  isConfigured: boolean;
+}
+
+const formatAuthError = (error: AuthError | Error | null) => {
+  if (!error) {
+    return null;
+  }
+  if ('message' in error) {
+    return error.message;
+  }
+  return 'Unexpected authentication error';
+};
+
+export const useSupabaseAuth = (): SupabaseAuthState => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(Boolean(isSupabaseConfigured));
+  const [error, setError] = useState<string | null>(null);
+  const [authMode, setAuthMode] = useState<AuthMode>('signIn');
+
+  useEffect(() => {
+    if (!supabase) {
+      setSession(null);
+      setIsLoading(false);
+      return;
+    }
+
+    let isMounted = true;
+
+    const hydrateSession = async () => {
+      try {
+        const { data, error: sessionError } = await supabase.auth.getSession();
+        if (!isMounted) return;
+        if (sessionError) {
+          setError(formatAuthError(sessionError));
+          setSession(null);
+          return;
+        }
+        setSession(data.session ?? null);
+        setError(null);
+      } catch (err) {
+        if (!isMounted) return;
+        setError(formatAuthError(err as Error));
+        setSession(null);
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void hydrateSession();
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, newSession) => {
+      if (!isMounted) {
+        return;
+      }
+      setSession(newSession ?? null);
+      setError(null);
+    });
+
+    return () => {
+      isMounted = false;
+      listener.subscription.unsubscribe();
+    };
+  }, []);
+
+  const signIn = useCallback(async (email: string, password: string) => {
+    if (!supabase) {
+      setError('Supabase is not configured.');
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const { error: authError } = await supabase.auth.signInWithPassword({ email, password });
+      if (authError) {
+        setError(formatAuthError(authError));
+        return;
+      }
+      setError(null);
+    } catch (err) {
+      setError(formatAuthError(err as Error));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const signUp = useCallback(async (email: string, password: string) => {
+    if (!supabase) {
+      setError('Supabase is not configured.');
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const { error: authError } = await supabase.auth.signUp({ email, password });
+      if (authError) {
+        setError(formatAuthError(authError));
+        return;
+      }
+      setError(null);
+    } catch (err) {
+      setError(formatAuthError(err as Error));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const signOut = useCallback(async () => {
+    if (!supabase) {
+      setError('Supabase is not configured.');
+      setSession(null);
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const { error: signOutError } = await supabase.auth.signOut();
+      if (signOutError) {
+        setError(formatAuthError(signOutError));
+        return;
+      }
+      setError(null);
+    } catch (err) {
+      setError(formatAuthError(err as Error));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const refreshSession = useCallback(async () => {
+    if (!supabase) {
+      setError('Supabase is not configured.');
+      setSession(null);
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const { data, error: refreshError } = await supabase.auth.getSession();
+      if (refreshError) {
+        setError(formatAuthError(refreshError));
+        setSession(null);
+        return;
+      }
+      setSession(data.session ?? null);
+      setError(null);
+    } catch (err) {
+      setError(formatAuthError(err as Error));
+      setSession(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return useMemo(
+    () => ({
+      session,
+      isLoading,
+      error,
+      authMode,
+      setAuthMode,
+      signIn,
+      signUp,
+      signOut,
+      refreshSession,
+      isConfigured: isSupabaseConfigured,
+    }),
+    [session, isLoading, error, authMode, signIn, signUp, signOut, refreshSession],
+  );
+};

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,0 +1,28 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+let client: SupabaseClient | null = null;
+
+if (!supabaseUrl) {
+  console.warn('VITE_SUPABASE_URL is not set. Supabase features will be disabled.');
+}
+
+if (!supabaseAnonKey) {
+  console.warn('VITE_SUPABASE_ANON_KEY is not set. Supabase features will be disabled.');
+}
+
+if (supabaseUrl && supabaseAnonKey) {
+  client = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      autoRefreshToken: true,
+      persistSession: true,
+      detectSessionInUrl: true,
+    },
+  });
+}
+
+export const supabase = client;
+
+export const isSupabaseConfigured = Boolean(client);

--- a/services/userStateRepository.ts
+++ b/services/userStateRepository.ts
@@ -1,0 +1,83 @@
+import type { PostgrestError } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabaseClient';
+import type { Character, Quest, SavedConversation, QuizResult } from '../types';
+
+export interface UserStateRecord {
+  conversations: SavedConversation[];
+  completedQuestIds: string[];
+  customQuests: Quest[];
+  customCharacters: Character[];
+  lastQuizResult: QuizResult | null;
+  activeQuestId: string | null;
+}
+
+export const DEFAULT_USER_STATE: UserStateRecord = {
+  conversations: [],
+  completedQuestIds: [],
+  customQuests: [],
+  customCharacters: [],
+  lastQuizResult: null,
+  activeQuestId: null,
+};
+
+const TABLE_NAME = 'user_state';
+
+const isRowNotFoundError = (error: PostgrestError | null) => {
+  if (!error) {
+    return false;
+  }
+  return error.code === 'PGRST116' || error.details?.includes('Results contain 0 rows');
+};
+
+export const fetchUserState = async (userId: string): Promise<UserStateRecord | null> => {
+  if (!supabase) {
+    return null;
+  }
+
+  const { data, error } = await supabase
+    .from(TABLE_NAME)
+    .select('state')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    if (isRowNotFoundError(error)) {
+      return null;
+    }
+    throw error;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const state = data.state as UserStateRecord | null;
+  if (!state) {
+    return null;
+  }
+
+  return {
+    ...DEFAULT_USER_STATE,
+    ...state,
+  };
+};
+
+export const persistUserState = async (userId: string, state: UserStateRecord): Promise<void> => {
+  if (!supabase) {
+    return;
+  }
+
+  const payload = {
+    user_id: userId,
+    state,
+    updated_at: new Date().toISOString(),
+  };
+
+  const { error } = await supabase
+    .from(TABLE_NAME)
+    .upsert(payload, { onConflict: 'user_id' });
+
+  if (error) {
+    throw error;
+  }
+};


### PR DESCRIPTION
## Summary
- add Supabase auth hook, client, and persistence repository to sync conversations, quests, and quiz results per user
- wrap the app in a user data provider and gate quest/history flows behind Supabase login with a modal sign-in experience
- refactor conversation and history views plus docs/README to reference the new Supabase state and setup instructions

## Testing
- npx vitest run tests/components/ConversationView.test.tsx --reporter verbose
- npx vitest --run App.test.tsx --reporter verbose
- npm run test -- --run


------
https://chatgpt.com/codex/tasks/task_e_68e413fb1240832f8bb802acee215efc