### PR TITLE
fix: add spa fallback for deep links

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting...</title>
+    <script>
+      (function persistSpaLocation() {
+        if (window.top !== window.self) {
+          return;
+        }
+
+        var storageKey = 'sota-spa-redirect';
+        var redirectUrl = window.location.href;
+        try {
+          window.sessionStorage.setItem(storageKey, redirectUrl);
+        } catch (error) {
+          console.error('Failed to persist SPA location for redirect', error);
+        }
+
+        if (window.location.pathname !== '/') {
+          window.location.replace('/');
+        }
+      })();
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,29 @@
 </head>
   <body class="bg-[#1a1a1a] text-white font-sans">
     <div id="root"></div>
+    <script>
+        (function restoreSpaLocation() {
+          const storageKey = 'sota-spa-redirect';
+          const redirectUrl = window.sessionStorage.getItem(storageKey);
+          if (!redirectUrl) {
+            return;
+          }
+
+          window.sessionStorage.removeItem(storageKey);
+        try {
+          const preservedUrl = new URL(redirectUrl, window.location.origin);
+          const targetPath = `${preservedUrl.pathname}${preservedUrl.search}${preservedUrl.hash}`;
+          const currentPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+          if (targetPath && targetPath !== currentPath) {
+            window.history.replaceState(null, '', targetPath);
+          }
+        } catch (error) {
+          console.error('Failed to restore preserved SPA location', error);
+        }
+      })();
+    </script>
     <script type="module" src="./index.tsx"></script>
-  <script type="module" src="/index.tsx"></script>
-</body>
+    <script type="module" src="/index.tsx"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add a static 404.html fallback that records the requested deep link and redirects to the SPA entry point
- restore preserved URLs before bootstrapping the React app so reloads land on the requested route

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68e48e9cbef4832f90612728e89c9592