### PR TITLE
feat: use gemini-2.5-flash-image for image generation

### DIFF
--- a/components/CharacterCreator.tsx
+++ b/components/CharacterCreator.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useRef, useState } from 'react';
 import { GoogleGenAI, Type } from '@google/genai';
+import { extractInlineImageData } from '@/src/lib/geminiImage';
 import type { Character, PersonaData } from '../types';
 import { AMBIENCE_LIBRARY, AVAILABLE_VOICES } from '../constants';
 import { HISTORICAL_FIGURES_SUGGESTIONS } from '../suggestions';
@@ -190,18 +191,12 @@ If you are not at least 80% confident in their historicity, set verified to fals
       let portraitUrl = makeFallbackAvatar(clean, persona.title);
       try {
         setMsg('Painting portrait…');
-        const imgResp = await ai.models.generateImages({
-          model: 'gemini-2.5-flash-preview-image',
-          prompt: `A realistic, academic portrait of ${clean}, ${persona.title}. Dignified, historical lighting, 1:1, museum catalogue style.`,
-          config: { numberOfImages: 1, outputMimeType: 'image/jpeg', aspectRatio: '1:1' },
+        const imgResp = await ai.models.generateContent({
+          model: 'gemini-2.5-flash-image',
+          contents: `A realistic, academic portrait of ${clean}, ${persona.title}. Dignified, historical lighting, 1:1, museum catalogue style.`,
         });
 
-        const maybe = (imgResp as any)?.generatedImages?.[0];
-        const bytes =
-          maybe?.image?.imageBytes ??
-          (maybe as any)?.b64Json ??
-          (maybe as any)?.content?.image?.imageBytes;
-
+        const bytes = extractInlineImageData(imgResp);
         if (bytes) {
           portraitUrl = `data:image/jpeg;base64,${bytes}`;
         } else {

--- a/components/ConversationView.tsx
+++ b/components/ConversationView.tsx
@@ -13,6 +13,7 @@ import SendIcon from './icons/SendIcon';
 import MuteIcon from './icons/MuteIcon';
 import UnmuteIcon from './icons/UnmuteIcon';
 import { useApiKey } from '../hooks/useApiKey';
+import { extractInlineImageData } from '@/src/lib/geminiImage';
 
 interface ConversationViewProps {
   character: Character;
@@ -270,10 +271,9 @@ const ConversationView: React.FC<ConversationViewProps> = ({
       if (!apiKey) throw new Error('Missing API key');
       const ai = new GoogleGenAI({ apiKey });
       
-      const imagePromise = ai.models.generateImages({
+      const imagePromise = ai.models.generateContent({
         model: 'gemini-2.5-flash-image',
-        prompt: `A photorealistic, atmospheric, wide-angle background of: ${description}, depicted authentically for the era of ${character.name} (${character.timeframe}). Cinematic and dramatic lighting. The scene should be evocative and immersive, without people or text.`,
-        config: { numberOfImages: 1, outputMimeType: 'image/jpeg', aspectRatio: '16:9' },
+        contents: `A photorealistic, atmospheric, wide-angle background of: ${description}, depicted authentically for the era of ${character.name} (${character.timeframe}). Cinematic and dramatic lighting. The scene should be evocative and immersive, without people or text.`,
       });
 
       const availableTags = AMBIENCE_LIBRARY.map(a => a.tag).join(', ');
@@ -290,8 +290,9 @@ const ConversationView: React.FC<ConversationViewProps> = ({
         changeAmbienceTrack(newAudioSrc);
       }
       
-      if (imageResponse.generatedImages && imageResponse.generatedImages.length > 0) {
-        const url = `data:image/jpeg;base64,${imageResponse.generatedImages[0].image.imageBytes}`;
+      const imageBytes = extractInlineImageData(imageResponse);
+      if (imageBytes) {
+        const url = `data:image/jpeg;base64,${imageBytes}`;
         onEnvironmentUpdate(url);
         setTranscript(prev => prev.map(turn => {
           if (turn.artifact?.id === environmentArtifactId) {
@@ -352,14 +353,14 @@ const ConversationView: React.FC<ConversationViewProps> = ({
     try {
         if (!apiKey) throw new Error('Missing API key');
         const ai = new GoogleGenAI({ apiKey });
-        const response = await ai.models.generateImages({
+        const response = await ai.models.generateContent({
             model: 'gemini-2.5-flash-image',
-            prompt: `A detailed, clear image of: a "${name}". ${description}. The artifact should be rendered in a style authentic to ${character.name}'s era and work (e.g., a da Vinci sketch, a 19th-century diagram, a classical Greek sculpture). Present it on a simple, non-distracting background like aged parchment or a museum display.`,
-            config: { numberOfImages: 1, outputMimeType: 'image/jpeg', aspectRatio: '4:3' },
+            contents: `A detailed, clear image of: a "${name}". ${description}. The artifact should be rendered in a style authentic to ${character.name}'s era and work (e.g., a da Vinci sketch, a 19th-century diagram, a classical Greek sculpture). Present it on a simple, non-distracting background like aged parchment or a museum display.`,
         });
 
-        if (response.generatedImages && response.generatedImages.length > 0) {
-            const url = `data:image/jpeg;base64,${response.generatedImages[0].image.imageBytes}`;
+        const imageBytes = extractInlineImageData(response);
+        if (imageBytes) {
+            const url = `data:image/jpeg;base64,${imageBytes}`;
             setTranscript(prev => prev.map(turn => {
                 if (turn.artifact?.id === artifactId) {
                     return { ...turn, text: name, artifact: { ...turn.artifact, imageUrl: url, loading: false } };

--- a/components/QuestCreator.tsx
+++ b/components/QuestCreator.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { GoogleGenAI, Type } from '@google/genai';
+import { extractInlineImageData } from '@/src/lib/geminiImage';
 import type { Character, PersonaData, Quest } from '../types';
 import { AMBIENCE_LIBRARY, AVAILABLE_VOICES } from '../constants';
 import { useApiKey } from '../hooks/useApiKey';
@@ -135,18 +136,12 @@ const QuestCreator: React.FC<QuestCreatorProps> = ({
     // --- SAFE portrait generation with fallback ---
     let portraitUrl = makeFallbackAvatar(name, persona.title);
     try {
-      const imgResp = await ai.models.generateImages({
-        model: 'gemini-2.5-flash-preview-image',
-        prompt: `A realistic, academic portrait of ${name}, ${persona.title}. Dignified, historical lighting, 1:1, museum catalogue style.`,
-        config: { numberOfImages: 1, outputMimeType: 'image/jpeg', aspectRatio: '1:1' },
+      const imgResp = await ai.models.generateContent({
+        model: 'gemini-2.5-flash-image',
+        contents: `A realistic, academic portrait of ${name}, ${persona.title}. Dignified, historical lighting, 1:1, museum catalogue style.`,
       });
 
-      const maybe = (imgResp as any)?.generatedImages?.[0];
-      const bytes =
-        maybe?.image?.imageBytes ??
-        (maybe as any)?.b64Json ??
-        (maybe as any)?.content?.image?.imageBytes;
-
+      const bytes = extractInlineImageData(imgResp);
       if (bytes) {
         portraitUrl = `data:image/jpeg;base64,${bytes}`;
       } else {

--- a/src/lib/geminiImage.ts
+++ b/src/lib/geminiImage.ts
@@ -1,0 +1,18 @@
+export const extractInlineImageData = (response: any): string | null => {
+  const parts = response?.candidates?.[0]?.content?.parts;
+  if (Array.isArray(parts)) {
+    for (const part of parts) {
+      const inlineData = part?.inlineData?.data;
+      if (inlineData) {
+        return inlineData;
+      }
+    }
+  }
+
+  const legacyBytes = response?.generatedImages?.[0]?.image?.imageBytes;
+  if (legacyBytes) {
+    return legacyBytes;
+  }
+
+  return null;
+};


### PR DESCRIPTION
### Motivation
- Migrate image generation from the previous `generateImages`/preview model to Gemini Flash image model `gemini-2.5-flash-image` which returns inline image data.
- Ensure environment, artifact, and portrait generation consume the new response shape and continue to produce `data:image/jpeg;base64,...` URLs for the UI.
- Centralize inline/base64 extraction so multiple components can handle both the new inline-data and legacy bytes formats.
- Preserve existing UI fallbacks and error handling when image bytes are not returned.

### Description
- Replaced image generation calls to use `ai.models.generateContent` with `model: 'gemini-2.5-flash-image'` for environment and artifact generation in `components/ConversationView.tsx`.
- Switched portrait generation in `components/CharacterCreator.tsx` and `components/QuestCreator.tsx` to call `generateContent` with `gemini-2.5-flash-image` and updated prompts accordingly.
- Added helper `src/lib/geminiImage.ts` implementing `extractInlineImageData` to pull inline image bytes from the new flash responses while falling back to legacy `generatedImages[0].image.imageBytes`.
- Updated components to import and use `extractInlineImageData` and to continue building `data:image/jpeg;base64,` URLs and to keep existing fallback avatars and error messages.

### Testing
- No automated tests were run against these changes (the Vitest suite was not executed).
- Manual runtime verification is recommended with a valid `GEMINI_API_KEY` to ensure image bytes are returned and displayed correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69621d0dc3a8832fb5f1ca3852d3473c)