### PR TITLE
Refactor routing to React Router

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
 import { GoogleGenAI, Type } from '@google/genai';
 
 import type {
@@ -12,72 +13,40 @@ import type {
   UserData,
 } from './types';
 
-import CharacterSelector from './components/CharacterSelector';
-import ConversationView from './components/ConversationView';
-import HistoryView from './components/HistoryView';
 import CharacterCreator from './components/CharacterCreator';
-import QuestsView from './components/QuestsView';
-import Instructions from './components/Instructions';
-import QuestIcon from './components/icons/QuestIcon';
-import QuestCreator from './components/QuestCreator';
-import QuestQuiz from './components/QuestQuiz';
 import AuthModal from './components/AuthModal';
 import Sidebar from './components/Sidebar';
+
+import SelectorRoute from './src/routes/Selector';
+import QuestsRoute from './src/routes/Quests';
+import QuestDetailRoute from './src/routes/QuestDetail';
+import QuestCreatorRoute from './src/routes/QuestCreator';
+import QuizRoute from './src/routes/Quiz';
+import ConversationRoute from './src/routes/Conversation';
+import HistoryRoute from './src/routes/History';
+import ScrollToTop from './src/components/ScrollToTop';
+import { links } from './src/lib/links';
 
 import { CHARACTERS, QUESTS } from './constants';
 import { useSupabaseAuth } from './hooks/useSupabaseAuth';
 import { useUserData } from './hooks/useUserData';
 import { DEFAULT_USER_DATA } from './supabase/userData';
 
-const updateCharacterQueryParam = (characterId: string, mode: 'push' | 'replace') => {
-  try {
-    const params = new URLSearchParams(window.location.search);
-    params.set('character', characterId);
-    const pathname = typeof window.location.pathname === 'string' && window.location.pathname
-      ? window.location.pathname
-      : '/';
-    const newSearch = params.toString();
-    const nextUrl = `${pathname}${newSearch ? `?${newSearch}` : ''}`;
-    if (mode === 'push') {
-      window.history.pushState({}, '', nextUrl);
-    } else {
-      window.history.replaceState({}, '', nextUrl);
-    }
-  } catch (error) {
-    console.warn('Failed to update character query parameter:', error);
-  }
-};
-
-// ---- App -------------------------------------------------------------------
-
 const App: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
   const { user, loading: authLoading, signOut } = useSupabaseAuth();
   const { data: userData, loading: dataLoading, saving: dataSaving, updateData } = useUserData();
 
   const [selectedCharacter, setSelectedCharacter] = useState<Character | null>(null);
-  const [view, setView] = useState<
-    | 'selector'
-    | 'conversation'
-    | 'history'
-    | 'creator'
-    | 'quests'
-    | 'questCreator'
-    | 'quiz'
-    | 'profile'
-    | 'settings'
-  >('selector');
-
   const [environmentImageUrl, setEnvironmentImageUrl] = useState<string | null>(null);
   const [activeQuest, setActiveQuest] = useState<Quest | null>(null);
   const [resumeConversationId, setResumeConversationId] = useState<string | null>(null);
-
   const [isSavingConversation, setIsSavingConversation] = useState(false);
-
   const [lastQuestOutcome, setLastQuestOutcome] = useState<QuestAssessment | null>(null);
   const [inProgressQuestIds, setInProgressQuestIds] = useState<string[]>([]);
   const [questCreatorPrefill, setQuestCreatorPrefill] = useState<string | null>(null);
-  const [quizQuest, setQuizQuest] = useState<Quest | null>(null);
-  const [quizAssessment, setQuizAssessment] = useState<QuestAssessment | null>(null);
+  const [pendingQuiz, setPendingQuiz] = useState<{ questId: string; assessment: QuestAssessment | null } | null>(null);
   const [authPrompt, setAuthPrompt] = useState<string | null>(null);
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
   const [notificationsEnabled, setNotificationsEnabled] = useState(true);
@@ -89,9 +58,20 @@ const App: React.FC = () => {
   const completedQuests = userData.completedQuestIds;
   const conversationHistory = userData.conversations;
   const lastQuizResult = userData.lastQuizResult;
+
   const isSaving = isSavingConversation || dataSaving;
   const isAuthenticated = Boolean(user);
   const isAppLoading = authLoading || dataLoading;
+
+  const allCharacters = useMemo(() => [...customCharacters, ...CHARACTERS], [customCharacters]);
+  const allQuests = useMemo(() => [...customQuests, ...QUESTS], [customQuests]);
+  const lastQuizQuest = useMemo(() => {
+    if (!lastQuizResult) {
+      return null;
+    }
+    return allQuests.find((quest) => quest.id === lastQuizResult.questId) ?? null;
+  }, [allQuests, lastQuizResult]);
+  const recentConversations = useMemo(() => conversationHistory.slice(0, 5), [conversationHistory]);
 
   const requireAuth = useCallback(
     (message?: string) => {
@@ -105,7 +85,7 @@ const App: React.FC = () => {
 
       return false;
     },
-    [isAuthenticated]
+    [isAuthenticated],
   );
 
   useEffect(() => {
@@ -114,18 +94,6 @@ const App: React.FC = () => {
       setIsAuthModalOpen(false);
     }
   }, [isAuthenticated]);
-
-  const allQuests = useMemo(() => [...customQuests, ...QUESTS], [customQuests]);
-  const lastQuizQuest = useMemo(() => {
-    if (!lastQuizResult) {
-      return null;
-    }
-    return allQuests.find((quest) => quest.id === lastQuizResult.questId) ?? null;
-  }, [allQuests, lastQuizResult]);
-  const recentConversations = useMemo(
-    () => conversationHistory.slice(0, 5),
-    [conversationHistory]
-  );
 
   useEffect(() => {
     if (customQuests.length === 0) {
@@ -165,9 +133,7 @@ const App: React.FC = () => {
           return conversation;
         }),
         activeQuestId:
-          prev.activeQuestId && removedQuestIds.includes(prev.activeQuestId)
-            ? null
-            : prev.activeQuestId,
+          prev.activeQuestId && removedQuestIds.includes(prev.activeQuestId) ? null : prev.activeQuestId,
       };
       return next;
     });
@@ -188,161 +154,144 @@ const App: React.FC = () => {
     setInProgressQuestIds(Array.from(inProgress));
   }, [conversationHistory]);
 
-  // On mount: load saved characters, url param character, and progress
   useEffect(() => {
     if (isAppLoading) {
       return;
     }
 
-    const allCharacters = [...customCharacters, ...CHARACTERS];
-    const availableQuests = [...customQuests, ...QUESTS];
-
     let nextActiveQuest: Quest | null = null;
     if (userData.activeQuestId) {
-      nextActiveQuest = availableQuests.find((quest) => quest.id === userData.activeQuestId) ?? null;
+      nextActiveQuest = allQuests.find((quest) => quest.id === userData.activeQuestId) ?? null;
     }
 
-    setActiveQuest(nextActiveQuest);
-
-    if (!selectedCharacter) {
-      let characterToSelect: Character | null = null;
-
-      if (nextActiveQuest) {
-        characterToSelect = allCharacters.find((c) => c.id === nextActiveQuest?.characterId) ?? null;
-      }
-
-      if (!characterToSelect) {
-        const urlParams = new URLSearchParams(window.location.search);
-        const characterId = urlParams.get('character');
-        if (characterId) {
-          characterToSelect = allCharacters.find((c) => c.id === characterId) ?? null;
-        }
-      }
-
-      if (characterToSelect) {
-        setSelectedCharacter(characterToSelect);
-        setView('conversation');
-        updateCharacterQueryParam(characterToSelect.id, 'replace');
-      }
+    if (nextActiveQuest) {
+      setActiveQuest(nextActiveQuest);
     }
 
     syncQuestProgress();
-  }, [
-    customCharacters,
-    customQuests,
-    isAppLoading,
-    selectedCharacter,
-    syncQuestProgress,
-    userData.activeQuestId,
-  ]);
+  }, [allQuests, isAppLoading, syncQuestProgress, userData.activeQuestId]);
 
   useEffect(() => {
     if (!isAuthenticated) {
       setSelectedCharacter(null);
       setActiveQuest(null);
-      setView('selector');
       setResumeConversationId(null);
       setEnvironmentImageUrl(null);
+      setPendingQuiz(null);
+      if (location.pathname !== '/') {
+        navigate('/', { replace: true });
+      }
     }
-  }, [isAuthenticated]);
+  }, [isAuthenticated, location.pathname, navigate]);
 
-  // ---- Navigation helpers ----
-
-  const handleSelectCharacter = (character: Character) => {
-    if (!requireAuth('Sign in to start a new conversation.')) {
-      return;
-    }
-    setSelectedCharacter(character);
-    setView('conversation');
-    setActiveQuest(null); // clear any quest when directly picking a character
-    updateData((prev) => ({
-      ...prev,
-      activeQuestId: null,
-    }));
-    setResumeConversationId(null);
-    updateCharacterQueryParam(character.id, 'push');
-  };
-
-  const handleSelectQuest = (quest: Quest) => {
-    if (!requireAuth('Sign in to embark on a quest.')) {
-      return;
-    }
-    const allCharacters = [...customCharacters, ...CHARACTERS];
-    const characterForQuest = allCharacters.find((c) => c.id === quest.characterId);
-    if (characterForQuest) {
+  const setActiveQuestState = useCallback(
+    (quest: Quest | null) => {
       setActiveQuest(quest);
       updateData((prev) => ({
         ...prev,
-        activeQuestId: quest.id,
+        activeQuestId: quest ? quest.id : null,
       }));
-      setSelectedCharacter(characterForQuest);
-      setView('conversation');
-      setResumeConversationId(null);
-      updateCharacterQueryParam(characterForQuest.id, 'push');
-    } else {
-      console.error(`Character with ID ${quest.characterId} not found for the selected quest.`);
-    }
-  };
+    },
+    [updateData],
+  );
 
