### PR TITLE
feat: store encrypted api key in user settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Deploy the contents of `dist/` to your static hosting platform of choice.
 
 ## Development Tips
 
-- Vite exposes `process.env.API_KEY` and `process.env.GEMINI_API_KEY` based on the `GEMINI_API_KEY` entry in your `.env` file. Be sure not to commit this file.
+- Add your personal Google Gemini API key from the in-app **Settings** view. The key is encrypted client-side before syncing to Supabase.
 - Shared UI components live in `components/`, while feature views are registered in `App.tsx`.
 - Hooks such as `useGeminiLive` encapsulate audio capture, streaming, and playback logic.
 - Tailwind utility classes handle layout; extend the Tailwind config before introducing custom CSS.
@@ -172,7 +172,7 @@ Deploy the contents of `dist/` to your static hosting platform of choice.
 
 ## Troubleshooting
 
-- **"API_KEY not set" errors**: Ensure your `.env` file is present and you restarted `npm run dev` after adding it.
+- **"API key not available" errors**: Open **Settings** in the app, paste your Google Gemini API key, and save it. Keys are encrypted before they sync to Supabase.
 - **Microphone permissions**: Clear browser permissions if you accidentally deny access; audio capture is required for real-time chat.
 - **Slow or missing visuals**: Imagen requests can take a few seconds. Watch the developer console for network errors if images do not appear.
 

