### PR TITLE
Refresh README with documentation map and roadmap context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,102 +1,160 @@
-# 📚 School of the Ancients 
+# 📚 School of the Ancients
 
-> *Old world wisdom. New world classroom.*  
-> An open-source **Living Educational Operating System** that merges ancient philosophy with modern AI to create a personalized, adaptive, and Socratic learning experience.
+> *Old world wisdom. New world classroom.*
+> An open-source **Living Educational Operating System** where ancient pedagogy meets adaptive AI mentors.
 
 ![School of the Ancients screenshot](sota-beta.png)
 
 ---
 
-## 🏛️ Overview
+## 📑 Table of Contents
 
-School of the Ancients (SotA) revives the timeless methods of learning — dialogue, mentorship, reflection — and reimagines them for the AI age.  
-Students don’t consume lessons. They *create quests*, summon *mentors*, and engage in *Socratic conversations* that grow their understanding over time.
-
-Every curiosity becomes a course.  
-Every learner builds their own academy.
-
----
-
-## ✨ Key Features
-
-| Feature | Description |
-|----------|-------------|
-| **Find Your Goal** | Reflective dialogue to uncover each learner’s purpose before learning begins. |
-| **Dynamic Quests** | Personalized quests created from any learning goal. |
-| **AI Mentors** | Historically inspired AI teachers who guide students through Socratic dialogue. |
-| **Socratic Dialogue Engine** | A question-based learning model that evaluates understanding in real time. |
-| **Questsmith & Mentor Kernel** | Systems that generate new quests and mentors dynamically. |
-| **Career Pathfinder** | Analyzes all learning to propose meaningful career directions and next-step skills. |
-| **Living Curriculum** | Each learner’s path evolves from their own curiosity and reflections. |
+- [Project Overview](#-project-overview)
+- [Feature Pillars](#-feature-pillars)
+- [Learning Loop & System Architecture](#-learning-loop--system-architecture)
+- [Tech Stack](#-tech-stack)
+- [Documentation Map](#-documentation-map)
+- [Roadmap Snapshot](#-roadmap-snapshot)
+- [Getting Started](#-getting-started)
+- [Development & Testing](#-development--testing)
+- [Contributing](#-contributing)
+- [Vision](#-vision)
 
 ---
 
-## 🧠 Architecture Overview
+## 🏛️ Project Overview
 
-The system operates as a **living loop** of learning:
+School of the Ancients (SotA) revives timeless methods of learning—dialogue, mentorship, reflection—and rebuilds them for the AI age. Learners don’t scroll through static lessons; they declare goals, generate quests, and converse with historically inspired mentors who guide them through Socratic inquiry, reflection, and mastery.【F:docs/MANIFESTO.md†L3-L63】【F:docs/SOTA_CORE_GOAL.md†L3-L44】
+
+The result is a **Living Educational Operating System**: a regenerative environment where every curiosity becomes a course and every learner grows their own academy.【F:docs/LIVING_EDUCATIONAL_OS.md†L3-L61】
+
+---
+
+## ✨ Feature Pillars
+
+| Pillar | What it unlocks |
+| --- | --- |
+| **Find Your Goal** | A reflective prelude that anchors every quest in personal meaning before instruction begins.【F:docs/MANIFESTO.md†L65-L87】 |
+| **Questsmith Engine** | Converts learner goals into structured quests with objectives, sections, and suggested assessments.【F:docs/quests/QUEST_FLOW.md†L1-L55】 |
+| **AI Mentors** | Persona-driven teachers who inherit methods from Socrates, Ada Lovelace, Confucius, and more to probe understanding through dialogue.【F:docs/SOTA_MISSION_STATEMENT.md†L1-L35】 |
+| **Socratic Dialogue Runtime** | A question-first engine that refuses to hand over answers until reasoning is demonstrated, mirroring ancient dialectic.【F:docs/SOTA_CORE_GOAL.md†L19-L44】 |
+| **Living Curriculum & Progress** | Adaptive quests, mastery tracking, and badges recomputed from canonical progress data—no stale counters.【F:docs/quests/PROGRESS_MODEL.md†L1-L74】 |
+| **Career Pathfinder** | Synthesizes the learner’s trail of quests, mentors, and mastery into career directions and targeted next steps.【F:docs/CAREER_PATHFINDER.md†L1-L92】 |
+
+---
+
+## 🧠 Learning Loop & System Architecture
+
+The product operates as a living loop of learning:
 
 ```
-Find Goal → Create Quest → Summon Mentor → Dialogue → Reflect → Assess → Next Quest
+Find Goal → Create Quest → Socratic Dialogue → Reflection → Quiz → Next Quest
 ```
 
-### Core Modules
-- `CharacterCreator.tsx` – AI Mentor Generator  
-- `QuestCreator.tsx` – Questsmith Engine  
-- `ConversationView.tsx` – Socratic Dialogue Runtime  
-- `QuestQuiz.tsx` – Assessment & Mastery Engine  
-- `HistoryView.tsx` – Reflection Archive  
-- `CareerRoute.tsx` – Career Pathfinder (in development)
+This loop is captured in the quest state machine—draft, in-progress, reflection, quiz, complete/needs review—ensuring every journey ends with either mastery or a targeted remediation plan.【F:docs/quests/QUEST_FLOW.md†L9-L80】
+
+### Core Runtime Modules
+
+- **Mentor Kernel:** `components/CharacterCreator.tsx` for generating mentors and assigning ambient context.
+- **Quest Engine:** `components/QuestCreator.tsx` and `components/QuestsView.tsx` for structuring objectives and active missions.
+- **Dialogue Runtime:** `components/ConversationView.tsx` paired with `hooks/useGeminiLive.ts` for live Socratic exchanges, visuals, and voice.
+- **Assessment Subsystem:** `components/QuestQuiz.tsx` implements the mastery quiz contract with configurable pass gates.【F:docs/quests/QUIZ_MVP_SPEC.md†L1-L92】
+- **Progress & Memory:** Supabase-backed providers keep quests, badges, and conversation history in sync across devices.【F:docs/quests/PROGRESS_MODEL.md†L41-L116】【F:docs/completed/ACCOUNT_PERSISTENCE_FOUNDATION.md†L1-L110】
+- **Career Pathfinder (in development):** `CareerRoute.tsx` surfaces emerging career trajectories informed by the learning trail.【F:docs/CAREER_PATHFINDER.md†L1-L158】
+
+### Operating System Layers
+
+The stack mirrors an OS: UI, mentor kernel, quest engine, dialogue runtime, assessment subsystem, memory/persistence, and evolution loop, all orchestrated to regenerate learning experiences dynamically.【F:docs/LIVING_EDUCATIONAL_OS.md†L27-L74】
+
+### The Learning Method
+
+SotA’s loop parallels the scientific method—observation, hypothesis, experimentation, analysis, and replication—treating education as a continuous experiment in wisdom for humans and AI alike.【F:docs/LEARNING_METHOD.md†L1-L64】
 
 ---
 
 ## ⚙️ Tech Stack
 
 | Layer | Tools |
-|--------|-------|
-| **Frontend** | React, Tailwind, Vite |
-| **AI Integration** | Google Gemini (2.5 Flash / Imagen 4.0) |
-| **Backend** | Supabase (Auth, DB, Storage) |
-| **Data Storage** | Encrypted local storage + cloud sync supabase |
-| **Environment Engine** | Imagen 4.0 for visual scenes + ambient audio |
-| **Voice** | Gemini Live + custom hooks (`useGeminiLive`, `useAmbientAudio`) |
+| --- | --- |
+| **Frontend** | React 19, Vite, Tailwind CSS |
+| **AI Integration** | Google Gemini (2.5 Flash, Gemini Live, Imagen 4) via `@google/genai` |
+| **Persistence** | Supabase Auth + Postgres JSON storage with offline-friendly local storage fallback |
+| **Audio & Voice** | Gemini Live streaming voice plus custom ambient soundscapes managed by `useGeminiLive` and `useAmbientAudio` |
+| **Build & Test** | TypeScript, Vitest, React Testing Library |
+
+Environment configuration requires `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` for authentication-backed persistence; without them the app gracefully falls back to local state.【F:docs/completed/ACCOUNT_PERSISTENCE_FOUNDATION.md†L96-L139】【F:supabaseClient.ts†L3-L21】
 
 ---
 
-## 📁 Documentation Index
+## 📁 Documentation Map
 
-| File | Purpose |
-|------|----------|
-| [`MANIFESTO.md`](./docs/MANIFESTO.md) | The philosophical foundation — “A Living Educational OS.” |
-| [`SOTA_CORE_GOAL.md`](./docs/SOTA_CORE_GOAL.md) | Defines SotA’s goal, problems solved, and unique value. |
-| [`SOTA_MISSION_STATEMENT.md`](./docs/SOTA_MISSION_STATEMENT.md) | Mission, solution, and vision overview. |
-| [`LIVING_EDUCATIONAL_OS.md`](./docs/LIVING_EDUCATIONAL_OS.md) | Explains SotA as a Living Operating System for learning. |
-| [`CAREER_PATHFINDER.md`](./docs/CAREER_PATHFINDER.md) | Translates learning data into ideal careers and next-step quests. |
-| [`LEARNING_METHOD.md`](./docs/LEARNING_METHOD.md) | Connects SotA to the scientific method — learning as experimentation. |
-| [`ROADMAP.md`](./docs/ROADMAP.md) | Implementation timeline and version goals. | 
+All product specs live in [`docs/`](docs/README.md). Start there for orientation and acceptance criteria before picking up an issue.【F:docs/README.md†L1-L42】 Key references include:
 
+- **Vision & Philosophy:** [`MANIFESTO.md`](docs/MANIFESTO.md), [`SOTA_CORE_GOAL.md`](docs/SOTA_CORE_GOAL.md), [`SOTA_MISSION_STATEMENT.md`](docs/SOTA_MISSION_STATEMENT.md).
+- **System Definition:** [`LIVING_EDUCATIONAL_OS.md`](docs/LIVING_EDUCATIONAL_OS.md), [`LEARNING_METHOD.md`](docs/LEARNING_METHOD.md).
+- **Product Loops:** [`quests/QUEST_FLOW.md`](docs/quests/QUEST_FLOW.md), [`quests/PROGRESS_MODEL.md`](docs/quests/PROGRESS_MODEL.md), [`quests/QUIZ_MVP_SPEC.md`](docs/quests/QUIZ_MVP_SPEC.md).
+- **Feature Specs:** [`CAREER_PATHFINDER.md`](docs/CAREER_PATHFINDER.md) and completed implementation notes such as [`docs/completed/implementation.md`](docs/completed/implementation.md) and [`docs/completed/ACCOUNT_PERSISTENCE_FOUNDATION.md`](docs/completed/ACCOUNT_PERSISTENCE_FOUNDATION.md).
+- **Delivery Process:** [`ISSUE_PRIORITIZATION.md`](docs/ISSUE_PRIORITIZATION.md) for sequencing major initiatives.
 
----
-
-## 🜂 Core Philosophy
-
-> **Education should not end with answers.**  
-> It should begin with better questions.
-
-SotA returns learning to its ancient roots — curiosity, conversation, and character — while giving every student a personal mentor, unique curriculum, and infinite room to grow.
+If you add a new capability, place the spec in `docs/` and link it from the docs README to keep the library authoritative.【F:docs/README.md†L12-L40】
 
 ---
 
-## 🌍 Contribute
+## 🗺️ Roadmap Snapshot
 
-- Fork the repo: `github.com/School-of-the-Ancients/sota-beta`  
-- Join discussions under **Issues → Philosophy or Product Ideas.**  
-- Share reflections, prompts, or new mentor templates.
+We are currently targeting the **Beta Stabilization** milestone: tighten quest completion, progress counters, suggestion cadence, and ship the quiz MVP. Subsequent milestones unlock authenticated sync (MVP v0.1) and a post-MVP backlog of multi-mentor curricula, content sharing, and richer media experiences.【F:docs/ROADMAP.md†L1-L126】
+
+Follow issue prioritization to see how roadmap goals map to GitHub tasks and phases (auth & persistence, curriculum intelligence, content ecosystem, experience enhancements).【F:docs/ISSUE_PRIORITIZATION.md†L1-L104】
+
+---
+
+## 🚀 Getting Started
+
+1. **Clone & Install**
+   ```bash
+   git clone https://github.com/School-of-the-Ancients/sota-beta.git
+   cd sota-beta
+   npm install
+   ```
+2. **Configure Environment**
+   - Copy `.env.example` → `.env` (create if missing) and set:
+     - `VITE_SUPABASE_URL`
+     - `VITE_SUPABASE_ANON_KEY`
+   - Launch the app without these to explore locally using in-browser storage, or add credentials to enable Supabase auth and syncing.【F:supabaseClient.ts†L3-L21】
+   - Provide your Gemini API key via the in-app Settings dialog to enable live mentors, audio, and visual generation.
+3. **Run the Dev Server**
+   ```bash
+   npm run dev
+   ```
+   Visit [http://localhost:3000](http://localhost:3000) and sign in to persist quests across devices.
+
+---
+
+## 🧪 Development & Testing
+
+- Run the Vitest suite with:
+  ```bash
+  npm run test
+  ```
+- Build for production with `npm run build`, and preview the static bundle via `npm run preview`.
+- Follow the quest flow acceptance criteria when testing manually: every quest must reach **COMPLETE** or **NEEDS_REVIEW**, suggestions appear only at section boundaries, and quiz results persist across reloads.【F:docs/quests/QUEST_FLOW.md†L57-L114】【F:docs/quests/QUIZ_MVP_SPEC.md†L73-L128】
+
+---
+
+## 🤝 Contributing
+
+1. Read the relevant spec(s) in `docs/` to understand behavior, data models, and acceptance criteria.【F:docs/README.md†L23-L39】
+2. Claim or open an issue with clear acceptance criteria and roadmap alignment.【F:docs/ISSUE_PRIORITIZATION.md†L5-L104】
+3. Land the smallest valuable slice, update docs when behavior changes, and include screenshots or demos for UX tweaks.
+4. Use Conventional Commits and reference issues in PRs; follow the repository’s PR template and testing expectations in `AGENTS.md`.
+
+Share reflections, new mentor templates, or quest ideas to help the academy evolve. Contributions spanning philosophy, pedagogy, engineering, audio, and visual design are all welcome.
 
 ---
 
 ## 🧭 Vision
 
-To build a **universal academy of wisdom** — where every human and AI can learn, reflect, and evolve through dialogue.
+Our north star is a **universal academy of wisdom**—a place where humans and AIs learn through infinite dialogue, grounded in ancient virtue and accelerated by modern intelligence.【F:docs/MANIFESTO.md†L89-L118】【F:docs/SOTA_MISSION_STATEMENT.md†L49-L60】
 
 > *Learning, like the soul, should be infinite.*
 


### PR DESCRIPTION
## Summary
- expand the README with a table of contents, updated overview, and feature pillars tied to the living educational OS concept
- document the learning loop, core runtime modules, and environment requirements surfaced across the existing specs
- map contributors to the roadmap and docs library so new collaborators can find specs, priorities, and onboarding steps quickly

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ed623d28a0832f81396169060decc0