### PR TITLE
feat: streamline sticky header layout

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1001,37 +1001,46 @@ const App: React.FC = () => {
       >
         <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8">
           <header
-            className="sticky top-0 z-30 -mx-4 space-y-4 bg-[#1a1a1a]/90 px-4 pb-4 pt-2 backdrop-blur-sm sm:static sm:mx-0 sm:bg-transparent sm:px-0 sm:pb-0 sm:pt-0 sm:backdrop-blur-none"
+            className="sticky top-0 z-30 -mx-4 bg-[#1a1a1a]/90 px-4 py-3 backdrop-blur-sm sm:static sm:mx-0 sm:bg-transparent sm:px-0 sm:py-0 sm:backdrop-blur-none"
           >
-            <div className="flex items-center justify-between gap-3 sm:hidden">
-              <button
-                type="button"
-                onClick={() => setIsSidebarOpen(true)}
-                className="inline-flex items-center gap-2 rounded-full border border-amber-400/60 bg-amber-500/10 px-4 py-2 text-sm font-semibold text-amber-200 transition hover:bg-amber-500/20"
-                aria-label="Open navigation menu"
-              >
-                <MenuIcon className="h-5 w-5" />
-                <span>Menu</span>
-              </button>
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => setIsSidebarOpen(true)}
+                  className="inline-flex items-center gap-2 rounded-full border border-amber-400/60 bg-amber-500/10 px-4 py-2 text-sm font-semibold text-amber-200 transition hover:bg-amber-500/20 sm:hidden"
+                  aria-label="Open navigation menu"
+                >
+                  <MenuIcon className="h-5 w-5" />
+                  <span>Menu</span>
+                </button>
+                <div className="hidden items-center gap-2 text-sm font-semibold uppercase tracking-widest text-amber-200 sm:inline-flex">
+                  <MenuIcon className="h-4 w-4" />
+                  <span>Menu</span>
+                </div>
+                <span
+                  className="text-lg font-bold uppercase tracking-[0.4em] text-amber-300 sm:text-xl"
+                  style={{ textShadow: '0 0 8px rgba(252, 211, 77, 0.35)' }}
+                >
+                  SoTA
+                </span>
+              </div>
               {renderAccountSection('flex flex-col items-end gap-1 text-right', 'right')}
             </div>
-
-            <div className="rounded-3xl border border-gray-800/80 bg-gray-900/60 p-6 shadow-xl backdrop-blur-sm sm:flex sm:items-center sm:justify-between sm:gap-6">
-              <div className="text-center sm:text-left">
-                <h1
-                  className="text-3xl font-bold tracking-wider text-amber-300 sm:text-4xl md:text-5xl"
-                  style={{ textShadow: '0 0 12px rgba(252, 211, 77, 0.45)' }}
-                >
-                  School of the Ancients
-                </h1>
-                <p className="mt-3 text-base text-gray-400 sm:text-lg">Old world wisdom. New world classroom.</p>
-                <p className="mt-2 text-sm text-gray-500 sm:text-base">
-                  Select a historical guide, continue a quest, or review your mastery.
-                </p>
-              </div>
-              {renderAccountSection('hidden sm:flex flex-col items-end gap-2 text-right', 'right')}
-            </div>
           </header>
+
+          <section className="rounded-3xl border border-gray-800/80 bg-gray-900/60 p-6 text-center shadow-xl backdrop-blur-sm sm:text-left">
+            <h1
+              className="text-3xl font-bold tracking-wider text-amber-300 sm:text-4xl md:text-5xl"
+              style={{ textShadow: '0 0 12px rgba(252, 211, 77, 0.45)' }}
+            >
+              School of the Ancients
+            </h1>
+            <p className="mt-3 text-base text-gray-400 sm:text-lg">Old world wisdom. New world classroom.</p>
+            <p className="mt-2 text-sm text-gray-500 sm:text-base">
+              Select a historical guide, continue a quest, or review your mastery.
+            </p>
+          </section>
 
           <main className="flex flex-1 flex-col gap-6 lg:flex-row">
             <Sidebar


### PR DESCRIPTION
## Summary
- replace the sticky header content with a compact Menu / SoTA / sign-in row
- relocate the full School of the Ancients hero messaging below the sticky bar to keep it visible without occupying the viewport

## Testing
- npm run dev -- --host 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68e4adf0bab4832fae32c8f15c3cae43