### PR TITLE
fix: restore client routes after static 404 fallback

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0; url=/" />
+    <title>School of the Ancients</title>
+    <script>
+      (function () {
+        try {
+          var redirectPath = window.location.pathname + window.location.search + window.location.hash;
+          if (redirectPath && redirectPath !== '/') {
+            sessionStorage.setItem('sota:redirect-path', redirectPath);
+          }
+        } catch (error) {
+          console.error('Failed to persist redirect path', error);
+        }
+      })();
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/App.tsx
+++ b/App.tsx
@@ -66,6 +66,14 @@ const App: React.FC = () => {
   const isAuthenticated = Boolean(user);
   const isAppLoading = authLoading || dataLoading;
 
+  useEffect(() => {
+    const pendingPath = sessionStorage.getItem('sota:redirect-path');
+    if (pendingPath) {
+      sessionStorage.removeItem('sota:redirect-path');
+      navigate(pendingPath, { replace: true });
+    }
+  }, [navigate]);
+
   const ensureConversationComplete = useCallback(
     (options?: { allowSessionId?: string; message?: string }) => {
       const hasActiveSession = Boolean(activeConversationSession || selectedCharacter);


### PR DESCRIPTION
## Summary
- add a static 404 page that captures the attempted URL and redirects back to the SPA entrypoint
- read the stored redirect path on app boot so direct links and refreshes land on the intended route

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e48e9cbef4832f90612728e89c9592