### PR TITLE
fix: keep mobile header menu sticky

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1159,40 +1159,45 @@ const App: React.FC = () => {
           style={{ background: environmentImageUrl ? 'transparent' : 'linear-gradient(to bottom right, #1a1a1a, #232323)' }}
         >
           <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8">
-            <header className="space-y-4">
-            <div className="sticky top-0 z-30 -mx-4 bg-[#1a1a1a]/90 px-4 pb-4 pt-2 backdrop-blur-sm sm:hidden">
-              <div className="flex items-center gap-4 rounded-3xl border border-gray-800/80 bg-gray-900/60 px-4 py-3 shadow-xl backdrop-blur-sm">
-                <button
-                  type="button"
-                  onClick={() => setIsSidebarOpen(true)}
-                  className="shrink-0 rounded-full border border-amber-400/60 bg-amber-500/10 px-4 py-2 text-sm font-semibold uppercase tracking-wide text-amber-200 transition hover:bg-amber-500/20"
-                  aria-label="Open navigation menu"
+            <header className="relative space-y-4">
+              <div className="sm:hidden">
+                <div
+                  className="sticky top-0 left-0 right-0 z-30 -mx-4 bg-[#1a1a1a]/90 px-4 pb-4 pt-[calc(env(safe-area-inset-top,0px)+0.5rem)] backdrop-blur-sm"
+                  role="banner"
                 >
-                  Menu
-                </button>
-                <span className="flex-1 text-center text-sm font-semibold uppercase tracking-[0.35em] text-amber-200">
-                  School of the Ancients
-                </span>
-              </div>
-            </div>
-
-            <div className="hidden sm:block">
-              <div className="rounded-3xl border border-gray-800/80 bg-gray-900/60 p-6 shadow-xl backdrop-blur-sm sm:flex sm:items-center sm:justify-between sm:gap-6">
-                <div className="text-center sm:text-left">
-                  <h1
-                    className="text-3xl font-bold tracking-wider text-amber-300 sm:text-4xl md:text-5xl"
-                    style={{ textShadow: '0 0 12px rgba(252, 211, 77, 0.45)' }}
-                  >
-                    School of the Ancients
-                  </h1>
-                  <p className="mt-3 text-base text-gray-400 sm:text-lg">Old world wisdom. New world classroom.</p>
-                  <p className="mt-2 text-sm text-gray-500 sm:text-base">
-                    Select a historical guide, continue a quest, or review your mastery.
-                  </p>
+                  <div className="flex items-center gap-4 rounded-3xl border border-gray-800/80 bg-gray-900/60 px-4 py-3 shadow-xl backdrop-blur-sm">
+                    <button
+                      type="button"
+                      onClick={() => setIsSidebarOpen(true)}
+                      className="shrink-0 rounded-full border border-amber-400/60 bg-amber-500/10 px-4 py-2 text-sm font-semibold uppercase tracking-wide text-amber-200 transition hover:bg-amber-500/20"
+                      aria-label="Open navigation menu"
+                    >
+                      Menu
+                    </button>
+                    <span className="flex-1 text-center text-sm font-semibold uppercase tracking-[0.35em] text-amber-200">
+                      School of the Ancients
+                    </span>
+                  </div>
                 </div>
-                {renderAccountSection('sm:flex flex-col items-end gap-2 text-right', 'right')}
               </div>
-            </div>
+
+              <div className="hidden sm:block">
+                <div className="rounded-3xl border border-gray-800/80 bg-gray-900/60 p-6 shadow-xl backdrop-blur-sm sm:flex sm:items-center sm:justify-between sm:gap-6">
+                  <div className="text-center sm:text-left">
+                    <h1
+                      className="text-3xl font-bold tracking-wider text-amber-300 sm:text-4xl md:text-5xl"
+                      style={{ textShadow: '0 0 12px rgba(252, 211, 77, 0.45)' }}
+                    >
+                      School of the Ancients
+                    </h1>
+                    <p className="mt-3 text-base text-gray-400 sm:text-lg">Old world wisdom. New world classroom.</p>
+                    <p className="mt-2 text-sm text-gray-500 sm:text-base">
+                      Select a historical guide, continue a quest, or review your mastery.
+                    </p>
+                  </div>
+                  {renderAccountSection('sm:flex flex-col items-end gap-2 text-right', 'right')}
+                </div>
+              </div>
           </header>
 
           <main className="flex flex-1 flex-col gap-6 lg:flex-row">


### PR DESCRIPTION
## Summary
- ensure the mobile header banner remains sticky with safe-area padding
- preserve menu styling while keeping desktop header unchanged

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4c2550f2c832f96769d5600728667