--- a/components/CharacterCreator.test.tsx
+++ b/components/CharacterCreator.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import CharacterCreator from './CharacterCreator';
+import { ApiKeyProvider } from '../hooks/useApiKey';
 
 // Mock suggestions for a controlled test environment
 vi.mock('../suggestions', () => ({
@@ -31,14 +32,20 @@ vi.mock('@google/genai', () => ({
   },
 }));
 
+const renderWithProvider = () =>
+  render(
+    <ApiKeyProvider apiKey="test-api-key">
+      <CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />
+    </ApiKeyProvider>
+  );
+
 describe('CharacterCreator', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.API_KEY = 'test-api-key';
   });
 
   it('renders correctly and shows initial suggestions on focus', async () => {
-    render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+    renderWithProvider();
 
     expect(screen.getByText('Create an Ancient')).toBeInTheDocument();
     const input = screen.getByPlaceholderText('Begin typing a historical figure…');
@@ -53,7 +60,7 @@ describe('CharacterCreator', () => {
 
   it('filters suggestions based on user input', async () => {
     const user = userEvent.setup();
-    render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+    renderWithProvider();
 
     const input = screen.getByPlaceholderText('Begin typing a historical figure…');
     await user.type(input, 'Alex');
@@ -66,7 +73,7 @@ describe('CharacterCreator', () => {
 
   it('fills the input when a suggestion is clicked', async () => {
     const user = userEvent.setup();
-    render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+    renderWithProvider();
 
     const input = screen.getByPlaceholderText('Begin typing a historical figure…');
     fireEvent.focus(input);
@@ -79,7 +86,7 @@ describe('CharacterCreator', () => {
 
   it('selects a random character when the randomize button is clicked', async () => {
     const user = userEvent.setup();
-    render(<CharacterCreator onCharacterCreated={mockOnCharacterCreated} onBack={mockOnBack} />);
+    renderWithProvider();
 
     const randomizeButton = screen.getByLabelText('Roll the dice for a random historical figure');
     await user.click(randomizeButton);

--- a/components/CharacterCreator.tsx
+++ b/components/CharacterCreator.tsx
@@ -4,6 +4,7 @@ import type { Character, PersonaData } from '../types';
 import { AMBIENCE_LIBRARY, AVAILABLE_VOICES } from '../constants';
 import { HISTORICAL_FIGURES_SUGGESTIONS } from '../suggestions';
 import DiceIcon from './icons/DiceIcon';
+import { useApiKey } from '../hooks/useApiKey';
 
 interface CharacterCreatorProps {
   onCharacterCreated: (character: Character) => void;
@@ -38,6 +39,7 @@ function makeFallbackAvatar(name: string, title?: string) {
 }
 
 const CharacterCreator: React.FC<CharacterCreatorProps> = ({ onCharacterCreated, onBack }) => {
+  const { apiKey } = useApiKey();
   const [name, setName] = useState('');
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState('');
@@ -112,8 +114,10 @@ If you are not at least 80% confident in their historicity, set verified to fals
       setLoading(true);
       setMsg('Verifying historical figure…');
 
-      if (!process.env.API_KEY) throw new Error('API_KEY not set.');
-      const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+      if (!apiKey) {
+        throw new Error('Add your Google API key in Settings to create custom ancients.');
+      }
+      const ai = new GoogleGenAI({ apiKey });
 
       const verification = await verifyHistoricalFigure(ai, clean);
 

--- a/components/QuestCreator.tsx
+++ b/components/QuestCreator.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { GoogleGenAI, Type } from '@google/genai';
 import type { Character, PersonaData, Quest } from '../types';
 import { AMBIENCE_LIBRARY, AVAILABLE_VOICES } from '../constants';
+import { useApiKey } from '../hooks/useApiKey';
 
 type QuestDraft = {
   title: string;
@@ -55,6 +56,7 @@ const QuestCreator: React.FC<QuestCreatorProps> = ({
   onCharacterCreated,
   initialGoal,
 }) => {
+  const { apiKey } = useApiKey();
   const [goal, setGoal] = useState(initialGoal ?? '');
   const [prefs, setPrefs] = useState({ difficulty: 'auto', style: 'auto', time: 'auto' });
   const [loading, setLoading] = useState(false);
@@ -72,8 +74,8 @@ const QuestCreator: React.FC<QuestCreatorProps> = ({
 
   /** Persona generator reused from your character creator, with a SAFE portrait step */
   const createPersonaFor = async (name: string): Promise<Character> => {
-    if (!process.env.API_KEY) throw new Error('API_KEY not set.');
-    const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+    if (!apiKey) throw new Error('Add your Google API key in Settings to generate mentors.');
+    const ai = new GoogleGenAI({ apiKey });
 
     const availableAmbienceTags = AMBIENCE_LIBRARY.map(a => a.tag).join(', ');
     const voiceOptions = AVAILABLE_VOICES.map(
@@ -174,8 +176,8 @@ const QuestCreator: React.FC<QuestCreatorProps> = ({
   };
 
   const ensureMeaningfulGoal = async (cleanGoal: string) => {
-    if (!process.env.API_KEY) throw new Error('API_KEY not set.');
-    const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+    if (!apiKey) throw new Error('Add your Google API key in Settings to generate quests.');
+    const ai = new GoogleGenAI({ apiKey });
 
     const validationPrompt = `You are the Gatekeeper for a learning quest generator. Decide if the user's goal is specific, meaningful, and actionable. If the text is gibberish, a single repeated word, or otherwise not a legitimate learning objective, reject it.\n\nReturn JSON with { "meaningful": boolean, "reason": string }. Use meaningful=false for gibberish, nonsense, or empty goals.`;
 
@@ -250,8 +252,10 @@ const QuestCreator: React.FC<QuestCreatorProps> = ({
 
       await ensureMeaningfulGoal(clean);
 
-      if (!process.env.API_KEY) throw new Error('API_KEY not set.');
-      const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+      if (!apiKey) {
+        throw new Error('Add your Google API key in Settings to generate quests.');
+      }
+      const ai = new GoogleGenAI({ apiKey });
 
       const draftPrompt = `You are the Quest Architect. Convert this learner goal into a concise quest and pick the most appropriate historical mentor.
 

--- a/components/QuestQuiz.tsx
+++ b/components/QuestQuiz.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { GoogleGenAI, Type } from '@google/genai';
 import type { Quest, QuizQuestion, QuizResult, QuestAssessment } from '../types';
+import { useApiKey } from '../hooks/useApiKey';
 
 interface QuestQuizProps {
   quest: Quest;
@@ -51,6 +52,7 @@ const validateQuestions = (data: unknown): QuizQuestion[] => {
 };
 
 const QuestQuiz: React.FC<QuestQuizProps> = ({ quest, assessment, onExit, onComplete }) => {
+  const { apiKey } = useApiKey();
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [questions, setQuestions] = useState<QuizQuestion[]>([]);
@@ -138,14 +140,15 @@ const QuestQuiz: React.FC<QuestQuizProps> = ({ quest, assessment, onExit, onComp
       setIsLoading(true);
       resetState();
 
-      if (!process.env.API_KEY) {
+      if (!apiKey) {
+        setError('Add your Google API key in Settings to generate tailored quiz questions.');
         setQuestions(buildFallbackQuestions());
         setIsLoading(false);
         return;
       }
 
       try {
-        const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+        const ai = new GoogleGenAI({ apiKey });
         const prompt = `You are an expert tutor creating a short mastery quiz. Design ${questionCount} multiple-choice questions (3-4 answer choices each) to evaluate whether a learner has mastered the quest "${quest.title}". The quest objective is: "${quest.objective}". Focus on these key learning points: ${quest.focusPoints.join('; ')}. Each question must test one learning point.
 
 Return JSON with this schema:
@@ -213,7 +216,7 @@ Ensure questions are rigorous but clear, avoid trick questions, and keep the ans
     return () => {
       isCancelled = true;
     };
-  }, [buildFallbackQuestions, questionCount, quest.focusPoints, quest.objective, quest.title, refreshToken, resetState]);
+  }, [apiKey, buildFallbackQuestions, questionCount, quest.focusPoints, quest.objective, quest.title, refreshToken, resetState]);
 
   const handleSelect = (questionId: string, optionIndex: number) => {
     setAnswers((prev) => ({ ...prev, [questionId]: optionIndex }));

--- a/hooks/useApiKey.tsx
+++ b/hooks/useApiKey.tsx
@@ -1,0 +1,23 @@
+import React, { createContext, useContext } from 'react';
+
+interface ApiKeyContextValue {
+  apiKey: string | null;
+}
+
+const ApiKeyContext = createContext<ApiKeyContextValue | undefined>(undefined);
+
+export const ApiKeyProvider: React.FC<{ apiKey: string | null; children: React.ReactNode }> = ({
+  apiKey,
+  children,
+}) => {
+  const value = React.useMemo(() => ({ apiKey }), [apiKey]);
+  return <ApiKeyContext.Provider value={value}>{children}</ApiKeyContext.Provider>;
+};
+
+export const useApiKey = () => {
+  const context = useContext(ApiKeyContext);
+  if (!context) {
+    throw new Error('useApiKey must be used within an ApiKeyProvider');
+  }
+  return context;
+};

--- a/hooks/useGeminiLive.ts
+++ b/hooks/useGeminiLive.ts
@@ -2,6 +2,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { GoogleGenAI, LiveServerMessage, Modality, Blob, FunctionDeclaration, Type, SessionResumptionConfig } from '@google/genai';
 import { ConnectionState, Quest } from '../types';
+import { useApiKey } from './useApiKey';
 
 // Audio Encoding & Decoding functions
 function encode(bytes: Uint8Array): string {
@@ -132,6 +133,7 @@ export const useGeminiLive = (
     const [userTranscription, setUserTranscription] = useState<string>('');
     const [modelTranscription, setModelTranscription] = useState<string>('');
     const [isMicActive, setIsMicActive] = useState(true);
+    const { apiKey } = useApiKey();
 
     // FIX: Using `any` for the session promise type as `LiveSession` is not an exported type from the library.
     const sessionPromiseRef = useRef<Promise<any> | null>(null);
@@ -306,14 +308,14 @@ export const useGeminiLive = (
 
         handledFunctionCallIdsRef.current.clear();
 
-        if (!process.env.API_KEY) {
-            console.error("API_KEY environment variable not set.");
+        if (!apiKey) {
+            console.error("Google API key not available. Add it in Settings to start live conversations.");
             setConnectionState(ConnectionState.ERROR);
             return;
         }
 
         try {
-            const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+            const ai = new GoogleGenAI({ apiKey });
 
             const sanitizedAccent = voiceAccent?.trim();
             let baseInstruction = systemInstruction.trim();
@@ -598,7 +600,7 @@ export const useGeminiLive = (
             console.error('Failed to connect to Gemini Live:', error);
             setConnectionState(ConnectionState.ERROR);
         }
-    }, [systemInstruction, voiceName, voiceAccent, activeQuest, disconnect]);
+    }, [systemInstruction, voiceName, voiceAccent, activeQuest, disconnect, apiKey]);
 
     useEffect(() => {
         connect();

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -1,0 +1,102 @@
+export const API_KEY_SECRET_STORAGE_PREFIX = 'school-of-the-ancients-api-secret:';
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+const bufferToBase64 = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+};
+
+const base64ToBuffer = (value: string): ArrayBuffer => {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+};
+
+const ensureCrypto = () => {
+  const crypto = globalThis.crypto;
+  if (!crypto || !crypto.subtle) {
+    throw new Error('Secure storage is not supported in this browser.');
+  }
+  return crypto;
+};
+
+const importAesKey = async (raw: ArrayBuffer) => {
+  const crypto = ensureCrypto();
+  return crypto.subtle.importKey('raw', raw, 'AES-GCM', true, ['encrypt', 'decrypt']);
+};
+
+const getStorageKey = (userId: string) => `${API_KEY_SECRET_STORAGE_PREFIX}${userId}`;
+
+export const clearStoredSecret = (userId: string) => {
+  try {
+    localStorage.removeItem(getStorageKey(userId));
+  } catch (error) {
+    console.warn('Failed to clear API key secret from storage', error);
+  }
+};
+
+const getOrCreateRawSecret = (userId: string): ArrayBuffer => {
+  const storageKey = getStorageKey(userId);
+  const crypto = ensureCrypto();
+  let stored: string | null = null;
+  try {
+    stored = localStorage.getItem(storageKey);
+  } catch (error) {
+    console.warn('Unable to access localStorage for API key secret', error);
+  }
+
+  if (stored) {
+    try {
+      return base64ToBuffer(stored);
+    } catch (error) {
+      console.warn('Invalid stored API key secret. Regenerating.', error);
+    }
+  }
+
+  const randomBytes = new Uint8Array(32);
+  crypto.getRandomValues(randomBytes);
+  const encoded = bufferToBase64(randomBytes.buffer);
+  try {
+    localStorage.setItem(storageKey, encoded);
+  } catch (error) {
+    console.warn('Failed to persist API key secret. Encryption may be unavailable.', error);
+  }
+  return randomBytes.buffer;
+};
+
+const getSecretKey = async (userId: string) => {
+  const rawSecret = getOrCreateRawSecret(userId);
+  return importAesKey(rawSecret);
+};
+
+export const encryptApiKeyForUser = async (userId: string, apiKey: string) => {
+  const crypto = ensureCrypto();
+  const secretKey = await getSecretKey(userId);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const payload = textEncoder.encode(apiKey);
+  const encrypted = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, secretKey, payload);
+  return {
+    ciphertext: bufferToBase64(encrypted),
+    iv: bufferToBase64(iv.buffer),
+  };
+};
+
+export const decryptApiKeyForUser = async (userId: string, ciphertext: string, iv: string) => {
+  const crypto = ensureCrypto();
+  const secretKey = await getSecretKey(userId);
+  const decrypted = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: base64ToBuffer(iv) },
+    secretKey,
+    base64ToBuffer(ciphertext)
+  );
+  return textDecoder.decode(decrypted);
+};

--- a/supabase/userData.ts
+++ b/supabase/userData.ts
@@ -9,6 +9,8 @@ export const DEFAULT_USER_DATA: UserData = {
   activeQuestId: null,
   lastQuizResult: null,
   migratedAt: null,
+  encryptedApiKey: null,
+  apiKeyIv: null,
 };
 
 const TABLE = 'user_data';

--- a/types.ts
+++ b/types.ts
@@ -128,4 +128,6 @@ export interface UserData {
   activeQuestId: string | null;
   lastQuizResult: QuizResult | null;
   migratedAt?: string | null;
+  encryptedApiKey: string | null;
+  apiKeyIv: string | null;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,30 +1,23 @@
 /// <reference types="vitest" />
 
 import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, '.', '');
-    return {
-      server: {
-        port: 3000,
-        host: '0.0.0.0',
-      },
-      plugins: [react()],
-      define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
-      },
-      resolve: {
-        alias: {
-          '@': path.resolve(__dirname, '.'),
-        }
-      },
-      test: {
-        globals: true,
-        environment: 'jsdom',
-        setupFiles: './vitest.setup.ts'
-      }
-    };
+export default defineConfig({
+  server: {
+    port: 3000,
+    host: '0.0.0.0',
+  },
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts',
+  },
 });


### PR DESCRIPTION
## Summary
- add an encrypted Google API key form to `/settings` backed by a new AES-GCM helper and Supabase fields
- introduce an `ApiKeyProvider` so Gemini features consume the signed-in user’s key instead of build-time env vars
- update Gemini-powered components/hooks to fail gracefully when the key is absent and refresh docs/build config

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e4b63c5fe4832fb82e215bbe05489d