### PR TITLE
feat: refresh landing ui and add home navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1206,6 +1206,10 @@ const App: React.FC = () => {
     setView('history');
   }, [requireAuth]);
 
+  const openHomeView = useCallback(() => {
+    setView('selector');
+  }, []);
+
   const openQuestsView = useCallback(() => {
     if (!requireAuth('Sign in to manage your quests.')) {
       return;
@@ -1242,34 +1246,49 @@ const App: React.FC = () => {
 
       <div
         className="relative z-10 min-h-screen flex flex-col text-gray-200 font-serif p-4 sm:p-6 lg:p-8"
-        style={{ background: environmentImageUrl ? 'transparent' : 'linear-gradient(to bottom right, #1a1a1a, #2b2b2b)' }}
+        style={{ background: environmentImageUrl ? 'transparent' : 'radial-gradient(circle at top, rgba(251, 191, 36, 0.08), transparent 55%)' }}
       >
-        <header className="mb-8">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-            <div className="text-center sm:text-left">
-              <h1
-                className="text-4xl sm:text-5xl md:text-6xl font-bold text-amber-300 tracking-wider"
-                style={{ textShadow: '0 0 10px rgba(252, 211, 77, 0.5)' }}
-              >
-                School of the Ancients
-              </h1>
-              <p className="text-gray-400 mt-2 text-lg">Old world wisdom. New world classroom.</p>
+        <header className="mb-10">
+          <div className="bg-gray-900/70 border border-gray-800/70 shadow-2xl shadow-amber-500/5 backdrop-blur rounded-2xl px-6 py-5 flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
+            <div className="text-center lg:text-left space-y-2">
+              <span className="inline-flex items-center gap-2 rounded-full bg-amber-500/10 text-amber-200 px-3 py-1 text-xs uppercase tracking-[0.2em]">
+                Live your legend
+              </span>
+              <div>
+                <h1
+                  className="text-4xl sm:text-5xl font-bold text-amber-200 tracking-wider drop-shadow-[0_0_25px_rgba(251,191,36,0.25)]"
+                >
+                  School of the Ancients
+                </h1>
+                <p className="text-gray-400 mt-2 text-base sm:text-lg max-w-xl">
+                  Engage in guided conversations with storied minds, build bespoke quests, and uncover timeless wisdom.
+                </p>
+              </div>
             </div>
-            <div className="flex flex-col sm:items-end gap-2">
-              {userEmail && (
-                <span className="text-sm text-gray-300">Signed in as {userEmail}</span>
-              )}
+            <nav className="flex flex-col sm:flex-row items-center gap-4">
+              <button
+                type="button"
+                onClick={openHomeView}
+                className="inline-flex items-center gap-2 rounded-full border border-amber-400/50 px-4 py-2 text-sm font-semibold text-amber-200 hover:bg-amber-500/10 transition-colors"
+              >
+                Home
+              </button>
               <button
                 type="button"
                 onClick={handleSignInClick}
-                className="self-center sm:self-end inline-flex items-center gap-2 rounded-md border border-amber-400/60 px-4 py-2 text-sm font-semibold text-amber-200 hover:bg-amber-500/10"
+                className="inline-flex items-center gap-2 rounded-full border border-amber-400/50 px-4 py-2 text-sm font-semibold text-amber-200 hover:bg-amber-500/10 transition-colors"
               >
                 {isAuthenticated ? 'Sign out' : 'Sign in'}
               </button>
-              {!isAuthenticated && authPrompt && (
-                <p className="text-xs text-amber-300 max-w-xs text-center sm:text-right">{authPrompt}</p>
+              {userEmail && (
+                <span className="text-xs text-gray-300 whitespace-nowrap">Signed in as {userEmail}</span>
               )}
-            </div>
+              {!isAuthenticated && authPrompt && (
+                <p className="text-xs text-amber-300 max-w-[220px] text-center lg:text-right">
+                  {authPrompt}
+                </p>
+              )}
+            </nav>
           </div>
         </header>
 
@@ -1277,6 +1296,7 @@ const App: React.FC = () => {
           <Sidebar
             recentConversations={recentConversations}
             onSelectConversation={handleResumeConversation}
+            onOpenHome={openHomeView}
             onCreateAncient={openCharacterCreatorView}
             onOpenHistory={openHistoryView}
             onOpenProfile={openProfileView}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import type { SavedConversation } from '../types';
 type SidebarProps = {
   recentConversations: SavedConversation[];
   onSelectConversation: (conversation: SavedConversation) => void;
+  onOpenHome: () => void;
   onCreateAncient: () => void;
   onOpenHistory: () => void;
   onOpenProfile: () => void;
@@ -18,6 +19,7 @@ type SidebarProps = {
 const Sidebar: React.FC<SidebarProps> = ({
   recentConversations,
   onSelectConversation,
+  onOpenHome,
   onCreateAncient,
   onOpenHistory,
   onOpenProfile,
@@ -28,6 +30,12 @@ const Sidebar: React.FC<SidebarProps> = ({
   userEmail,
 }) => {
   const navigationItems = [
+    {
+      key: 'selector',
+      label: 'Home',
+      description: 'Return to the hall of legendary guides.',
+      onClick: onOpenHome,
+    },
     {
       key: 'quests',
       label: 'Quest Library',
@@ -56,7 +64,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
   return (
     <aside className="w-full lg:w-72 xl:w-80 flex-shrink-0">
-      <div className="bg-gray-900/70 border border-gray-800 rounded-2xl p-5 shadow-xl backdrop-blur-sm">
+      <div className="bg-gradient-to-b from-gray-900/80 to-gray-950/80 border border-gray-800/70 rounded-2xl p-6 shadow-2xl backdrop-blur">
         <div className="mb-6">
           <h2 className="text-lg font-semibold text-amber-300 tracking-wide">Explorer Hub</h2>
           <p className="text-sm text-gray-400">
@@ -81,10 +89,10 @@ const Sidebar: React.FC<SidebarProps> = ({
                     key={item.key}
                     type="button"
                     onClick={item.onClick}
-                    className={`w-full text-left px-3 py-2 rounded-lg transition-all duration-200 border flex flex-col gap-1 ${
+                    className={`w-full text-left px-4 py-3 rounded-xl transition-all duration-200 border flex flex-col gap-1 ${
                       isActive
-                        ? 'border-amber-500/80 bg-amber-500/10 text-amber-200'
-                        : 'border-gray-800 hover:border-amber-500/40 hover:bg-gray-800/60 text-gray-200'
+                        ? 'border-amber-500/80 bg-amber-500/15 text-amber-100 shadow-lg shadow-amber-500/20'
+                        : 'border-gray-800/80 hover:border-amber-500/50 hover:bg-gray-900/70 text-gray-200'
                     }`}
                   >
                     <span className="text-sm font-semibold">{item.label}</span>
@@ -108,7 +116,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             </div>
 
             {recentConversations.length === 0 ? (
-              <p className="text-sm text-gray-400 bg-gray-800/50 border border-dashed border-gray-700 rounded-lg p-3">
+              <p className="text-sm text-gray-400 bg-gray-900/50 border border-dashed border-gray-700 rounded-xl p-4">
                 {isAuthenticated
                   ? 'Your latest conversations will appear here.'
                   : 'Sign in to start building your historical dialogue archive.'}
@@ -120,7 +128,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                     <button
                       type="button"
                       onClick={() => onSelectConversation(conversation)}
-                      className="w-full text-left px-3 py-2 rounded-lg border border-gray-800 hover:border-amber-500/40 hover:bg-gray-800/70 transition-all duration-200"
+                      className="w-full text-left px-4 py-3 rounded-xl border border-gray-800/70 bg-gray-900/40 hover:border-amber-500/50 hover:bg-gray-900/70 transition-all duration-200"
                     >
                       <p className="text-sm font-semibold text-gray-100 truncate">
                         {conversation.title ?? conversation.characterName ?? 'Conversation'}


### PR DESCRIPTION
## Summary
- refresh the landing header with a glassmorphism card and clearer copy to improve first impression
- add a reusable home action in the header and sidebar navigation for quick access to the character selector
- elevate sidebar styling for navigation and recent chat cards to better match the updated hero

## Testing
- npm run test

## Screenshots
![Updated landing UI](browser:/invocations/aqarwhmg/artifacts/artifacts/ui-refresh.png)

------
https://chatgpt.com/codex/tasks/task_e_68e45d39573c832fa6df4ec8c699333b