### PR TITLE
feat: add React Router navigation

### DIFF
--- a/App.test.tsx
+++ b/App.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import App from './App';
 import type { Character, UserData } from './types';
 import { ConnectionState } from './types';
@@ -142,10 +143,18 @@ const resetLocation = () => {
   Object.defineProperty(window, 'location', {
     value: {
       search: '',
+      pathname: '/',
     },
     writable: true,
   });
 };
+
+const renderApp = (initialEntries: string[] = ['/']) =>
+  render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <App />
+    </MemoryRouter>
+  );
 
 describe('App', () => {
   beforeEach(() => {
@@ -200,7 +209,7 @@ describe('App', () => {
       writable: true,
     });
 
-    render(<App />);
+    renderApp([`/?character=${customCharacter.id}`]);
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: customCharacter.name })).toBeInTheDocument();
@@ -230,7 +239,7 @@ describe('App', () => {
 
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
 
-    render(<App />);
+    renderApp();
 
     await waitFor(() => {
       expect(
@@ -274,7 +283,7 @@ describe('App', () => {
       customCharacters: [],
     });
 
-    render(<App />);
+    renderApp();
 
     await waitFor(() => {
       expect(

--- a/index.tsx
+++ b/index.tsx
@@ -1,6 +1,8 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+
 import App from './App';
 import { SupabaseAuthProvider } from './hooks/useSupabaseAuth';
 import { UserDataProvider } from './hooks/useUserData';
@@ -13,10 +15,12 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <SupabaseAuthProvider>
-      <UserDataProvider>
-        <App />
-      </UserDataProvider>
-    </SupabaseAuthProvider>
+    <BrowserRouter>
+      <SupabaseAuthProvider>
+        <UserDataProvider>
+          <App />
+        </UserDataProvider>
+      </SupabaseAuthProvider>
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@google/genai": "^1.22.0",
         "@supabase/supabase-js": "^2.58.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.9.3"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -2107,6 +2108,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3224,6 +3234,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.3.tgz",
+      "integrity": "sha512-4o2iWCFIwhI/eYAIL43+cjORXYn/aRQPgtFRRZb3VzoyQ5Uej0Bmqj7437L97N9NJW4wnicSwLOLS+yCXfAPgg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.3.tgz",
+      "integrity": "sha512-1QSbA0TGGFKTAc/aWjpfW/zoEukYfU4dc1dLkT/vvf54JoGMkW+fNA+3oyo2gWVW1GM7BxjJVHz5GnPJv40rvg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.9.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -3352,6 +3400,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@google/genai": "^1.22.0",
     "@supabase/supabase-js": "^2.58.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.9.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## Summary
- replace the view state machine with React Router routes so conversation, quests, profile, settings, and quiz screens are directly addressable
- coordinate authentication and quest effects with the router to preserve environment state and deep-link handling
- wrap the app with BrowserRouter, add the react-router-dom dependency, and update App tests to render through MemoryRouter

## Testing
- npm run test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e4795d3914832fbb3163e2c44876ff