-  const handleContinueQuest = (questId: string | undefined) => {
-    if (!requireAuth('Sign in to resume your quest.')) {
-      return;
-    }
-    if (!questId) {
-      return;
-    }
-    const questToResume = allQuests.find((quest) => quest.id === questId);
-    if (!questToResume) {
-      console.warn(`Quest with ID ${questId} could not be found for continuation.`);
-      return;
-    }
-    handleSelectQuest(questToResume);
-  };
-
-  const handleResumeConversation = (conversation: SavedConversation) => {
-    if (!requireAuth('Sign in to view your saved conversations.')) {
-      return;
-    }
-    const allCharacters = [...customCharacters, ...CHARACTERS];
-    const characterToResume = allCharacters.find((c) => c.id === conversation.characterId);
-
-    if (!characterToResume) {
-      console.error(`Unable to resume conversation: character with ID ${conversation.characterId} not found.`);
-      return;
-    }
-
-    setResumeConversationId(conversation.id);
-    setSelectedCharacter(characterToResume);
-    setEnvironmentImageUrl(conversation.environmentImageUrl || null);
-
-    if (conversation.questId) {
-      const questToResume = allQuests.find((quest) => quest.id === conversation.questId);
-      if (questToResume) {
-        setActiveQuest(questToResume);
-        updateData((prev) => ({
-          ...prev,
-          activeQuestId: questToResume.id,
-        }));
-      } else {
-        console.warn(`Quest with ID ${conversation.questId} not found while resuming conversation.`);
-        setActiveQuest(null);
-        updateData((prev) => ({
-          ...prev,
-          activeQuestId: null,
-        }));
+  const applyConversationContext = useCallback(
+    (context: {
+      character?: Character | null;
+      quest?: Quest | null;
+      resumeId?: string | null;
+      environmentUrl?: string | null;
+    }) => {
+      if (context.character !== undefined) {
+        setSelectedCharacter(context.character);
       }
-    } else {
-      setActiveQuest(null);
-      updateData((prev) => ({
-        ...prev,
-        activeQuestId: null,
-      }));
-    }
+      if (context.quest !== undefined) {
+        setActiveQuestState(context.quest);
+      }
+      if (context.resumeId !== undefined) {
+        setResumeConversationId(context.resumeId);
+      }
+      if (context.environmentUrl !== undefined) {
+        setEnvironmentImageUrl(context.environmentUrl);
+      }
+    },
+    [setActiveQuestState],
+  );
 
-    setView('conversation');
+  const handleSelectCharacter = useCallback(
+    (character: Character) => {
+      if (!requireAuth('Sign in to start a new conversation.')) {
+        return;
+      }
+      applyConversationContext({ character, quest: null, resumeId: null, environmentUrl: null });
+      navigate(links.conversation(character.id));
+    },
+    [applyConversationContext, navigate, requireAuth],
+  );
 
-    updateCharacterQueryParam(characterToResume.id, 'push');
-  };
+  const handleSelectQuest = useCallback(
+    (quest: Quest) => {
+      if (!requireAuth('Sign in to embark on a quest.')) {
+        return;
+      }
+      const characterForQuest = allCharacters.find((c) => c.id === quest.characterId);
+      if (!characterForQuest) {
+        console.error(`Character with ID ${quest.characterId} not found for the selected quest.`);
+        return;
+      }
+      applyConversationContext({ character: characterForQuest, quest, resumeId: null, environmentUrl: null });
+      navigate(links.conversation(characterForQuest.id));
+    },
+    [allCharacters, applyConversationContext, navigate, requireAuth],
+  );
+
+  const handleContinueQuest = useCallback(
+    (questId: string | undefined) => {
+      if (!requireAuth('Sign in to resume your quest.')) {
+        return;
+      }
+      if (!questId) {
+        return;
+      }
+      const questToResume = allQuests.find((quest) => quest.id === questId);
+      if (!questToResume) {
+        console.warn(`Quest with ID ${questId} could not be found for continuation.`);
+        return;
+      }
+      handleSelectQuest(questToResume);
+    },
+    [allQuests, handleSelectQuest, requireAuth],
+  );
+
+  const handleResumeConversation = useCallback(
+    (conversation: SavedConversation) => {
+      if (!requireAuth('Sign in to view your saved conversations.')) {
+        return;
+      }
+      const characterToResume = allCharacters.find((c) => c.id === conversation.characterId);
+
+      if (!characterToResume) {
+        console.error(`Unable to resume conversation: character with ID ${conversation.characterId} not found.`);
+        return;
+      }
+
+      applyConversationContext({
+        character: characterToResume,
+        resumeId: conversation.id,
+        environmentUrl: conversation.environmentImageUrl || null,
+        quest: conversation.questId
+          ? allQuests.find((quest) => quest.id === conversation.questId) ?? null
+          : null,
+      });
+
+      navigate(
+        links.conversation(characterToResume.id, {
+          resumeId: conversation.id,
+        }),
+      );
+    },
+    [allCharacters, allQuests, applyConversationContext, navigate, requireAuth],
+  );
 
   const handleConversationUpdate = useCallback(
     (conversation: SavedConversation) => {
@@ -361,7 +310,7 @@ const App: React.FC = () => {
         };
       });
     },
-    [updateData]
+    [updateData],
   );
 
   const handleDeleteConversation = useCallback(
@@ -371,818 +320,422 @@ const App: React.FC = () => {
         conversations: prev.conversations.filter((conversation) => conversation.id !== conversationId),
       }));
     },
-    [updateData]
+    [updateData],
   );
 
-  const handleCharacterCreated = (newCharacter: Character) => {
-    if (!requireAuth('Sign in to save your custom ancient.')) {
-      return;
-    }
-    updateData((prev) => ({
-      ...prev,
-      customCharacters: [newCharacter, ...prev.customCharacters],
-      activeQuestId: null,
-    }));
-    setSelectedCharacter(newCharacter);
-    setView('conversation');
-    setActiveQuest(null);
-    setResumeConversationId(null);
-    updateCharacterQueryParam(newCharacter.id, 'push');
-  };
-
-  const handleDeleteCharacter = (characterId: string) => {
-    if (!requireAuth('Sign in to manage your roster of ancients.')) {
-      return;
-    }
-    if (!window.confirm('Are you sure you want to permanently delete this ancient?')) {
-      return;
-    }
-
-    const questsToRemove = customQuests.filter((quest) => quest.characterId === characterId).map((quest) => quest.id);
-
-    updateData((prev) => {
-      const remainingCharacters = prev.customCharacters.filter((c) => c.id !== characterId);
-      const remainingQuests = prev.customQuests.filter((quest) => quest.characterId !== characterId);
-      const remainingConversations = prev.conversations.filter((conversation) => conversation.characterId !== characterId);
-      const remainingCompleted = prev.completedQuestIds.filter((id) => !questsToRemove.includes(id));
-      const nextActiveQuestId =
-        prev.activeQuestId && questsToRemove.includes(prev.activeQuestId) ? null : prev.activeQuestId;
-
-      return {
-        ...prev,
-        customCharacters: remainingCharacters,
-        customQuests: remainingQuests,
-        completedQuestIds: remainingCompleted,
-        conversations: remainingConversations,
-        activeQuestId: nextActiveQuestId,
-      };
-    });
-
-    setSelectedCharacter((current) => (current?.id === characterId ? null : current));
-    setActiveQuest((current) => (current && current.characterId === characterId ? null : current));
-  };
-
-  const handleDeleteQuest = (questId: string) => {
-    if (!requireAuth('Sign in to update your quest log.')) {
-      return;
-    }
-    const questToDelete = customQuests.find((quest) => quest.id === questId);
-    if (!questToDelete) {
-      return;
-    }
-
-    const confirmed = window.confirm('Are you sure you want to permanently delete this quest? This cannot be undone.');
-    if (!confirmed) {
-      return;
-    }
-
-    updateData((prev) => ({
-      ...prev,
-      customQuests: prev.customQuests.filter((quest) => quest.id !== questId),
-      completedQuestIds: prev.completedQuestIds.filter((id) => id !== questId),
-      conversations: prev.conversations.map((conversation) => {
-        if (conversation.questId !== questId) {
-          return conversation;
-        }
-        const { questAssessment: _questAssessment, ...rest } = conversation;
-        return {
-          ...rest,
-          questId: undefined,
-          questTitle: undefined,
-          questAssessment: undefined,
-        };
-      }),
-      activeQuestId: prev.activeQuestId === questId ? null : prev.activeQuestId,
-    }));
-
-    setInProgressQuestIds((prev) => prev.filter((id) => id !== questId));
-
-    setActiveQuest((current) => {
-      if (current?.id === questId) {
-        return null;
+  const handleCharacterCreated = useCallback(
+    (newCharacter: Character) => {
+      if (!requireAuth('Sign in to save your custom ancient.')) {
+        return;
       }
-      return current;
-    });
-  };
+      updateData((prev) => ({
+        ...prev,
+        customCharacters: [newCharacter, ...prev.customCharacters],
+        activeQuestId: null,
+      }));
+      applyConversationContext({ character: newCharacter, quest: null, resumeId: null, environmentUrl: null });
+      navigate(links.conversation(newCharacter.id));
+    },
+    [applyConversationContext, navigate, requireAuth, updateData],
+  );
 
-  const openQuestCreator = (goal?: string | null) => {
-    if (!requireAuth('Sign in to design new quests.')) {
-      return;
-    }
-    setQuestCreatorPrefill(goal ?? null);
-    setView('questCreator');
-  };
+  const handleDeleteCharacter = useCallback(
+    (characterId: string) => {
+      if (!requireAuth('Sign in to manage your roster of ancients.')) {
+        return;
+      }
+      if (!window.confirm('Are you sure you want to permanently delete this ancient?')) {
+        return;
+      }
+
+      const questsToRemove = customQuests.filter((quest) => quest.characterId === characterId).map((quest) => quest.id);
+
+      updateData((prev) => {
+        const remainingCharacters = prev.customCharacters.filter((c) => c.id !== characterId);
+        const remainingQuests = prev.customQuests.filter((quest) => quest.characterId !== characterId);
+        const remainingConversations = prev.conversations.filter((conversation) => conversation.characterId !== characterId);
+        const remainingCompleted = prev.completedQuestIds.filter((id) => !questsToRemove.includes(id));
+        const nextActiveQuestId =
+          prev.activeQuestId && questsToRemove.includes(prev.activeQuestId) ? null : prev.activeQuestId;
+
+        return {
+          ...prev,
+          customCharacters: remainingCharacters,
+          customQuests: remainingQuests,
+          completedQuestIds: remainingCompleted,
+          conversations: remainingConversations,
+          activeQuestId: nextActiveQuestId,
+        };
+      });
+
+      setSelectedCharacter((current) => (current?.id === characterId ? null : current));
+      setActiveQuest((current) => (current && current.characterId === characterId ? null : current));
+    },
+    [customQuests, requireAuth, updateData],
+  );
+
+  const handleDeleteQuest = useCallback(
+    (questId: string) => {
+      if (!requireAuth('Sign in to update your quest log.')) {
+        return;
+      }
+      const questToDelete = customQuests.find((quest) => quest.id === questId);
+      if (!questToDelete) {
+        return;
+      }
+
+      const confirmed = window.confirm('Are you sure you want to permanently delete this quest? This cannot be undone.');
+      if (!confirmed) {
+        return;
+      }
+
+      updateData((prev) => ({
+        ...prev,
+        customQuests: prev.customQuests.filter((quest) => quest.id !== questId),
+        completedQuestIds: prev.completedQuestIds.filter((id) => id !== questId),
+        conversations: prev.conversations.map((conversation) => {
+          if (conversation.questId !== questId) {
+            return conversation;
+          }
+          const { questAssessment: _questAssessment, ...rest } = conversation;
+          return {
+            ...rest,
+            questId: undefined,
+            questTitle: undefined,
+            questAssessment: undefined,
+          };
+        }),
+        activeQuestId: prev.activeQuestId === questId ? null : prev.activeQuestId,
+      }));
+
+      setInProgressQuestIds((prev) => prev.filter((id) => id !== questId));
+
+      setActiveQuest((current) => {
+        if (current?.id === questId) {
+          return null;
+        }
+        return current;
+      });
+    },
+    [customQuests, requireAuth, updateData],
+  );
+
+  const openQuestCreator = useCallback(
+    (goal?: string | null) => {
+      if (!requireAuth('Sign in to design new quests.')) {
+        return;
+      }
+      setQuestCreatorPrefill(goal ?? null);
+      navigate('/quest/new');
+    },
+    [navigate, requireAuth],
+  );
 
   const openCharacterCreatorView = useCallback(() => {
     if (!requireAuth('Sign in to create a new ancient.')) {
       return;
     }
-    setView('creator');
-  }, [requireAuth]);
+    navigate('/characters/new');
+  }, [navigate, requireAuth]);
 
