### PR TITLE
fix: keep mobile header accessible while scrolling

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1159,64 +1159,66 @@ const App: React.FC = () => {
           style={{ background: environmentImageUrl ? 'transparent' : 'linear-gradient(to bottom right, #1a1a1a, #232323)' }}
         >
           <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8">
-            <header className="space-y-4">
-            <div className="sticky top-0 z-30 -mx-4 bg-[#1a1a1a]/90 px-4 pb-4 pt-2 backdrop-blur-sm sm:hidden">
-              <div className="flex items-center gap-4 rounded-3xl border border-gray-800/80 bg-gray-900/60 px-4 py-3 shadow-xl backdrop-blur-sm">
-                <button
-                  type="button"
-                  onClick={() => setIsSidebarOpen(true)}
-                  className="shrink-0 rounded-full border border-amber-400/60 bg-amber-500/10 px-4 py-2 text-sm font-semibold uppercase tracking-wide text-amber-200 transition hover:bg-amber-500/20"
-                  aria-label="Open navigation menu"
-                >
-                  Menu
-                </button>
-                <span className="flex-1 text-center text-sm font-semibold uppercase tracking-[0.35em] text-amber-200">
-                  School of the Ancients
-                </span>
-              </div>
-            </div>
-
-            <div className="hidden sm:block">
-              <div className="rounded-3xl border border-gray-800/80 bg-gray-900/60 p-6 shadow-xl backdrop-blur-sm sm:flex sm:items-center sm:justify-between sm:gap-6">
-                <div className="text-center sm:text-left">
-                  <h1
-                    className="text-3xl font-bold tracking-wider text-amber-300 sm:text-4xl md:text-5xl"
-                    style={{ textShadow: '0 0 12px rgba(252, 211, 77, 0.45)' }}
+            <header
+              className="sticky top-6 z-40 space-y-4 sm:static sm:top-auto"
+              style={{ top: 'calc(env(safe-area-inset-top, 0px) + 1.5rem)' }}
+            >
+              <div className="-mx-4 bg-[#1a1a1a]/90 px-4 pb-4 pt-2 backdrop-blur-sm sm:hidden">
+                <div className="flex items-center gap-4 rounded-3xl border border-gray-800/80 bg-gray-900/60 px-4 py-3 shadow-xl backdrop-blur-sm">
+                  <button
+                    type="button"
+                    onClick={() => setIsSidebarOpen(true)}
+                    className="shrink-0 rounded-full border border-amber-400/60 bg-amber-500/10 px-4 py-2 text-sm font-semibold uppercase tracking-wide text-amber-200 transition hover:bg-amber-500/20"
+                    aria-label="Open navigation menu"
                   >
+                    Menu
+                  </button>
+                  <span className="flex-1 text-center text-sm font-semibold uppercase tracking-[0.35em] text-amber-200">
                     School of the Ancients
-                  </h1>
-                  <p className="mt-3 text-base text-gray-400 sm:text-lg">Old world wisdom. New world classroom.</p>
-                  <p className="mt-2 text-sm text-gray-500 sm:text-base">
-                    Select a historical guide, continue a quest, or review your mastery.
-                  </p>
+                  </span>
                 </div>
-                {renderAccountSection('sm:flex flex-col items-end gap-2 text-right', 'right')}
               </div>
-            </div>
-          </header>
 
-          <main className="flex flex-1 flex-col gap-6 lg:flex-row">
-            <Sidebar
-              recentConversations={recentConversations}
-              onSelectConversation={handleResumeConversation}
-              onCreateAncient={openCharacterCreatorView}
-              onOpenHistory={openHistoryView}
-              onOpenProfile={openProfileView}
-              onOpenSettings={openSettingsView}
-              onOpenQuests={openQuestsView}
-              currentView={currentView}
-              isAuthenticated={isAuthenticated}
-              userEmail={userEmail}
-              className="hidden lg:flex lg:sticky lg:top-6 lg:max-h-[calc(100vh-6rem)] lg:flex-col"
-            />
-            <div className="flex-1">
-              <div className="flex h-full flex-col overflow-hidden rounded-3xl border border-gray-800/80 bg-gray-900/70 shadow-2xl backdrop-blur-sm">
-                <ScrollToTop />
-                <div
-                  className="h-full overflow-y-auto p-4 sm:p-6 lg:p-8"
-                  data-app-scroll-container
-                >
-                  <Routes>
+              <div className="hidden sm:block">
+                <div className="rounded-3xl border border-gray-800/80 bg-gray-900/60 p-6 shadow-xl backdrop-blur-sm sm:flex sm:items-center sm:justify-between sm:gap-6">
+                  <div className="text-center sm:text-left">
+                    <h1
+                      className="text-3xl font-bold tracking-wider text-amber-300 sm:text-4xl md:text-5xl"
+                      style={{ textShadow: '0 0 12px rgba(252, 211, 77, 0.45)' }}
+                    >
+                      School of the Ancients
+                    </h1>
+                    <p className="mt-3 text-base text-gray-400 sm:text-lg">Old world wisdom. New world classroom.</p>
+                    <p className="mt-2 text-sm text-gray-500 sm:text-base">
+                      Select a historical guide, continue a quest, or review your mastery.
+                    </p>
+                  </div>
+                  {renderAccountSection('sm:flex flex-col items-end gap-2 text-right', 'right')}
+                </div>
+              </div>
+            </header>
+            <main className="flex flex-1 flex-col gap-6 lg:flex-row">
+              <Sidebar
+                recentConversations={recentConversations}
+                onSelectConversation={handleResumeConversation}
+                onCreateAncient={openCharacterCreatorView}
+                onOpenHistory={openHistoryView}
+                onOpenProfile={openProfileView}
+                onOpenSettings={openSettingsView}
+                onOpenQuests={openQuestsView}
+                currentView={currentView}
+                isAuthenticated={isAuthenticated}
+                userEmail={userEmail}
+                className="hidden lg:flex lg:sticky lg:top-6 lg:max-h-[calc(100vh-6rem)] lg:flex-col"
+              />
+              <div className="flex-1">
+                <div className="flex h-full flex-col overflow-hidden rounded-3xl border border-gray-800/80 bg-gray-900/70 shadow-2xl backdrop-blur-sm">
+                  <ScrollToTop />
+                  <div
+                    className="h-full overflow-y-auto p-4 sm:p-6 lg:p-8"
+                    data-app-scroll-container
+                  >
+                    <Routes>
               <Route
                 path="/"
                 element={
@@ -1499,7 +1501,7 @@ const App: React.FC = () => {
                 </div>
               </div>
             </div>
-          </main>
+            </main>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- make the mobile header container sticky on small screens so the menu stays visible while scrolling
- preserve the desktop layout and backdrop styling while accounting for safe area insets on mobile devices

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e4c2550f2c832f96769d5600728667