### PR TITLE
fix: add vercel rewrite for spa routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a vercel.json rewrite rule so deep links are served through index.html
- ensure SPA refreshes on nested routes do not return 404s on Vercel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e48e9cbef4832f90612728e89c9592