-  const handleCreateQuestFromNextSteps = (steps: string[], questTitle?: string) => {
-    if (!requireAuth('Sign in to turn feedback into new quests.')) {
-      return;
-    }
-    const trimmedSteps = steps.map((step) => step.trim()).filter(Boolean);
-    if (trimmedSteps.length === 0) {
-      openQuestCreator();
-      return;
-    }
-
-    const bulletList = trimmedSteps.map((step) => `- ${step}`).join('\n');
-    const intro = questTitle
-      ? `I need a follow-up quest to improve at "${questTitle}".`
-      : 'I need a new quest to improve my understanding.';
-    const prefill = `${intro}\nFocus on:\n${bulletList}`;
-
-    openQuestCreator(prefill);
-  };
-
-  // NEW: handle a freshly-generated quest & mentor from QuestCreator
-  const startGeneratedQuest = (quest: Quest, mentor: Character) => {
-    if (!requireAuth('Sign in to embark on your generated quest.')) {
-      return;
-    }
-    setQuestCreatorPrefill(null);
-    updateData((prev) => {
-      const existingIndex = prev.customQuests.findIndex((q) => q.id === quest.id);
-      let updatedCustomQuests: Quest[];
-      if (existingIndex > -1) {
-        updatedCustomQuests = [...prev.customQuests];
-        updatedCustomQuests[existingIndex] = quest;
-      } else {
-        updatedCustomQuests = [quest, ...prev.customQuests];
+  const handleCreateQuestFromNextSteps = useCallback(
+    (steps: string[], questTitle?: string) => {
+      if (!requireAuth('Sign in to turn feedback into new quests.')) {
+        return;
       }
-      return {
-        ...prev,
-        customQuests: updatedCustomQuests,
-        activeQuestId: quest.id,
-      };
-    });
-    setActiveQuest(quest);
-    setSelectedCharacter(mentor);
-    setView('conversation');
-    setResumeConversationId(null);
-    updateCharacterQueryParam(mentor.id, 'push');
-  };
-
-  const handleQuizExit = () => {
-    setQuizQuest(null);
-    setQuizAssessment(null);
-    setView('selector');
-  };
-
-  const handleQuizComplete = (result: QuizResult) => {
-    if (!requireAuth('Sign in to track quiz results.')) {
-      setQuizQuest(null);
-      setQuizAssessment(null);
-      setView('selector');
-      return;
-    }
-    const quest = quizQuest;
-    updateData((prev) => {
-      let updatedCompleted = [...prev.completedQuestIds];
-      if (quest) {
-        const alreadyCompleted = updatedCompleted.includes(quest.id);
-        if (result.passed && !alreadyCompleted) {
-          updatedCompleted = [...updatedCompleted, quest.id];
-        }
-        if (!result.passed && alreadyCompleted) {
-          updatedCompleted = updatedCompleted.filter((id) => id !== quest.id);
-        }
+      const trimmedSteps = steps.map((step) => step.trim()).filter(Boolean);
+      if (trimmedSteps.length === 0) {
+        openQuestCreator();
+        return;
       }
 
-      return {
-        ...prev,
-        completedQuestIds: updatedCompleted,
-        lastQuizResult: result,
-      };
-    });
-    setQuizQuest(null);
-    setQuizAssessment(null);
-    setView('selector');
-  };
+      const bulletList = trimmedSteps.map((step) => `- ${step}`).join('\n');
+      const intro = questTitle
+        ? `I need a follow-up quest to improve at "${questTitle}".`
+        : 'I need a new quest to improve my understanding.';
+      const prefill = `${intro}\nFocus on:\n${bulletList}`;
 
-  const launchQuizForQuest = (questId: string) => {
-    const quest = allQuests.find((q) => q.id === questId);
-    if (!quest) {
-      console.warn(`Unable to launch quiz: quest with ID ${questId} not found.`);
-      setView('selector');
-      return;
-    }
+      openQuestCreator(prefill);
+    },
+    [openQuestCreator, requireAuth],
+  );
 
-    setQuizQuest(quest);
-    if (lastQuestOutcome?.questId === questId) {
-      setQuizAssessment(lastQuestOutcome);
-    } else {
-      setQuizAssessment(null);
-    }
-    setView('quiz');
-  };
-
-  // ---- End conversation: summarize & (if quest) evaluate mastery ----
-    const handleEndConversation = async (transcript: ConversationTurn[], sessionId: string) => {
-    if (!selectedCharacter) return;
-    if (!requireAuth('Sign in to save your conversation.')) {
-      return;
-    }
-    setIsSavingConversation(true);
-    let questAssessment: QuestAssessment | null = null;
-    const questForSession = activeQuest;
-
-    if (questForSession) {
-      setQuizQuest(null);
-      setQuizAssessment(null);
-    }
-
-    try {
-      const existingConversation = conversationHistory.find((c) => c.id === sessionId);
-
-      let updatedConversation: SavedConversation =
-        existingConversation ??
-        ({
-          id: sessionId,
-          characterId: selectedCharacter.id,
-          characterName: selectedCharacter.name,
-          portraitUrl: selectedCharacter.portraitUrl,
-          timestamp: Date.now(),
-          transcript,
-          environmentImageUrl: environmentImageUrl || undefined,
-        } as SavedConversation);
-
-      updatedConversation = {
-        ...updatedConversation,
-        transcript,
-        environmentImageUrl: environmentImageUrl || undefined,
-        timestamp: Date.now(),
-      };
-
-      if (questForSession) {
-        updatedConversation = {
-          ...updatedConversation,
-          questId: questForSession.id,
-          questTitle: questForSession.title,
-        };
+  const startGeneratedQuest = useCallback(
+    (quest: Quest, mentor: Character) => {
+      if (!requireAuth('Sign in to embark on your generated quest.')) {
+        return;
       }
-
-      let ai: GoogleGenAI | null = null;
-      if (!process.env.API_KEY) {
-        console.error('API_KEY not set, skipping summary and quest assessment.');
-      } else {
-        ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
-      }
-
-      if (ai && transcript.length > 1) {
-        const transcriptText = transcript
-          .slice(1)
-          .map((turn) => `${turn.speakerName}: ${turn.text}`)
-          .join('\n\n');
-
-        if (transcriptText.trim()) {
-          const prompt = `Please summarize the following educational dialogue with ${selectedCharacter.name}. Provide a concise one-paragraph overview of the key topics discussed, and then list 3-5 of the most important takeaways or concepts as bullet points.\n\nDialogue:\n${transcriptText}`;
-
-          const response = await ai.models.generateContent({
-            model: 'gemini-2.5-flash',
-            contents: prompt,
-            config: {
-              responseMimeType: 'application/json',
-              responseSchema: {
-                type: Type.OBJECT,
-                properties: {
-                  overview: { type: Type.STRING, description: 'A one-paragraph overview of the conversation.' },
-                  takeaways: {
-                    type: Type.ARRAY,
-                    items: { type: Type.STRING },
-                    description: 'A list of 3-5 key takeaways from the conversation.',
-                  },
-                },
-                required: ['overview', 'takeaways'],
-              },
-            },
-          });
-
-          const summary: Summary = JSON.parse(response.text);
-          updatedConversation = {
-            ...updatedConversation,
-            summary,
-            timestamp: Date.now(),
-          };
-        }
-      }
-
-      if (ai && questForSession) {
-        const questTranscriptText = transcript.map((turn) => `${turn.speakerName}: ${turn.text}`).join('\n\n');
-
-        if (questTranscriptText.trim()) {
-          const evaluationPrompt = `You are a meticulous mentor evaluating whether a student has mastered the quest "${questForSession.title}". Review the conversation transcript between the mentor and student. Determine if the student demonstrates a working understanding of the quest objective: "${questForSession.objective}".\n\nReturn a JSON object with this structure:\n{\n  "passed": boolean,\n  "summary": string,          // one or two sentences explaining your verdict in plain language\n  "evidence": string[],       // bullet-friendly phrases citing what the student said that shows understanding\n  "improvements": string[]    // actionable suggestions if the student has gaps (empty if passed)\n}\n\nFocus only on the student's contributions. Mark passed=true only if the learner clearly articulates key ideas from the objective.`;
-
-          const evaluationResponse = await ai.models.generateContent({
-            model: 'gemini-2.5-flash',
-            contents: evaluationPrompt + `\n\nTranscript:\n${questTranscriptText}`,
-            config: {
-              responseMimeType: 'application/json',
-              responseSchema: {
-                type: Type.OBJECT,
-                properties: {
-                  passed: { type: Type.BOOLEAN },
-                  summary: { type: Type.STRING },
-                  evidence: { type: Type.ARRAY, items: { type: Type.STRING } },
-                  improvements: { type: Type.ARRAY, items: { type: Type.STRING } },
-                },
-                required: ['passed', 'summary', 'evidence', 'improvements'],
-              },
-            },
-          });
-
-          const evaluation = JSON.parse(evaluationResponse.text);
-          questAssessment = {
-            questId: questForSession.id,
-            questTitle: questForSession.title,
-            passed: Boolean(evaluation.passed),
-            summary: evaluation.summary || '',
-            evidence: Array.isArray(evaluation.evidence) ? evaluation.evidence : [],
-            improvements: Array.isArray(evaluation.improvements) ? evaluation.improvements : [],
-          };
-
-          updatedConversation = {
-            ...updatedConversation,
-            questAssessment,
-          };
-        }
-      } else if (questForSession) {
-        updatedConversation = {
-          ...updatedConversation,
-          questId: questForSession.id,
-          questTitle: questForSession.title,
-        };
-      }
-
+      setQuestCreatorPrefill(null);
       updateData((prev) => {
-        const existingIndex = prev.conversations.findIndex((conversation) => conversation.id === updatedConversation.id);
-        const nextHistory = [...prev.conversations];
+        const existingIndex = prev.customQuests.findIndex((q) => q.id === quest.id);
+        let updatedCustomQuests: Quest[];
         if (existingIndex > -1) {
-          nextHistory[existingIndex] = updatedConversation;
+          updatedCustomQuests = [...prev.customQuests];
+          updatedCustomQuests[existingIndex] = quest;
         } else {
-          nextHistory.unshift(updatedConversation);
+          updatedCustomQuests = [quest, ...prev.customQuests];
         }
+        return {
+          ...prev,
+          customQuests: updatedCustomQuests,
+          activeQuestId: quest.id,
+        };
+      });
+      applyConversationContext({ character: mentor, quest, resumeId: null, environmentUrl: null });
+      navigate(links.conversation(mentor.id));
+    },
+    [applyConversationContext, navigate, requireAuth, updateData],
+  );
 
-        let nextCompleted = [...prev.completedQuestIds];
-        if (questForSession) {
-          const alreadyCompleted = nextCompleted.includes(questForSession.id);
-          if (questAssessment?.passed) {
-            if (!alreadyCompleted) {
-              nextCompleted.push(questForSession.id);
-            }
-          } else if (alreadyCompleted) {
-            nextCompleted = nextCompleted.filter((id) => id !== questForSession.id);
+  const handleQuizExit = useCallback(() => {
+    setPendingQuiz(null);
+    navigate('/');
+  }, [navigate]);
+
+  const handleQuizComplete = useCallback(
+    (result: QuizResult) => {
+      if (!requireAuth('Sign in to track quiz results.')) {
+        setPendingQuiz(null);
+        navigate('/');
+        return;
+      }
+      const quest = pendingQuiz ? allQuests.find((q) => q.id === pendingQuiz.questId) ?? null : null;
+      updateData((prev) => {
+        let updatedCompleted = [...prev.completedQuestIds];
+        if (quest) {
+          const alreadyCompleted = updatedCompleted.includes(quest.id);
+          if (result.passed && !alreadyCompleted) {
+            updatedCompleted = [...updatedCompleted, quest.id];
+          }
+          if (!result.passed && alreadyCompleted) {
+            updatedCompleted = updatedCompleted.filter((id) => id !== quest.id);
           }
         }
 
         return {
           ...prev,
-          conversations: nextHistory,
-          completedQuestIds: nextCompleted,
+          completedQuestIds: updatedCompleted,
+          lastQuizResult: result,
         };
       });
+      setPendingQuiz(null);
+      navigate('/');
+    },
+    [allQuests, navigate, pendingQuiz, requireAuth, updateData],
+  );
 
-      if (questAssessment) {
-        setLastQuestOutcome(questAssessment);
-      } else {
-        setLastQuestOutcome(null);
+  const launchQuizForQuest = useCallback(
+    (questId: string) => {
+      const quest = allQuests.find((q) => q.id === questId);
+      if (!quest) {
+        console.warn(`Unable to launch quiz: quest with ID ${questId} not found.`);
+        navigate('/');
+        return;
       }
 
-      syncQuestProgress();
-    } catch (error) {
-      console.error('Failed to finalize conversation:', error);
-    } finally {
-      setIsSavingConversation(false);
-      if (questAssessment) {
-        if (questAssessment.passed && questForSession) {
-          setQuizQuest(questForSession);
-          setQuizAssessment(questAssessment);
-          setView('quiz');
-        } else {
-          setView('selector');
+      const assessment = lastQuestOutcome?.questId === questId ? lastQuestOutcome : null;
+      setPendingQuiz({ questId, assessment });
+      navigate(links.quiz(questId));
+    },
+    [allQuests, lastQuestOutcome, navigate],
+  );
+
+  const handleEndConversation = useCallback(
+    async (transcript: ConversationTurn[], sessionId: string) => {
+      if (!selectedCharacter) return;
+      if (!requireAuth('Sign in to save your conversation.')) {
+        return;
+      }
+      setIsSavingConversation(true);
+      let questAssessment: QuestAssessment | null = null;
+      const questForSession = activeQuest;
+
+      if (questForSession) {
+        setPendingQuiz(null);
+      }
+
+      try {
+        const existingConversation = conversationHistory.find((c) => c.id === sessionId);
+
+        let updatedConversation: SavedConversation =
+          existingConversation ??
+          ({
+            id: sessionId,
+            characterId: selectedCharacter.id,
+            characterName: selectedCharacter.name,
+            portraitUrl: selectedCharacter.portraitUrl,
+            timestamp: Date.now(),
+            transcript,
+            environmentImageUrl: environmentImageUrl || undefined,
+          } as SavedConversation);
+
+        updatedConversation = {
+          ...updatedConversation,
+          transcript,
+          environmentImageUrl: environmentImageUrl || undefined,
+          timestamp: Date.now(),
+        };
+
+        if (questForSession) {
+          updatedConversation = {
+            ...updatedConversation,
+            questId: questForSession.id,
+            questTitle: questForSession.title,
+          };
         }
-      } else {
-        setView('selector');
-      }
-      setSelectedCharacter(null);
-      setEnvironmentImageUrl(null);
-      setActiveQuest(null);
-      updateData((prev) => ({
-        ...prev,
-        activeQuestId: null,
-      }));
-      setResumeConversationId(null);
-      window.history.pushState({}, '', window.location.pathname);
-    }
-  };
 
-  // ---- View switcher ----
+        let ai: GoogleGenAI | null = null;
+        if (!process.env.API_KEY) {
+          console.error('API_KEY not set, skipping summary and quest assessment.');
+        } else {
+          ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+        }
 
-  const renderContent = () => {
-    switch (view) {
-      case 'conversation':
-        return selectedCharacter ? (
-          <ConversationView
-            character={selectedCharacter}
-            onEndConversation={handleEndConversation}
-            environmentImageUrl={environmentImageUrl}
-            onEnvironmentUpdate={setEnvironmentImageUrl}
-            activeQuest={activeQuest}
-            isSaving={isSaving} // pass saving state
-            resumeConversationId={resumeConversationId}
-            conversationHistory={conversationHistory}
-            onConversationUpdate={handleConversationUpdate}
-          />
-        ) : null;
-      case 'history':
-        return (
-          <HistoryView
-            onBack={() => setView('selector')}
-            onResumeConversation={handleResumeConversation}
-            onCreateQuestFromNextSteps={handleCreateQuestFromNextSteps}
-            history={conversationHistory}
-            onDeleteConversation={handleDeleteConversation}
-          />
-        );
-      case 'creator':
-        return <CharacterCreator onCharacterCreated={handleCharacterCreated} onBack={() => setView('selector')} />;
-      case 'quests': {
-        const allCharacters = [...customCharacters, ...CHARACTERS];
-        return (
-          <QuestsView
-            onBack={() => setView('selector')}
-            onSelectQuest={handleSelectQuest}
-            quests={allQuests}
-            characters={allCharacters}
-            completedQuestIds={completedQuests}
-            onCreateQuest={() => openQuestCreator()}
-            inProgressQuestIds={inProgressQuestIds}
-            onDeleteQuest={handleDeleteQuest}
-            deletableQuestIds={customQuests.map((quest) => quest.id)}
-          />
-        );
-      }
-      case 'questCreator': {
-        const allChars = [...customCharacters, ...CHARACTERS];
-        const handleBack = () => {
-          setQuestCreatorPrefill(null);
-          setView('selector');
-        };
-        const handleQuestReady = (quest: Quest, character: Character) => {
-          setQuestCreatorPrefill(null);
-          startGeneratedQuest(quest, character);
-        };
-        return (
-          <QuestCreator
-            characters={allChars}
-            onBack={handleBack}
-            onQuestReady={handleQuestReady}
-            onCharacterCreated={(newChar) => {
-              if (!requireAuth('Sign in to save your custom ancient.')) {
-                return;
+        if (ai && transcript.length > 1) {
+          const transcriptText = transcript
+            .slice(1)
+            .map((turn) => `${turn.speakerName}: ${turn.text}`)
+            .join('\n\n');
+
+          if (transcriptText.trim()) {
+            const prompt = `Please summarize the following educational dialogue with ${selectedCharacter.name}. Provide a concise one-paragraph overview of the key topics discussed, and then list 3-5 of the most important takeaways or concepts as bullet points.\n\nDialogue:\n${transcriptText}`;
+
+            const response = await ai.models.generateContent({
+              model: 'gemini-2.5-flash',
+              contents: prompt,
+              config: {
+                responseMimeType: 'application/json',
+                responseSchema: {
+                  type: Type.OBJECT,
+                  properties: {
+                    overview: { type: Type.STRING, description: 'A one-paragraph overview of the conversation.' },
+                    takeaways: {
+                      type: Type.ARRAY,
+                      items: { type: Type.STRING },
+                      description: 'A list of 3-5 key takeaways from the conversation.',
+                    },
+                  },
+                  required: ['overview', 'takeaways'],
+                },
+              },
+            });
+
+            const summary: Summary = JSON.parse(response.text);
+            updatedConversation = {
+              ...updatedConversation,
+              summary,
+              timestamp: Date.now(),
+            };
+          }
+        }
+
+        if (ai && questForSession) {
+          const questTranscriptText = transcript.map((turn) => `${turn.speakerName}: ${turn.text}`).join('\n\n');
+
+          if (questTranscriptText.trim()) {
+            const evaluationPrompt = `You are a meticulous mentor evaluating whether a student has mastered the quest "${questForSession.title}". Review the conversation transcript between the mentor and student. Determine if the student demonstrates a working understanding of the quest objective: "${questForSession.objective}".\n\nReturn a JSON object with this structure:\n{\n  "passed": boolean,\n  "summary": string,          // one or two sentences explaining your verdict in plain language\n  "evidence": string[],       // bullet-friendly phrases citing what the student said that shows understanding\n  "improvements": string[]    // actionable suggestions if the student has gaps (empty if passed)\n}\n\nFocus only on the student's contributions. Mark passed=true only if the learner clearly articulates key ideas from the objective.`;
+
+            const evaluationResponse = await ai.models.generateContent({
+              model: 'gemini-2.5-flash',
+              contents: evaluationPrompt + `\n\nTranscript:\n${questTranscriptText}`,
+              config: {
+                responseMimeType: 'application/json',
+                responseSchema: {
+                  type: Type.OBJECT,
+                  properties: {
+                    passed: { type: Type.BOOLEAN },
+                    summary: { type: Type.STRING },
+                    evidence: { type: Type.ARRAY, items: { type: Type.STRING } },
+                    improvements: { type: Type.ARRAY, items: { type: Type.STRING } },
+                  },
+                  required: ['passed', 'summary', 'evidence', 'improvements'],
+                },
+              },
+            });
+
+            const evaluation = JSON.parse(evaluationResponse.text);
+            questAssessment = {
+              questId: questForSession.id,
+              questTitle: questForSession.title,
+              passed: Boolean(evaluation.passed),
+              summary: evaluation.summary || '',
+              evidence: Array.isArray(evaluation.evidence) ? evaluation.evidence : [],
+              improvements: Array.isArray(evaluation.improvements) ? evaluation.improvements : [],
+            };
+
+            updatedConversation = {
+              ...updatedConversation,
+              questAssessment,
+            };
+          }
+        } else if (questForSession) {
+          updatedConversation = {
+            ...updatedConversation,
+            questId: questForSession.id,
+            questTitle: questForSession.title,
+          };
+        }
+
+        updateData((prev) => {
+          const existingIndex = prev.conversations.findIndex((conversation) => conversation.id === updatedConversation.id);
+          const nextHistory = [...prev.conversations];
+          if (existingIndex > -1) {
+            nextHistory[existingIndex] = updatedConversation;
+          } else {
+            nextHistory.unshift(updatedConversation);
+          }
+
+          let nextCompleted = [...prev.completedQuestIds];
+          if (questForSession) {
+            const alreadyCompleted = nextCompleted.includes(questForSession.id);
+            if (questAssessment?.passed) {
+              if (!alreadyCompleted) {
+                nextCompleted.push(questForSession.id);
               }
-              updateData((prev) => ({
-                ...prev,
-                customCharacters: [newChar, ...prev.customCharacters],
-              }));
-            }}
-            initialGoal={questCreatorPrefill ?? undefined}
-          />
-        );
+            } else if (alreadyCompleted) {
+              nextCompleted = nextCompleted.filter((id) => id !== questForSession.id);
+            }
+          }
+
+          return {
+            ...prev,
+            conversations: nextHistory,
+            completedQuestIds: nextCompleted,
+          };
+        });
+
+        if (questAssessment) {
+          setLastQuestOutcome(questAssessment);
+        } else {
+          setLastQuestOutcome(null);
+        }
+
+        syncQuestProgress();
+      } catch (error) {
+        console.error('Failed to finalize conversation:', error);
+      } finally {
+        setIsSavingConversation(false);
+        if (questAssessment && questForSession) {
+          setPendingQuiz({ questId: questForSession.id, assessment: questAssessment });
+          navigate(links.quiz(questForSession.id));
+        } else {
+          navigate('/');
+        }
+        applyConversationContext({ character: null, quest: null, resumeId: null, environmentUrl: null });
       }
-      case 'quiz':
-        return quizQuest ? (
-          <QuestQuiz
-            quest={quizQuest}
-            assessment={quizAssessment}
-            onExit={handleQuizExit}
-            onComplete={handleQuizComplete}
-          />
-        ) : (
-          <div className="text-center text-gray-300">
-            <p className="text-lg">Quiz unavailable. Returning to the hub…</p>
-            <button
-              type="button"
-              onClick={() => setView('selector')}
-              className="mt-4 inline-flex items-center rounded-md bg-amber-600 px-4 py-2 text-sm font-semibold text-black hover:bg-amber-500"
-            >
-              Go back
-            </button>
-          </div>
-        );
-      case 'profile':
-        return (
-          <div className="bg-gray-900/60 border border-gray-800 rounded-2xl p-6 text-left space-y-6 animate-fade-in">
-            <div>
-              <h2 className="text-3xl font-bold text-amber-200">Explorer Profile</h2>
-              <p className="text-sm text-gray-400 mt-1">
-                Chronicle your journey with the ancients and track your learning legacy.
-              </p>
-            </div>
-            {isAuthenticated ? (
-              <div className="space-y-6">
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                  <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-4">
-                    <p className="text-xs uppercase tracking-wide text-gray-400">Custom Ancients</p>
-                    <p className="text-2xl font-semibold text-amber-200 mt-1">{customCharacters.length}</p>
-                  </div>
-                  <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-4">
-                    <p className="text-xs uppercase tracking-wide text-gray-400">Conversations</p>
-                    <p className="text-2xl font-semibold text-amber-200 mt-1">{conversationHistory.length}</p>
-                  </div>
-                  <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-4">
-                    <p className="text-xs uppercase tracking-wide text-gray-400">Quests Complete</p>
-                    <p className="text-2xl font-semibold text-amber-200 mt-1">{completedQuests.length}</p>
-                  </div>
-                </div>
-
-                <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-5 space-y-2">
-                  <p className="text-xs uppercase tracking-wide text-gray-400">Account Email</p>
-                  <p className="text-lg text-gray-100">{userEmail ?? 'Unknown adventurer'}</p>
-                </div>
-
-                <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-5">
-                  <p className="text-sm text-gray-200 leading-relaxed">
-                    Keep creating ancients and embarking on quests to expand your mastery. Each conversation strengthens your
-                    connection to the eras you study.
-                  </p>
-                </div>
-              </div>
-            ) : (
-              <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-6 text-center">
-                <p className="text-lg text-amber-200 font-semibold mb-2">Traveler, you must sign in.</p>
-                <p className="text-sm text-gray-300">
-                  Access your profile, track achievements, and synchronize progress across devices once you are authenticated.
-                </p>
-              </div>
-            )}
-          </div>
-        );
-      case 'settings':
-        return (
-          <div className="bg-gray-900/60 border border-gray-800 rounded-2xl p-6 text-left space-y-6 animate-fade-in">
-            <div>
-              <h2 className="text-3xl font-bold text-amber-200">User Settings</h2>
-              <p className="text-sm text-gray-400 mt-1">
-                Customize how you experience conversations with history&apos;s greatest minds.
-              </p>
-            </div>
-            {isAuthenticated ? (
-              <div className="space-y-5">
-                <label className="flex items-center justify-between gap-4 bg-gray-800/50 border border-gray-700 rounded-xl p-4">
-                  <div>
-                    <span className="text-sm font-semibold text-gray-200">Journey Notifications</span>
-                    <p className="text-xs text-gray-400">Receive alerts when a quest assessment is ready.</p>
-                  </div>
-                  <input
-                    type="checkbox"
-                    className="h-5 w-5 rounded border-gray-600 bg-gray-900 text-amber-500 focus:ring-amber-400"
-                    checked={notificationsEnabled}
-                    onChange={(event) => setNotificationsEnabled(event.target.checked)}
-                  />
-                </label>
-
-                <label className="flex items-center justify-between gap-4 bg-gray-800/50 border border-gray-700 rounded-xl p-4">
-                  <div>
-                    <span className="text-sm font-semibold text-gray-200">Auto-save Transcripts</span>
-                    <p className="text-xs text-gray-400">Keep every exchange stored in your history automatically.</p>
-                  </div>
-                  <input
-                    type="checkbox"
-                    className="h-5 w-5 rounded border-gray-600 bg-gray-900 text-amber-500 focus:ring-amber-400"
-                    checked={autoSaveEnabled}
-                    onChange={(event) => setAutoSaveEnabled(event.target.checked)}
-                  />
-                </label>
-
-                <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-4 space-y-2">
-                  <label htmlFor="theme-select" className="text-sm font-semibold text-gray-200">
-                    Interface Theme
-                  </label>
-                  <p className="text-xs text-gray-400">
-                    Choose the ambiance that best matches your study ritual.
-                  </p>
-                  <select
-                    id="theme-select"
-                    className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200 focus:border-amber-400 focus:ring-amber-400"
-                    value={preferredTheme}
-                    onChange={(event) => setPreferredTheme(event.target.value as 'system' | 'light' | 'dark')}
-                  >
-                    <option value="dark">Dark</option>
-                    <option value="light">Light</option>
-                    <option value="system">System</option>
-                  </select>
-                </div>
-
-                <p className="text-xs text-gray-400">
-                  Settings are stored locally for now. Cloud sync will arrive in a future update of School of the Ancients.
-                </p>
-              </div>
-            ) : (
-              <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-6 text-center">
-                <p className="text-lg text-amber-200 font-semibold mb-2">Sign in to tailor your experience.</p>
-                <p className="text-sm text-gray-300">
-                  Manage notifications, transcripts, and appearance preferences once you&apos;re authenticated.
-                </p>
-              </div>
-            )}
-          </div>
-        );
-      case 'selector':
-      default:
-        return (
-          <div className="text-center animate-fade-in">
-            <p className="max-w-3xl mx-auto mb-8 text-gray-400 text-lg">
-              Engage in real-time voice conversations with legendary minds from history, or embark on a guided Learning
-              Quest to master a new subject.
-            </p>
-
-            <div className="max-w-3xl mx-auto mb-8 bg-gray-800/50 border border-gray-700 rounded-lg p-4 text-left">
-              <p className="text-sm text-gray-300 mb-2 font-semibold">Quest Progress</p>
-              <p className="text-xs uppercase tracking-wide text-gray-400 mb-3">
-                {completedQuests.length} of {allQuests.length} quests completed
-              </p>
-              <div className="w-full h-2 bg-gray-700 rounded-full overflow-hidden">
-                <div
-                  className="h-full bg-amber-500 transition-all duration-500"
-                  style={{
-                    width: `${Math.min(
-                      100,
-                      Math.round(
-                        (completedQuests.length / Math.max(allQuests.length, 1)) * 100
-                      )
-                    )}%`,
-                  }}
-                />
-              </div>
-            </div>
-
-            {lastQuestOutcome && (
-              <div
-                className={`max-w-3xl mx-auto mb-8 rounded-lg border p-5 text-left shadow-lg ${
-                  lastQuestOutcome.passed ? 'bg-emerald-900/40 border-emerald-700' : 'bg-red-900/30 border-red-700'
-                }`}
-              >
-                <div className="flex justify-between items-start gap-4">
-                  <div>
-                    <p className="text-xs uppercase tracking-wide text-gray-300 font-semibold">Latest Quest Review</p>
-                    <h3 className="text-2xl font-bold text-amber-200 mt-1">{lastQuestOutcome.questTitle}</h3>
-                  </div>
-                  <span
-                    className={`text-sm font-semibold px-3 py-1 rounded-full ${
-                      lastQuestOutcome.passed ? 'bg-emerald-600 text-emerald-50' : 'bg-red-600 text-red-50'
-                    }`}
-                  >
-                    {lastQuestOutcome.passed ? 'Completed' : 'Needs Review'}
-                  </span>
-                </div>
-
-                <p className="text-gray-200 mt-4 leading-relaxed">{lastQuestOutcome.summary}</p>
-
-                {lastQuestOutcome.evidence.length > 0 && (
-                  <div className="mt-4">
-                    <p className="text-sm font-semibold text-emerald-200 uppercase tracking-wide mb-1">Highlights</p>
-                    <ul className="list-disc list-inside text-gray-100 space-y-1 text-sm">
-                      {lastQuestOutcome.evidence.map((item) => (
-                        <li key={item}>{item}</li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-
-                {!lastQuestOutcome.passed && lastQuestOutcome.improvements.length > 0 && (
-                  <div className="mt-4">
-                    <p className="text-sm font-semibold text-red-200 uppercase tracking-wide mb-1">Next Steps</p>
-                    <ul className="list-disc list-inside text-red-100 space-y-1 text-sm">
-                      {lastQuestOutcome.improvements.map((item) => (
-                        <li key={item}>{item}</li>
-                      ))}
-                    </ul>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        handleCreateQuestFromNextSteps(
-                          lastQuestOutcome.improvements,
-                          lastQuestOutcome.questTitle
-                        )
-                      }
-                      className="mt-3 inline-flex items-center text-sm font-semibold text-teal-200 border border-teal-500/60 px-3 py-1.5 rounded-md hover:bg-teal-600/20 focus:outline-none focus:ring-2 focus:ring-teal-400/60"
-                    >
-                      Turn next steps into a new quest
-                    </button>
-                  </div>
-                )}
-
-                {!lastQuestOutcome.passed && lastQuestOutcome.questId && (
-                  <button
-                    type="button"
-                    onClick={() => handleContinueQuest(lastQuestOutcome.questId)}
-                    className="mt-4 inline-flex items-center text-sm font-semibold text-amber-200 hover:text-amber-100 hover:underline focus:outline-none"
-                  >
-                    Continue quest?
-                  </button>
-                )}
-              </div>
-            )}
-
-            {lastQuizResult && (
-              <div
-                className={`max-w-3xl mx-auto mb-8 rounded-lg border p-5 text-left shadow-lg ${
-                  lastQuizResult.passed ? 'bg-emerald-900/30 border-emerald-700/80' : 'bg-amber-900/30 border-amber-700/80'
-                }`}
-              >
-                <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
-                  <div>
-                    <p className="text-xs uppercase tracking-wide text-gray-300 font-semibold">Latest Quiz Result</p>
-                    <h3 className="text-2xl font-bold text-amber-200 mt-1">
-                      {lastQuizQuest?.title ?? 'Quest Mastery Quiz'}
-                    </h3>
-                  </div>
-                  <span
-                    className={`text-sm font-semibold px-3 py-1 rounded-full ${
-                      lastQuizResult.passed ? 'bg-emerald-600 text-emerald-50' : 'bg-amber-600 text-amber-50'
-                    }`}
-                  >
-                    {lastQuizResult.passed ? 'Mastery Confirmed' : 'Needs Review'}
-                  </span>
-                </div>
-
-                <p className="text-gray-200 mt-4 text-lg font-semibold">
-                  Score: {lastQuizResult.correct} / {lastQuizResult.total} correct ({
-                    Math.round(lastQuizResult.scoreRatio * 100)
-                  }
-                  %)
-                </p>
-
-                {lastQuizResult.missedObjectiveTags.length > 0 && (
-                  <div className="mt-4">
-                    <p className="text-xs uppercase tracking-wide text-amber-200 mb-2">Review focus areas</p>
-                    <div className="flex flex-wrap justify-center gap-2">
-                      {lastQuizResult.missedObjectiveTags.map((tag) => (
-                        <span
-                          key={tag}
-                          className="inline-flex items-center rounded-full border border-amber-500/70 bg-amber-900/30 px-3 py-1 text-xs text-amber-100"
-                        >
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                <div className="mt-6 flex flex-col sm:flex-row sm:items-center sm:justify-end gap-3">
-                  <button
-                    type="button"
-                    onClick={() => launchQuizForQuest(lastQuizResult.questId)}
-                    className="rounded-lg border border-amber-500/70 px-4 py-2 text-sm font-semibold text-amber-200 hover:bg-amber-500/10"
-                  >
-                    {lastQuizResult.passed ? 'Retake for practice' : 'Retry quiz'}
-                  </button>
-                </div>
-              </div>
-            )}
-
-            <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mb-12">
-              <button
-                onClick={openQuestsView}
-                className="flex items-center gap-3 bg-amber-600 hover:bg-amber-500 text-black font-bold py-3 px-8 rounded-lg transition-colors duration-300 text-lg w-full sm:w-auto"
-              >
-                <QuestIcon className="w-6 h-6" />
-                <span>Learning Quests</span>
-              </button>
-
-              <button
-                onClick={openHistoryView}
-                className="bg-gray-700 hover:bg-gray-600 text-amber-300 font-bold py-3 px-8 rounded-lg transition-colors duration-300 border border-gray-600 w-full sm:w-auto"
-              >
-                View Conversation History
-              </button>
-
-              {/* NEW CTA */}
-              <button
-                onClick={() => openQuestCreator()}
-                className="bg-teal-700 hover:bg-teal-600 text-white font-bold py-3 px-8 rounded-lg transition-colors duration-300 w-full sm:w-auto"
-              >
-                Create Your Quest
-              </button>
-            </div>
-
-            <Instructions />
-
-            <CharacterSelector
-              characters={[...customCharacters, ...CHARACTERS]}
-              onSelectCharacter={handleSelectCharacter}
-              onStartCreation={openCharacterCreatorView}
-              onDeleteCharacter={handleDeleteCharacter}
-            />
-          </div>
-        );
-    }
-  };
+    },
+    [
+      activeQuest,
+      applyConversationContext,
+      conversationHistory,
+      environmentImageUrl,
+      navigate,
+      requireAuth,
+      selectedCharacter,
+      syncQuestProgress,
+      updateData,
+    ],
+  );
 
   const handleSignInClick = useCallback(() => {
     if (isAuthenticated) {
@@ -1197,38 +750,124 @@ const App: React.FC = () => {
     setIsAuthModalOpen(true);
   }, [isAuthenticated, signOut]);
 
-  const userEmail = user?.email ?? (user?.user_metadata as { email?: string })?.email;
+  const handleConversationRouteHydration = useCallback(
+    ({ characterId, resumeId }: { characterId: string | null; resumeId: string | null }) => {
+      if (!characterId && !resumeId) {
+        return { validResume: true };
+      }
+
+      let validResume = true;
+      let character: Character | null = null;
+
+      if (characterId) {
+        character = allCharacters.find((item) => item.id === characterId) ?? null;
+        if (character) {
+          applyConversationContext({ character });
+          if (!resumeId && activeQuest && activeQuest.characterId !== character.id) {
+            applyConversationContext({ quest: null });
+          }
+        } else if (!resumeId) {
+          applyConversationContext({ character: null, quest: null, resumeId: null, environmentUrl: null });
+        }
+      }
+
+      if (resumeId) {
+        const conversation = conversationHistory.find((item) => item.id === resumeId) ?? null;
+        if (!conversation) {
+          validResume = false;
+          setResumeConversationId(null);
+        } else {
+          const resumeCharacter =
+            allCharacters.find((item) => item.id === conversation.characterId) ?? character ?? null;
+          if (resumeCharacter) {
+            character = resumeCharacter;
+            applyConversationContext({
+              character: resumeCharacter,
+              resumeId: conversation.id,
+              environmentUrl: conversation.environmentImageUrl || null,
+              quest: conversation.questId
+                ? allQuests.find((quest) => quest.id === conversation.questId) ?? null
+                : null,
+            });
+          }
+        }
+      } else {
+        setResumeConversationId(null);
+        if (character) {
+          applyConversationContext({ character, environmentUrl: null });
+        }
+      }
+
+      return { validResume };
+    },
+    [
+      activeQuest,
+      allCharacters,
+      allQuests,
+      applyConversationContext,
+      conversationHistory,
+      setResumeConversationId,
+    ],
+  );
 
   const openHistoryView = useCallback(() => {
     if (!requireAuth('Sign in to review your past conversations.')) {
       return;
     }
-    setView('history');
-  }, [requireAuth]);
+    navigate('/history');
+  }, [navigate, requireAuth]);
 
   const openQuestsView = useCallback(() => {
     if (!requireAuth('Sign in to manage your quests.')) {
       return;
     }
-    setView('quests');
-  }, [requireAuth]);
+    navigate('/quests');
+  }, [navigate, requireAuth]);
 
   const openProfileView = useCallback(() => {
     if (!requireAuth('Sign in to view your explorer profile.')) {
       return;
     }
-    setView('profile');
-  }, [requireAuth]);
+    navigate('/profile');
+  }, [navigate, requireAuth]);
 
   const openSettingsView = useCallback(() => {
     if (!requireAuth('Sign in to update your settings.')) {
       return;
     }
-    setView('settings');
-  }, [requireAuth]);
+    navigate('/settings');
+  }, [navigate, requireAuth]);
+
+  const currentView = useMemo(() => {
+    if (location.pathname.startsWith('/quests/')) {
+      return 'quests';
+    }
+    switch (location.pathname) {
+      case '/quests':
+        return 'quests';
+      case '/quest/new':
+        return 'questCreator';
+      case '/conversation':
+        return 'conversation';
+      case '/history':
+        return 'history';
+      case '/characters/new':
+        return 'creator';
+      case '/profile':
+        return 'profile';
+      case '/settings':
+        return 'settings';
+      case '/quiz':
+      default:
+        return 'selector';
+    }
+  }, [location.pathname]);
+
+  const userEmail = user?.email ?? (user?.user_metadata as { email?: string })?.email;
 
   return (
     <div className="relative min-h-screen bg-[#1a1a1a]">
+      <ScrollToTop />
       <AuthModal
         isOpen={isAuthModalOpen && !isAuthenticated}
         prompt={authPrompt}
@@ -1256,9 +895,7 @@ const App: React.FC = () => {
               <p className="text-gray-400 mt-2 text-lg">Old world wisdom. New world classroom.</p>
             </div>
             <div className="flex flex-col sm:items-end gap-2">
-              {userEmail && (
-                <span className="text-sm text-gray-300">Signed in as {userEmail}</span>
-              )}
+              {userEmail && <span className="text-sm text-gray-300">Signed in as {userEmail}</span>}
               <button
                 type="button"
                 onClick={handleSignInClick}
@@ -1282,11 +919,261 @@ const App: React.FC = () => {
             onOpenProfile={openProfileView}
             onOpenSettings={openSettingsView}
             onOpenQuests={openQuestsView}
-            currentView={view}
+            currentView={currentView}
             isAuthenticated={isAuthenticated}
             userEmail={userEmail}
           />
-          <div className="flex-1 flex flex-col">{renderContent()}</div>
+          <div className="flex-1 flex flex-col">
+            <Routes>
+              <Route
+                path="/"
+                element={
+                  <SelectorRoute
+                    builtInCharacters={CHARACTERS}
+                    customCharacters={customCharacters}
+                    allQuests={allQuests}
+                    completedQuestIds={completedQuests}
+                    lastQuestOutcome={lastQuestOutcome}
+                    lastQuizResult={lastQuizResult}
+                    lastQuizQuest={lastQuizQuest}
+                    onSelectCharacter={handleSelectCharacter}
+                    onStartCreation={openCharacterCreatorView}
+                    onDeleteCharacter={handleDeleteCharacter}
+                    onOpenQuests={openQuestsView}
+                    onOpenHistory={openHistoryView}
+                    onOpenQuestCreator={() => openQuestCreator()}
+                    onCreateQuestFromNextSteps={handleCreateQuestFromNextSteps}
+                    onContinueQuest={handleContinueQuest}
+                    onLaunchQuiz={launchQuizForQuest}
+                  />
+                }
+              />
+              <Route
+                path="/quests"
+                element={
+                  <QuestsRoute
+                    quests={allQuests}
+                    characters={allCharacters}
+                    completedQuestIds={completedQuests}
+                    inProgressQuestIds={inProgressQuestIds}
+                    deletableQuestIds={customQuests.map((quest) => quest.id)}
+                    onSelectQuest={handleSelectQuest}
+                    onCreateQuest={() => openQuestCreator()}
+                    onBack={() => navigate('/')}
+                    onDeleteQuest={handleDeleteQuest}
+                  />
+                }
+              />
+              <Route
+                path="/quests/:questId"
+                element={
+                  <QuestDetailRoute
+                    quests={allQuests}
+                    characters={allCharacters}
+                    completedQuestIds={completedQuests}
+                    inProgressQuestIds={inProgressQuestIds}
+                    deletableQuestIds={customQuests.map((quest) => quest.id)}
+                    onSelectQuest={handleSelectQuest}
+                    onDeleteQuest={handleDeleteQuest}
+                  />
+                }
+              />
+              <Route
+                path="/quest/new"
+                element={
+                  <QuestCreatorRoute
+                    characters={allCharacters}
+                    initialGoal={questCreatorPrefill}
+                    onBack={() => {
+                      setQuestCreatorPrefill(null);
+                      navigate(-1);
+                    }}
+                    onQuestReady={(quest, mentor) => {
+                      setQuestCreatorPrefill(null);
+                      startGeneratedQuest(quest, mentor);
+                    }}
+                    onCharacterCreated={(newChar) => {
+                      if (!requireAuth('Sign in to save your custom ancient.')) {
+                        return;
+                      }
+                      updateData((prev) => ({
+                        ...prev,
+                        customCharacters: [newChar, ...prev.customCharacters],
+                      }));
+                    }}
+                  />
+                }
+              />
+              <Route
+                path="/quiz/:questId"
+                element={
+                  <QuizRoute
+                    quests={allQuests}
+                    pendingAssessment={pendingQuiz}
+                    onExit={handleQuizExit}
+                    onComplete={handleQuizComplete}
+                  />
+                }
+              />
+              <Route
+                path="/conversation"
+                element={
+                  <ConversationRoute
+                    selectedCharacter={selectedCharacter}
+                    conversationHistory={conversationHistory}
+                    resumeConversationId={resumeConversationId}
+                    environmentImageUrl={environmentImageUrl}
+                    activeQuest={activeQuest}
+                    isSaving={isSaving}
+                    isAuthenticated={isAuthenticated}
+                    onEnvironmentUpdate={setEnvironmentImageUrl}
+                    onConversationUpdate={handleConversationUpdate}
+                    onEndConversation={handleEndConversation}
+                    onHydrateFromParams={handleConversationRouteHydration}
+                  />
+                }
+              />
+              <Route
+                path="/history"
+                element={
+                  <HistoryRoute
+                    history={conversationHistory}
+                    onResumeConversation={handleResumeConversation}
+                    onCreateQuestFromNextSteps={handleCreateQuestFromNextSteps}
+                    onDeleteConversation={handleDeleteConversation}
+                    onBack={() => navigate('/')}
+                  />
+                }
+              />
+              <Route
+                path="/characters/new"
+                element={<CharacterCreator onCharacterCreated={handleCharacterCreated} onBack={() => navigate('/')} />}
+              />
+              <Route
+                path="/profile"
+                element={
+                  <div className="bg-gray-900/60 border border-gray-800 rounded-2xl p-6 text-left space-y-6 animate-fade-in">
+                    <div>
+                      <h2 className="text-3xl font-bold text-amber-200">Explorer Profile</h2>
+                      <p className="text-sm text-gray-400 mt-1">
+                        Chronicle your journey with the ancients and track your learning legacy.
+                      </p>
+                    </div>
+                    {isAuthenticated ? (
+                      <div className="space-y-6">
+                        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                          <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-4">
+                            <p className="text-xs uppercase tracking-wide text-gray-400">Custom Ancients</p>
+                            <p className="text-2xl font-semibold text-amber-200 mt-1">{customCharacters.length}</p>
+                          </div>
+                          <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-4">
+                            <p className="text-xs uppercase tracking-wide text-gray-400">Conversations</p>
+                            <p className="text-2xl font-semibold text-amber-200 mt-1">{conversationHistory.length}</p>
+                          </div>
+                          <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-4">
+                            <p className="text-xs uppercase tracking-wide text-gray-400">Quests Complete</p>
+                            <p className="text-2xl font-semibold text-amber-200 mt-1">{completedQuests.length}</p>
+                          </div>
+                        </div>
+
+                        <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-5 space-y-2">
+                          <p className="text-xs uppercase tracking-wide text-gray-400">Account Email</p>
+                          <p className="text-lg text-gray-100">{userEmail ?? 'Unknown adventurer'}</p>
+                        </div>
+
+                        <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-5">
+                          <p className="text-sm text-gray-200 leading-relaxed">
+                            Keep creating ancients and embarking on quests to expand your mastery. Each conversation
+                            strengthens your connection to the eras you study.
+                          </p>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-6 text-center">
+                        <p className="text-lg text-amber-200 font-semibold mb-2">Traveler, you must sign in.</p>
+                        <p className="text-sm text-gray-300">
+                          Access your profile, track achievements, and synchronize progress across devices once you are
+                          authenticated.
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                }
+              />
+              <Route
+                path="/settings"
+                element={
+                  <div className="bg-gray-900/60 border border-gray-800 rounded-2xl p-6 text-left space-y-6 animate-fade-in">
+                    <div>
+                      <h2 className="text-3xl font-bold text-amber-200">User Settings</h2>
+                      <p className="text-sm text-gray-400 mt-1">
+                        Customize how you experience conversations with history&apos;s greatest minds.
+                      </p>
+                    </div>
+                    {isAuthenticated ? (
+                      <div className="space-y-5">
+                        <label className="flex items-center justify-between gap-4 bg-gray-800/50 border border-gray-700 rounded-xl p-4">
+                          <div>
+                            <span className="text-sm font-semibold text-gray-200">Journey Notifications</span>
+                            <p className="text-xs text-gray-400">Receive alerts when a quest assessment is ready.</p>
+                          </div>
+                          <input
+                            type="checkbox"
+                            className="h-5 w-5 rounded border-gray-600 bg-gray-900 text-amber-500 focus:ring-amber-400"
+                            checked={notificationsEnabled}
+                            onChange={(event) => setNotificationsEnabled(event.target.checked)}
+                          />
+                        </label>
+
+                        <label className="flex items-center justify-between gap-4 bg-gray-800/50 border border-gray-700 rounded-xl p-4">
+                          <div>
+                            <span className="text-sm font-semibold text-gray-200">Auto-save Transcripts</span>
+                            <p className="text-xs text-gray-400">Keep every exchange stored in your history automatically.</p>
+                          </div>
+                          <input
+                            type="checkbox"
+                            className="h-5 w-5 rounded border-gray-600 bg-gray-900 text-amber-500 focus:ring-amber-400"
+                            checked={autoSaveEnabled}
+                            onChange={(event) => setAutoSaveEnabled(event.target.checked)}
+                          />
+                        </label>
+
+                        <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-4 space-y-2">
+                          <label htmlFor="theme-select" className="text-sm font-semibold text-gray-200">
+                            Interface Theme
+                          </label>
+                          <p className="text-xs text-gray-400">Choose the ambiance that best matches your study ritual.</p>
+                          <select
+                            id="theme-select"
+                            className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200 focus:border-amber-400 focus:ring-amber-400"
+                            value={preferredTheme}
+                            onChange={(event) => setPreferredTheme(event.target.value as 'system' | 'light' | 'dark')}
+                          >
+                            <option value="dark">Dark</option>
+                            <option value="light">Light</option>
+                            <option value="system">System</option>
+                          </select>
+                        </div>
+
+                        <p className="text-xs text-gray-400">
+                          Settings are stored locally for now. Cloud sync will arrive in a future update of School of the
+                          Ancients.
+                        </p>
+                      </div>
+                    ) : (
+                      <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-6 text-center">
+                        <p className="text-lg text-amber-200 font-semibold mb-2">Sign in to tailor your experience.</p>
+                        <p className="text-sm text-gray-300">
+                          Manage notifications, transcripts, and appearance preferences once you&apos;re authenticated.
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                }
+              />
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
+          </div>
         </main>
       </div>
     </div>

--- a/index.tsx
+++ b/index.tsx
@@ -1,22 +1,25 @@
-
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+
 import App from './App';
 import { SupabaseAuthProvider } from './hooks/useSupabaseAuth';
 import { UserDataProvider } from './hooks/useUserData';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
-  throw new Error("Could not find root element to mount to");
+  throw new Error('Could not find root element to mount to');
 }
 
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <SupabaseAuthProvider>
-      <UserDataProvider>
-        <App />
-      </UserDataProvider>
-    </SupabaseAuthProvider>
-  </React.StrictMode>
+    <BrowserRouter>
+      <SupabaseAuthProvider>
+        <UserDataProvider>
+          <App />
+        </UserDataProvider>
+      </SupabaseAuthProvider>
+    </BrowserRouter>
+  </React.StrictMode>,
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@google/genai": "^1.22.0",
         "@supabase/supabase-js": "^2.58.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.9.3"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -2107,6 +2108,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3224,6 +3234,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.3.tgz",
+      "integrity": "sha512-4o2iWCFIwhI/eYAIL43+cjORXYn/aRQPgtFRRZb3VzoyQ5Uej0Bmqj7437L97N9NJW4wnicSwLOLS+yCXfAPgg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.3.tgz",
+      "integrity": "sha512-1QSbA0TGGFKTAc/aWjpfW/zoEukYfU4dc1dLkT/vvf54JoGMkW+fNA+3oyo2gWVW1GM7BxjJVHz5GnPJv40rvg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.9.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -3352,6 +3400,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@google/genai": "^1.22.0",
     "@supabase/supabase-js": "^2.58.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.9.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -1,0 +1,14 @@
+export const links = {
+  quest: (id: string) => `/quests/${id}`,
+  quiz: (id: string) => `/quiz/${id}`,
+  conversation: (characterId: string, options?: { resumeId?: string }) => {
+    const params = new URLSearchParams({ character: characterId });
+    if (options?.resumeId) {
+      params.set('resume', options.resumeId);
+    }
+    const search = params.toString();
+    return `/conversation${search ? `?${search}` : ''}`;
+  },
+};
+
+export type ConversationLinkOptions = Parameters<typeof links.conversation>[1];

--- a/src/routes/Conversation.tsx
+++ b/src/routes/Conversation.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+import ConversationView from '../../components/ConversationView';
+import type {
+  Character,
+  ConversationTurn,
+  Quest,
+  SavedConversation,
+} from '../../types';
+
+interface ConversationRouteProps {
+  selectedCharacter: Character | null;
+  conversationHistory: SavedConversation[];
+  resumeConversationId: string | null;
+  environmentImageUrl: string | null;
+  activeQuest: Quest | null;
+  isSaving: boolean;
+  isAuthenticated: boolean;
+  onEnvironmentUpdate: (value: string | null) => void;
+  onConversationUpdate: (conversation: SavedConversation) => void;
+  onEndConversation: (transcript: ConversationTurn[], sessionId: string) => Promise<void>;
+  onHydrateFromParams: (
+    params: { characterId: string | null; resumeId: string | null }
+  ) => { validResume: boolean };
+}
+
+const ConversationRoute: React.FC<ConversationRouteProps> = ({
+  selectedCharacter,
+  conversationHistory,
+  resumeConversationId,
+  environmentImageUrl,
+  activeQuest,
+  isSaving,
+  isAuthenticated,
+  onEnvironmentUpdate,
+  onConversationUpdate,
+  onEndConversation,
+  onHydrateFromParams,
+}) => {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    const characterId = searchParams.get('character');
+    const resumeId = searchParams.get('resume');
+    const { validResume } = onHydrateFromParams({ characterId, resumeId });
+    if (resumeId && !validResume) {
+      const next = new URLSearchParams(searchParams.toString());
+      next.delete('resume');
+      setSearchParams(next, { replace: true });
+    }
+  }, [onHydrateFromParams, searchParams, setSearchParams]);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate('/', { replace: true });
+    }
+  }, [isAuthenticated, navigate]);
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  if (!selectedCharacter) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-center text-gray-300">
+        <div>
+          <p className="text-lg font-semibold text-amber-200">Choose a mentor to begin your conversation.</p>
+          <p className="text-sm text-gray-400 mt-2">Return to the ancient selector to pick a guide.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ConversationView
+      character={selectedCharacter}
+      onEndConversation={onEndConversation}
+      environmentImageUrl={environmentImageUrl}
+      onEnvironmentUpdate={onEnvironmentUpdate}
+      activeQuest={activeQuest}
+      isSaving={isSaving}
+      resumeConversationId={resumeConversationId}
+      conversationHistory={conversationHistory}
+      onConversationUpdate={onConversationUpdate}
+    />
+  );
+};
+
+export default ConversationRoute;

--- a/src/routes/History.tsx
+++ b/src/routes/History.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import HistoryView from '../../components/HistoryView';
+import type { SavedConversation } from '../../types';
+
+interface HistoryRouteProps {
+  history: SavedConversation[];
+  onResumeConversation: (conversation: SavedConversation) => void;
+  onCreateQuestFromNextSteps: (steps: string[], questTitle?: string) => void;
+  onDeleteConversation: (conversationId: string) => void;
+  onBack: () => void;
+}
+
+const HistoryRoute: React.FC<HistoryRouteProps> = ({
+  history,
+  onResumeConversation,
+  onCreateQuestFromNextSteps,
+  onDeleteConversation,
+  onBack,
+}) => {
+  return (
+    <HistoryView
+      onBack={onBack}
+      onResumeConversation={onResumeConversation}
+      onCreateQuestFromNextSteps={onCreateQuestFromNextSteps}
+      history={history}
+      onDeleteConversation={onDeleteConversation}
+    />
+  );
+};
+
+export default HistoryRoute;

--- a/src/routes/QuestCreator.tsx
+++ b/src/routes/QuestCreator.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import QuestCreator from '../../components/QuestCreator';
+import type { Character, Quest } from '../../types';
+
+interface QuestCreatorRouteProps {
+  characters: Character[];
+  initialGoal?: string | null;
+  onBack: () => void;
+  onQuestReady: (quest: Quest, mentor: Character) => void;
+  onCharacterCreated: (character: Character) => void;
+}
+
+const QuestCreatorRoute: React.FC<QuestCreatorRouteProps> = ({
+  characters,
+  initialGoal,
+  onBack,
+  onQuestReady,
+  onCharacterCreated,
+}) => {
+  return (
+    <QuestCreator
+      characters={characters}
+      onBack={onBack}
+      onQuestReady={onQuestReady}
+      onCharacterCreated={onCharacterCreated}
+      initialGoal={initialGoal ?? undefined}
+    />
+  );
+};
+
+export default QuestCreatorRoute;

--- a/src/routes/QuestDetail.tsx
+++ b/src/routes/QuestDetail.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import QuestIcon from '../../components/icons/QuestIcon';
+import type { Character, Quest } from '../../types';
+
+interface QuestDetailRouteProps {
+  quests: Quest[];
+  characters: Character[];
+  completedQuestIds: string[];
+  inProgressQuestIds: string[];
+  deletableQuestIds: string[];
+  onSelectQuest: (quest: Quest) => void;
+  onDeleteQuest: (questId: string) => void;
+}
+
+const QuestDetailRoute: React.FC<QuestDetailRouteProps> = ({
+  quests,
+  characters,
+  completedQuestIds,
+  inProgressQuestIds,
+  deletableQuestIds,
+  onSelectQuest,
+  onDeleteQuest,
+}) => {
+  const navigate = useNavigate();
+  const { questId } = useParams<{ questId: string }>();
+
+  const quest = useMemo(() => quests.find((item) => item.id === questId), [quests, questId]);
+  const character = useMemo(
+    () => (quest ? characters.find((item) => item.id === quest.characterId) ?? null : null),
+    [characters, quest],
+  );
+
+  useEffect(() => {
+    if (!quest || !character) {
+      navigate('/quests', { replace: true });
+    }
+  }, [character, navigate, quest]);
+
+  if (!quest || !character) {
+    return null;
+  }
+
+  const isCompleted = completedQuestIds.includes(quest.id);
+  const isInProgress = inProgressQuestIds.includes(quest.id);
+  const isDeletable = deletableQuestIds.includes(quest.id);
+
+  const handleStartQuest = () => {
+    onSelectQuest(quest);
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto animate-fade-in">
+      <button
+        type="button"
+        onClick={() => navigate('/quests')}
+        className="mb-6 inline-flex items-center text-sm font-semibold text-amber-200 hover:text-amber-100 hover:underline"
+      >
+        ← Back to quests
+      </button>
+
+      <div className="bg-gray-900/70 border border-gray-800 rounded-2xl p-8 shadow-xl">
+        <div className="flex flex-col lg:flex-row lg:items-start gap-8">
+          <img
+            src={character.portraitUrl}
+            alt={character.name}
+            className="w-32 h-32 rounded-full border-2 border-amber-300 object-cover"
+          />
+
+          <div className="flex-1 space-y-4 text-left">
+            <div className="flex items-center gap-3">
+              <QuestIcon className="w-8 h-8 text-amber-300" />
+              <h2 className="text-3xl font-bold text-amber-200">{quest.title}</h2>
+            </div>
+            <p className="text-sm text-gray-400 uppercase tracking-wide">Guided by {character.name}</p>
+            <p className="text-gray-200 text-lg leading-relaxed">{quest.description}</p>
+
+            <div className="flex flex-wrap gap-3">
+              <span className="inline-flex items-center px-3 py-1 rounded-full bg-amber-500/20 text-amber-200 text-xs font-semibold uppercase tracking-wide">
+                {quest.duration}
+              </span>
+              {isCompleted && (
+                <span className="inline-flex items-center px-3 py-1 rounded-full bg-emerald-600/30 text-emerald-100 text-xs font-semibold uppercase tracking-wide">
+                  Completed
+                </span>
+              )}
+              {!isCompleted && isInProgress && (
+                <span className="inline-flex items-center px-3 py-1 rounded-full bg-teal-600/30 text-teal-100 text-xs font-semibold uppercase tracking-wide">
+                  In Progress
+                </span>
+              )}
+            </div>
+
+            <div className="bg-gray-800/60 border border-gray-700 rounded-xl p-5 space-y-4">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-amber-200 mb-1">Objective</p>
+                <p className="text-sm text-gray-200 leading-relaxed">{quest.objective}</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wide text-amber-200 mb-1">Focus Points</p>
+                <ul className="list-disc list-inside space-y-1 text-sm text-gray-200">
+                  {quest.focusPoints.map((point) => (
+                    <li key={point}>{point}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-4">
+              <button
+                type="button"
+                onClick={handleStartQuest}
+                className={`flex-1 font-semibold py-3 px-6 rounded-lg transition-colors ${
+                  isCompleted
+                    ? 'bg-emerald-600 hover:bg-emerald-500 text-black'
+                    : isInProgress
+                      ? 'bg-teal-600 hover:bg-teal-500 text-black'
+                      : 'bg-amber-600 hover:bg-amber-500 text-black'
+                }`}
+              >
+                {isCompleted ? 'Review quest' : isInProgress ? 'Continue quest' : 'Begin quest'}
+              </button>
+
+              {isDeletable && (
+                <button
+                  type="button"
+                  onClick={() => onDeleteQuest(quest.id)}
+                  className="px-6 py-3 rounded-lg border border-red-600/70 text-red-200 hover:bg-red-900/40 transition-colors"
+                >
+                  Delete quest
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default QuestDetailRoute;

--- a/src/routes/Quests.tsx
+++ b/src/routes/Quests.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import QuestsView from '../../components/QuestsView';
+import type { Character, Quest } from '../../types';
+
+interface QuestsRouteProps {
+  quests: Quest[];
+  characters: Character[];
+  completedQuestIds: string[];
+  inProgressQuestIds: string[];
+  deletableQuestIds: string[];
+  onSelectQuest: (quest: Quest) => void;
+  onCreateQuest: () => void;
+  onBack: () => void;
+  onDeleteQuest: (questId: string) => void;
+}
+
+const QuestsRoute: React.FC<QuestsRouteProps> = ({
+  quests,
+  characters,
+  completedQuestIds,
+  inProgressQuestIds,
+  deletableQuestIds,
+  onSelectQuest,
+  onCreateQuest,
+  onBack,
+  onDeleteQuest,
+}) => {
+  return (
+    <QuestsView
+      quests={quests}
+      characters={characters}
+      completedQuestIds={completedQuestIds}
+      onSelectQuest={onSelectQuest}
+      onCreateQuest={onCreateQuest}
+      onBack={onBack}
+      inProgressQuestIds={inProgressQuestIds}
+      onDeleteQuest={onDeleteQuest}
+      deletableQuestIds={deletableQuestIds}
+    />
+  );
+};
+
+export default QuestsRoute;

--- a/src/routes/Quiz.tsx
+++ b/src/routes/Quiz.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import QuestQuiz from '../../components/QuestQuiz';
+import type { Quest, QuestAssessment, QuizResult } from '../../types';
+
+interface QuizRouteProps {
+  quests: Quest[];
+  pendingAssessment: { questId: string; assessment: QuestAssessment | null } | null;
+  onExit: () => void;
+  onComplete: (result: QuizResult) => void;
+}
+
+const QuizRoute: React.FC<QuizRouteProps> = ({ quests, pendingAssessment, onExit, onComplete }) => {
+  const navigate = useNavigate();
+  const { questId } = useParams<{ questId: string }>();
+
+  const quest = useMemo(() => quests.find((item) => item.id === questId) ?? null, [questId, quests]);
+  const assessment = quest && pendingAssessment?.questId === quest.id ? pendingAssessment.assessment ?? undefined : undefined;
+
+  useEffect(() => {
+    if (!quest && questId) {
+      navigate('/quests', { replace: true });
+    }
+  }, [navigate, quest, questId]);
+
+  if (!quest) {
+    return (
+      <div className="text-center text-gray-300">
+        <p className="text-lg">Quiz unavailable. Returning to the quest library…</p>
+      </div>
+    );
+  }
+
+  return <QuestQuiz quest={quest} assessment={assessment} onExit={onExit} onComplete={onComplete} />;
+};
+
+export default QuizRoute;

--- a/src/routes/Selector.tsx
+++ b/src/routes/Selector.tsx
@@ -1,0 +1,222 @@
+import React from 'react';
+
+import CharacterSelector from '../../components/CharacterSelector';
+import Instructions from '../../components/Instructions';
+import QuestIcon from '../../components/icons/QuestIcon';
+import type { Character, Quest, QuestAssessment, QuizResult } from '../../types';
+
+interface SelectorRouteProps {
+  builtInCharacters: Character[];
+  customCharacters: Character[];
+  allQuests: Quest[];
+  completedQuestIds: string[];
+  lastQuestOutcome: QuestAssessment | null;
+  lastQuizResult: QuizResult | null;
+  lastQuizQuest: Quest | null;
+  onSelectCharacter: (character: Character) => void;
+  onStartCreation: () => void;
+  onDeleteCharacter: (characterId: string) => void;
+  onOpenQuests: () => void;
+  onOpenHistory: () => void;
+  onOpenQuestCreator: () => void;
+  onCreateQuestFromNextSteps: (steps: string[], questTitle?: string) => void;
+  onContinueQuest: (questId: string | undefined) => void;
+  onLaunchQuiz: (questId: string) => void;
+}
+
+const SelectorRoute: React.FC<SelectorRouteProps> = ({
+  builtInCharacters,
+  customCharacters,
+  allQuests,
+  completedQuestIds,
+  lastQuestOutcome,
+  lastQuizResult,
+  lastQuizQuest,
+  onSelectCharacter,
+  onStartCreation,
+  onDeleteCharacter,
+  onOpenQuests,
+  onOpenHistory,
+  onOpenQuestCreator,
+  onCreateQuestFromNextSteps,
+  onContinueQuest,
+  onLaunchQuiz,
+}) => {
+  const totalQuests = allQuests.length || 1;
+  const completedCount = completedQuestIds.length;
+  const completionPercent = Math.min(100, Math.round((completedCount / totalQuests) * 100));
+
+  return (
+    <div className="text-center animate-fade-in">
+      <p className="max-w-3xl mx-auto mb-8 text-gray-400 text-lg">
+        Engage in real-time voice conversations with legendary minds from history, or embark on a guided Learning
+        Quest to master a new subject.
+      </p>
+
+      <div className="max-w-3xl mx-auto mb-8 bg-gray-800/50 border border-gray-700 rounded-lg p-4 text-left">
+        <p className="text-sm text-gray-300 mb-2 font-semibold">Quest Progress</p>
+        <p className="text-xs uppercase tracking-wide text-gray-400 mb-3">
+          {completedCount} of {allQuests.length} quests completed
+        </p>
+        <div className="w-full h-2 bg-gray-700 rounded-full overflow-hidden">
+          <div className="h-full bg-amber-500 transition-all duration-500" style={{ width: `${completionPercent}%` }} />
+        </div>
+      </div>
+
+      {lastQuestOutcome && (
+        <div
+          className={`max-w-3xl mx-auto mb-8 rounded-lg border p-5 text-left shadow-lg ${
+            lastQuestOutcome.passed ? 'bg-emerald-900/40 border-emerald-700' : 'bg-red-900/30 border-red-700'
+          }`}
+        >
+          <div className="flex justify-between items-start gap-4">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-300 font-semibold">Latest Quest Review</p>
+              <h3 className="text-2xl font-bold text-amber-200 mt-1">{lastQuestOutcome.questTitle}</h3>
+            </div>
+            <span
+              className={`text-sm font-semibold px-3 py-1 rounded-full ${
+                lastQuestOutcome.passed ? 'bg-emerald-600 text-emerald-50' : 'bg-red-600 text-red-50'
+              }`}
+            >
+              {lastQuestOutcome.passed ? 'Completed' : 'Needs Review'}
+            </span>
+          </div>
+
+          <p className="text-gray-200 mt-4 leading-relaxed">{lastQuestOutcome.summary}</p>
+
+          {lastQuestOutcome.evidence.length > 0 && (
+            <div className="mt-4">
+              <p className="text-sm font-semibold text-emerald-200 uppercase tracking-wide mb-1">Highlights</p>
+              <ul className="list-disc list-inside text-gray-100 space-y-1 text-sm">
+                {lastQuestOutcome.evidence.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {!lastQuestOutcome.passed && lastQuestOutcome.improvements.length > 0 && (
+            <div className="mt-4">
+              <p className="text-sm font-semibold text-red-200 uppercase tracking-wide mb-1">Next Steps</p>
+              <ul className="list-disc list-inside text-red-100 space-y-1 text-sm">
+                {lastQuestOutcome.improvements.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+              <button
+                type="button"
+                onClick={() =>
+                  onCreateQuestFromNextSteps(lastQuestOutcome.improvements, lastQuestOutcome.questTitle)
+                }
+                className="mt-3 inline-flex items-center text-sm font-semibold text-teal-200 border border-teal-500/60 px-3 py-1.5 rounded-md hover:bg-teal-600/20 focus:outline-none focus:ring-2 focus:ring-teal-400/60"
+              >
+                Turn next steps into a new quest
+              </button>
+            </div>
+          )}
+
+          {!lastQuestOutcome.passed && lastQuestOutcome.questId && (
+            <button
+              type="button"
+              onClick={() => onContinueQuest(lastQuestOutcome.questId)}
+              className="mt-4 inline-flex items-center text-sm font-semibold text-amber-200 hover:text-amber-100 hover:underline focus:outline-none"
+            >
+              Continue quest?
+            </button>
+          )}
+        </div>
+      )}
+
+      {lastQuizResult && (
+        <div
+          className={`max-w-3xl mx-auto mb-8 rounded-lg border p-5 text-left shadow-lg ${
+            lastQuizResult.passed ? 'bg-emerald-900/30 border-emerald-700/80' : 'bg-amber-900/30 border-amber-700/80'
+          }`}
+        >
+          <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-300 font-semibold">Latest Quiz Result</p>
+              <h3 className="text-2xl font-bold text-amber-200 mt-1">{lastQuizQuest?.title ?? 'Quest Mastery Quiz'}</h3>
+            </div>
+            <span
+              className={`text-sm font-semibold px-3 py-1 rounded-full ${
+                lastQuizResult.passed ? 'bg-emerald-600 text-emerald-50' : 'bg-amber-600 text-amber-50'
+              }`}
+            >
+              {lastQuizResult.passed ? 'Mastery Confirmed' : 'Needs Review'}
+            </span>
+          </div>
+
+          <p className="text-gray-200 mt-4 text-lg font-semibold">
+            Score: {lastQuizResult.correct} / {lastQuizResult.total} correct ({Math.round(lastQuizResult.scoreRatio * 100)}%)
+          </p>
+
+          {lastQuizResult.missedObjectiveTags.length > 0 && (
+            <div className="mt-4">
+              <p className="text-xs uppercase tracking-wide text-amber-200 mb-2">Review focus areas</p>
+              <div className="flex flex-wrap justify-center gap-2">
+                {lastQuizResult.missedObjectiveTags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="inline-flex items-center rounded-full border border-amber-500/70 bg-amber-900/30 px-3 py-1 text-xs text-amber-100"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="mt-6 flex flex-col sm:flex-row sm:items-center sm:justify-end gap-3">
+            <button
+              type="button"
+              onClick={() => onLaunchQuiz(lastQuizResult.questId)}
+              className="rounded-lg border border-amber-500/70 px-4 py-2 text-sm font-semibold text-amber-200 hover:bg-amber-500/10"
+            >
+              {lastQuizResult.passed ? 'Retake for practice' : 'Retry quiz'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mb-12">
+        <button
+          type="button"
+          onClick={onOpenQuests}
+          className="flex items-center gap-3 bg-amber-600 hover:bg-amber-500 text-black font-bold py-3 px-8 rounded-lg transition-colors duration-300 text-lg w-full sm:w-auto"
+        >
+          <QuestIcon className="w-6 h-6" />
+          <span>Learning Quests</span>
+        </button>
+
+        <button
+          type="button"
+          onClick={onOpenHistory}
+          className="bg-gray-700 hover:bg-gray-600 text-amber-300 font-bold py-3 px-8 rounded-lg transition-colors duration-300 border border-gray-600 w-full sm:w-auto"
+        >
+          View Conversation History
+        </button>
+
+        <button
+          type="button"
+          onClick={onOpenQuestCreator}
+          className="bg-teal-700 hover:bg-teal-600 text-white font-bold py-3 px-8 rounded-lg transition-colors duration-300 w-full sm:w-auto"
+        >
+          Create Your Quest
+        </button>
+      </div>
+
+      <Instructions />
+
+      <CharacterSelector
+        characters={[...customCharacters, ...builtInCharacters]}
+        onSelectCharacter={onSelectCharacter}
+        onStartCreation={onStartCreation}
+        onDeleteCharacter={onDeleteCharacter}
+      />
+    </div>
+  );
+};
+
+export default SelectorRoute;


### PR DESCRIPTION
## Summary
- adopt React Router to replace manual view switching and handle deep link hydration across conversation, quests, quiz, history, profile, and settings views
- add dedicated route components plus navigation helpers for conversation, quests, and quiz flows
- wrap the app in BrowserRouter and update tests to render through MemoryRouter

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e4695fee6c832fb42003516968ce9c