### PR TITLE
feat: refresh responsive layout

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1000,7 +1000,9 @@ const App: React.FC = () => {
         style={{ background: environmentImageUrl ? 'transparent' : 'linear-gradient(to bottom right, #1a1a1a, #232323)' }}
       >
         <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8">
-          <header className="space-y-4">
+          <header
+            className="sticky top-0 z-30 -mx-4 space-y-4 bg-[#1a1a1a]/90 px-4 pb-4 pt-2 backdrop-blur-sm sm:static sm:mx-0 sm:bg-transparent sm:px-0 sm:pb-0 sm:pt-0 sm:backdrop-blur-none"
+          >
             <div className="flex items-center justify-between gap-3 sm:hidden">
               <button
                 type="button"
@@ -1048,7 +1050,10 @@ const App: React.FC = () => {
             <div className="flex-1">
               <div className="flex h-full flex-col overflow-hidden rounded-3xl border border-gray-800/80 bg-gray-900/70 shadow-2xl backdrop-blur-sm">
                 <ScrollToTop />
-                <div className="h-full overflow-y-auto p-4 sm:p-6 lg:p-8">
+                <div
+                  className="h-full overflow-y-auto p-4 sm:p-6 lg:p-8"
+                  data-app-scroll-container
+                >
                   <Routes>
               <Route
                 path="/"

--- a/App.tsx
+++ b/App.tsx
@@ -1024,7 +1024,7 @@ const App: React.FC = () => {
                 </h1>
                 <p className="mt-3 text-base text-gray-400 sm:text-lg">Old world wisdom. New world classroom.</p>
                 <p className="mt-2 text-sm text-gray-500 sm:text-base">
-                  Select a historical guide, continue a quest, or review your mastery—now in a layout that feels at home on any screen.
+                  Select a historical guide, continue a quest, or review your mastery.
                 </p>
               </div>
               {renderAccountSection('hidden sm:flex flex-col items-end gap-2 text-right', 'right')}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -165,12 +165,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             )}
           </div>
 
-          <div className="mt-auto rounded-2xl border border-gray-800/80 bg-gradient-to-r from-amber-500/20 via-transparent to-amber-500/10 p-4 text-sm text-gray-300">
-            <p className="font-semibold text-amber-200">Need inspiration?</p>
-            <p className="mt-1 text-sm text-gray-300">
-              Continue a saved conversation or launch a new quest to keep your learning streak alive.
-            </p>
-          </div>
+          
         </div>
       </div>
     </aside>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import type { SavedConversation } from '../types';
+import CloseIcon from './icons/CloseIcon';
 
 type SidebarProps = {
   recentConversations: SavedConversation[];
@@ -13,6 +14,8 @@ type SidebarProps = {
   currentView: string;
   isAuthenticated: boolean;
   userEmail?: string | null;
+  className?: string;
+  onRequestClose?: () => void;
 };
 
 const Sidebar: React.FC<SidebarProps> = ({
@@ -26,6 +29,8 @@ const Sidebar: React.FC<SidebarProps> = ({
   currentView,
   isAuthenticated,
   userEmail,
+  className,
+  onRequestClose,
 }) => {
   const navigationItems = [
     {
@@ -54,61 +59,76 @@ const Sidebar: React.FC<SidebarProps> = ({
     },
   ];
 
-  return (
-    <aside className="w-full lg:w-72 xl:w-80 flex-shrink-0">
-      <div className="bg-gray-900/70 border border-gray-800 rounded-2xl p-5 shadow-xl backdrop-blur-sm">
-        <div className="mb-6">
-          <h2 className="text-lg font-semibold text-amber-300 tracking-wide">Explorer Hub</h2>
-          <p className="text-sm text-gray-400">
-            {isAuthenticated
-              ? userEmail
-                ? `Signed in as ${userEmail}`
-                : 'Signed in traveller'
-              : 'Sign in to unlock personalized features.'}
-          </p>
-        </div>
+  const handleNavigation = (callback: () => void) => {
+    callback();
+    onRequestClose?.();
+  };
 
-        <div className="space-y-4">
-          <div>
-            <div className="flex items-center justify-between mb-2">
-              <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300">Navigation</h3>
-            </div>
-            <div className="space-y-3">
+  return (
+    <aside className={`w-full max-w-md lg:w-72 xl:w-80 flex-shrink-0 ${className ?? ''}`}>
+      <div className="relative h-full overflow-hidden rounded-3xl border border-gray-800/80 bg-gray-950/80 shadow-2xl backdrop-blur">
+        <div className="absolute inset-0 bg-gradient-to-br from-amber-500/10 via-transparent to-amber-500/5" />
+        <div className="relative z-10 p-5 sm:p-6 flex flex-col gap-6 h-full">
+          {onRequestClose && (
+            <button
+              type="button"
+              onClick={onRequestClose}
+              className="absolute right-4 top-4 inline-flex items-center justify-center rounded-full border border-gray-700 bg-gray-900/80 p-2 text-gray-300 shadow-lg transition hover:text-amber-200 hover:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/50 lg:hidden"
+              aria-label="Close navigation"
+            >
+              <CloseIcon className="h-5 w-5" />
+            </button>
+          )}
+
+          <div className="space-y-2">
+            <h2 className="text-base font-semibold uppercase tracking-[0.3em] text-amber-300">Explorer Hub</h2>
+            <p className="text-sm leading-relaxed text-gray-400">
+              {isAuthenticated
+                ? userEmail
+                  ? `Signed in as ${userEmail}`
+                  : 'Signed in traveller'
+                : 'Sign in to unlock personalized features and sync your journeys.'}
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-gray-800/80 bg-gray-900/80 p-4 shadow-inner">
+            <p className="text-xs uppercase tracking-wide text-gray-400">Quick Links</p>
+            <div className="mt-3 flex flex-col gap-3">
               {navigationItems.map((item) => {
                 const isActive = currentView === item.key;
                 return (
                   <button
                     key={item.key}
                     type="button"
-                    onClick={item.onClick}
-                    className={`w-full text-left px-3 py-2 rounded-lg transition-all duration-200 border flex flex-col gap-1 ${
+                    onClick={() => handleNavigation(item.onClick)}
+                    className={`rounded-xl border px-4 py-3 text-left transition-all duration-200 ${
                       isActive
-                        ? 'border-amber-500/80 bg-amber-500/10 text-amber-200'
-                        : 'border-gray-800 hover:border-amber-500/40 hover:bg-gray-800/60 text-gray-200'
+                        ? 'border-amber-400/80 bg-amber-500/10 text-amber-100 shadow-lg shadow-amber-500/10'
+                        : 'border-gray-800 bg-gray-900/60 text-gray-200 hover:border-amber-400/50 hover:bg-gray-900/80'
                     }`}
                   >
-                    <span className="text-sm font-semibold">{item.label}</span>
-                    <span className="text-xs text-gray-400">{item.description}</span>
+                    <span className="block text-sm font-semibold">{item.label}</span>
+                    <span className="mt-1 block text-xs text-gray-400">{item.description}</span>
                   </button>
                 );
               })}
             </div>
           </div>
 
-          <div>
-            <div className="flex items-center justify-between mb-2">
-              <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-300">Recent Chats</h3>
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-300">Recent Chats</h3>
               <button
                 type="button"
-                onClick={onOpenHistory}
-                className="text-xs text-amber-300 hover:text-amber-200"
+                onClick={() => handleNavigation(onOpenHistory)}
+                className="text-xs font-semibold text-amber-300 transition hover:text-amber-100"
               >
                 View all
               </button>
             </div>
 
             {recentConversations.length === 0 ? (
-              <p className="text-sm text-gray-400 bg-gray-800/50 border border-dashed border-gray-700 rounded-lg p-3">
+              <p className="rounded-2xl border border-dashed border-gray-700 bg-gray-900/60 p-4 text-sm text-gray-400">
                 {isAuthenticated
                   ? 'Your latest conversations will appear here.'
                   : 'Sign in to start building your historical dialogue archive.'}
@@ -119,21 +139,23 @@ const Sidebar: React.FC<SidebarProps> = ({
                   <li key={conversation.id}>
                     <button
                       type="button"
-                      onClick={() => onSelectConversation(conversation)}
-                      className="w-full text-left px-3 py-2 rounded-lg border border-gray-800 hover:border-amber-500/40 hover:bg-gray-800/70 transition-all duration-200"
+                      onClick={() => {
+                        onSelectConversation(conversation);
+                        onRequestClose?.();
+                      }}
+                      className="group w-full rounded-2xl border border-gray-800 bg-gray-900/50 px-4 py-3 text-left transition hover:border-amber-400/50 hover:bg-gray-900/80"
                     >
-                      <p className="text-sm font-semibold text-gray-100 truncate">
+                      <p className="text-sm font-semibold text-gray-100 group-hover:text-amber-100">
                         {conversation.title ?? conversation.characterName ?? 'Conversation'}
                       </p>
-                      {conversation.updatedAt && (
+                      {conversation.updatedAt ? (
                         <p className="text-xs text-gray-400">
                           {new Date(conversation.updatedAt).toLocaleString(undefined, {
                             month: 'short',
                             day: 'numeric',
                           })}
                         </p>
-                      )}
-                      {!conversation.updatedAt && (
+                      ) : (
                         <p className="text-xs text-gray-500">Tap to resume</p>
                       )}
                     </button>
@@ -141,6 +163,13 @@ const Sidebar: React.FC<SidebarProps> = ({
                 ))}
               </ul>
             )}
+          </div>
+
+          <div className="mt-auto rounded-2xl border border-gray-800/80 bg-gradient-to-r from-amber-500/20 via-transparent to-amber-500/10 p-4 text-sm text-gray-300">
+            <p className="font-semibold text-amber-200">Need inspiration?</p>
+            <p className="mt-1 text-sm text-gray-300">
+              Continue a saved conversation or launch a new quest to keep your learning streak alive.
+            </p>
           </div>
         </div>
       </div>

--- a/components/icons/CloseIcon.tsx
+++ b/components/icons/CloseIcon.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const CloseIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <line x1="18" y1="6" x2="6" y2="18" />
+    <line x1="6" y1="6" x2="18" y2="18" />
+  </svg>
+);
+
+export default CloseIcon;

--- a/components/icons/MenuIcon.tsx
+++ b/components/icons/MenuIcon.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const MenuIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <line x1="3" y1="6" x2="21" y2="6" />
+    <line x1="3" y1="12" x2="21" y2="12" />
+    <line x1="3" y1="18" x2="21" y2="18" />
+  </svg>
+);
+
+export default MenuIcon;

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -5,7 +5,21 @@ const ScrollToTop: React.FC = () => {
   const { pathname } = useLocation();
 
   useEffect(() => {
-    window.scrollTo(0, 0);
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const scrollContainer = document.querySelector(
+      '[data-app-scroll-container]'
+    ) as HTMLElement | null;
+
+    if (scrollContainer) {
+      scrollContainer.scrollTo({ top: 0, behavior: 'auto' });
+      scrollContainer.scrollTop = 0;
+      return;
+    }
+
+    window.scrollTo({ top: 0, behavior: 'auto' });
   }, [pathname]);
 
   return null;


### PR DESCRIPTION
## Summary
- add a responsive mobile navigation overlay and refreshed header layout for the main app shell
- modernize the sidebar experience with closable mobile panel styling and contextual quick links
- add dedicated menu and close icon components for reuse in navigation controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4a501c414832f82e056fb12357823