### PR TITLE
fix: guard navigation away from active conversations

### DIFF
--- a/src/routes/Conversation.tsx
+++ b/src/routes/Conversation.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import type { Character, ConversationTurn, Quest, SavedConversation } from '../../types';
+import type {
+  Character,
+  ConversationSessionState,
+  ConversationTurn,
+  Quest,
+  SavedConversation,
+} from '../../types';
 import ConversationView from '../../components/ConversationView';
 
 interface ConversationRouteProps {
@@ -15,6 +21,7 @@ interface ConversationRouteProps {
   onEndConversation: (transcript: ConversationTurn[], sessionId: string) => Promise<void> | void;
   onHydrateFromParams: (characterId: string | null, resumeId: string | null) => void;
   isAppLoading: boolean;
+  onSessionStateChange: (state: ConversationSessionState | null) => void;
 }
 
 const ConversationRoute: React.FC<ConversationRouteProps> = ({
@@ -29,6 +36,7 @@ const ConversationRoute: React.FC<ConversationRouteProps> = ({
   onEndConversation,
   onHydrateFromParams,
   isAppLoading,
+  onSessionStateChange,
 }) => {
   const [searchParams] = useSearchParams();
 
@@ -60,6 +68,7 @@ const ConversationRoute: React.FC<ConversationRouteProps> = ({
       resumeConversationId={resumeConversationId}
       conversationHistory={conversationHistory}
       onConversationUpdate={onConversationUpdate}
+      onSessionStateChange={onSessionStateChange}
     />
   );
 };

--- a/types.ts
+++ b/types.ts
@@ -93,6 +93,11 @@ export interface SavedConversation {
   questAssessment?: QuestAssessment;
 }
 
+export interface ConversationSessionState {
+  sessionId: string;
+  hasUnfinishedChanges: boolean;
+}
+
 export interface QuizQuestion {
   id: string;
   prompt: string;


### PR DESCRIPTION
## Summary
- track active conversation session state and block navigation when a conversation is unfinished or saving
- add confirmation flows to sidebar, auth, and quest launch actions to preserve the end-conversation workflow
- report session status from the conversation view and route via the new `ConversationSessionState` type

## Testing
- npm run test -- --run *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68e4837ef278832fae2be3e193c4efb4