### PR TITLE
Add local-only auth fallback and Supabase offline handling

### DIFF
--- a/components/AuthModal.tsx
+++ b/components/AuthModal.tsx
@@ -50,14 +50,10 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, prompt, onClose }) => {
     return null;
   }
 
-  const disabled = !isConfigured || isSubmitting;
+  const disabled = isSubmitting;
 
   const handleEmailSubmit: React.FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault();
-    if (!isConfigured) {
-      setError('Authentication is not configured. Provide Supabase credentials to enable sign in.');
-      return;
-    }
     if (!email.trim() || !password) {
       setError('Enter both email and password.');
       return;
@@ -87,7 +83,7 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, prompt, onClose }) => {
 
   const handleGoogleClick = async () => {
     if (!isConfigured) {
-      setError('Authentication is not configured. Provide Supabase credentials to enable sign in.');
+      setError('Authentication is currently unavailable. Check Supabase credentials and project status.');
       return;
     }
     setIsSubmitting(true);
@@ -129,7 +125,7 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, prompt, onClose }) => {
 
         {!isConfigured && (
           <p className="mt-4 rounded-md border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">
-            Authentication is not configured. Provide VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to enable sign in.
+            Supabase auth is unavailable. Email sign-in works in local-only mode (this browser only); Google sign-in is disabled.
           </p>
         )}
 
@@ -193,7 +189,7 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, prompt, onClose }) => {
           type="button"
           onClick={handleGoogleClick}
           className="mt-4 flex w-full items-center justify-center gap-2 rounded-md border border-amber-500/40 px-4 py-2 text-sm font-semibold text-amber-100 transition hover:bg-amber-500/10 disabled:cursor-not-allowed disabled:opacity-60"
-          disabled={disabled}
+          disabled={disabled || !isConfigured}
         >
           Continue with Google
         </button>

--- a/hooks/useSupabaseAuth.tsx
+++ b/hooks/useSupabaseAuth.tsx
@@ -12,6 +12,7 @@ interface SupabaseAuthContextValue {
   session: Session | null;
   loading: boolean;
   isConfigured: boolean;
+  isLocalAuth: boolean;
   signInWithGoogle: () => Promise<void>;
   signInWithPassword: (email: string, password: string) => Promise<EmailAuthResult>;
   signUpWithPassword: (email: string, password: string) => Promise<EmailAuthResult>;
@@ -21,9 +22,26 @@ interface SupabaseAuthContextValue {
 const SupabaseAuthContext = createContext<SupabaseAuthContextValue | undefined>(undefined);
 
 export const SupabaseAuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const isConfigured = Boolean(supabase);
+  const [isAvailable, setIsAvailable] = useState(true);
+  const isConfigured = Boolean(supabase) && isAvailable;
   const [session, setSession] = useState<Session | null>(null);
+  const [localUser, setLocalUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem('sota-local-auth-user');
+      if (!saved) {
+        return;
+      }
+      const parsed = JSON.parse(saved) as { id?: string; email?: string };
+      if (parsed?.id && parsed?.email) {
+        setLocalUser({ id: parsed.id, email: parsed.email } as User);
+      }
+    } catch (_error) {
+      // ignore malformed local auth payload
+    }
+  }, []);
 
   useEffect(() => {
     if (!supabase) {
@@ -33,16 +51,25 @@ export const SupabaseAuthProvider: React.FC<{ children: React.ReactNode }> = ({ 
 
     let cancelled = false;
 
-    supabase.auth
-      .getSession()
+    const getSessionWithTimeout = Promise.race([
+      supabase.auth.getSession(),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('Supabase auth request timed out.')), 3500);
+      }),
+    ]);
+
+    getSessionWithTimeout
       .then(({ data }) => {
         if (!cancelled) {
           setSession(data.session ?? null);
+          setIsAvailable(true);
           setLoading(false);
         }
       })
       .catch(() => {
         if (!cancelled) {
+          setSession(null);
+          setIsAvailable(false);
           setLoading(false);
         }
       });
@@ -58,8 +85,8 @@ export const SupabaseAuthProvider: React.FC<{ children: React.ReactNode }> = ({ 
   }, []);
 
   const signInWithGoogle = useCallback(async () => {
-    if (!supabase) {
-      throw new Error('Supabase is not configured. Provide VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to enable authentication.');
+    if (!supabase || !isAvailable) {
+      throw new Error('Google sign in is unavailable while Supabase is offline. Use email sign in for local access.');
     }
 
     const { error } = await supabase.auth.signInWithOAuth({
@@ -72,11 +99,17 @@ export const SupabaseAuthProvider: React.FC<{ children: React.ReactNode }> = ({ 
     if (error) {
       throw error;
     }
-  }, []);
+  }, [isAvailable]);
 
   const signInWithPassword = useCallback(async (email: string, password: string): Promise<EmailAuthResult> => {
-    if (!supabase) {
-      throw new Error('Supabase is not configured. Provide VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to enable authentication.');
+    if (!supabase || !isAvailable) {
+      const fallbackUser = { id: `local-${email.toLowerCase()}`, email: email.toLowerCase() } as User;
+      setLocalUser(fallbackUser);
+      localStorage.setItem('sota-local-auth-user', JSON.stringify({ id: fallbackUser.id, email: fallbackUser.email }));
+      return {
+        user: fallbackUser,
+        session: null,
+      };
     }
 
     const { data, error } = await supabase.auth.signInWithPassword({
@@ -92,11 +125,17 @@ export const SupabaseAuthProvider: React.FC<{ children: React.ReactNode }> = ({ 
       user: data.user,
       session: data.session,
     };
-  }, []);
+  }, [isAvailable]);
 
   const signUpWithPassword = useCallback(async (email: string, password: string): Promise<EmailAuthResult> => {
-    if (!supabase) {
-      throw new Error('Supabase is not configured. Provide VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to enable authentication.');
+    if (!supabase || !isAvailable) {
+      const fallbackUser = { id: `local-${email.toLowerCase()}`, email: email.toLowerCase() } as User;
+      setLocalUser(fallbackUser);
+      localStorage.setItem('sota-local-auth-user', JSON.stringify({ id: fallbackUser.id, email: fallbackUser.email }));
+      return {
+        user: fallbackUser,
+        session: null,
+      };
     }
 
     const { data, error } = await supabase.auth.signUp({
@@ -112,9 +151,11 @@ export const SupabaseAuthProvider: React.FC<{ children: React.ReactNode }> = ({ 
       user: data.user,
       session: data.session,
     };
-  }, []);
+  }, [isAvailable]);
 
   const signOut = useCallback(async () => {
+    setLocalUser(null);
+    localStorage.removeItem('sota-local-auth-user');
     if (!supabase) {
       return;
     }
@@ -127,16 +168,17 @@ export const SupabaseAuthProvider: React.FC<{ children: React.ReactNode }> = ({ 
 
   const value = useMemo(
     () => ({
-      user: session?.user ?? null,
+      user: session?.user ?? localUser,
       session,
       loading,
       isConfigured,
+      isLocalAuth: !session?.user && Boolean(localUser),
       signInWithGoogle,
       signInWithPassword,
       signUpWithPassword,
       signOut,
     }),
-    [session, loading, isConfigured, signInWithGoogle, signInWithPassword, signUpWithPassword, signOut]
+    [session, localUser, loading, isConfigured, signInWithGoogle, signInWithPassword, signUpWithPassword, signOut]
   );
 
   return <SupabaseAuthContext.Provider value={value}>{children}</SupabaseAuthContext.Provider>;

--- a/hooks/useUserData.tsx
+++ b/hooks/useUserData.tsx
@@ -94,7 +94,7 @@ const clearLocalSnapshot = () => {
 };
 
 export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { user } = useSupabaseAuth();
+  const { user, isLocalAuth } = useSupabaseAuth();
   const [data, setData] = useState<UserData>({ ...DEFAULT_USER_DATA });
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -105,7 +105,7 @@ export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 
   const persist = useCallback(
     async (next: UserData) => {
-      if (!user) {
+      if (!user || isLocalAuth) {
         return;
       }
       setSaving(true);
@@ -119,7 +119,7 @@ export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         setSaving(false);
       }
     },
-    [user]
+    [isLocalAuth, user]
   );
 
   const flushPendingPersist = useCallback(async () => {
@@ -140,7 +140,7 @@ export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 
   const schedulePersist = useCallback(
     (next: UserData) => {
-      if (!user) {
+      if (!user || isLocalAuth) {
         pendingPersistRef.current = null;
         if (persistTimeoutRef.current) {
           clearTimeout(persistTimeoutRef.current);
@@ -159,7 +159,7 @@ export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         void flushPendingPersist();
       }, 1500);
     },
-    [flushPendingPersist, user]
+    [flushPendingPersist, isLocalAuth, user]
   );
 
   const migrateFromLocalStorage = useCallback(
@@ -198,7 +198,7 @@ export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   );
 
   const refresh = useCallback(async () => {
-    if (!user) {
+    if (!user || isLocalAuth) {
       setData({ ...DEFAULT_USER_DATA });
       setLoading(false);
       return;
@@ -217,7 +217,7 @@ export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     } finally {
       setLoading(false);
     }
-  }, [migrateFromLocalStorage, user]);
+  }, [isLocalAuth, migrateFromLocalStorage, user]);
 
   useEffect(() => {
     hasMigratedRef.current = false;


### PR DESCRIPTION
### Motivation

- Allow email sign-in to work in a local/browser-only mode when Supabase is unreachable so users can still use the app offline.
- Prevent Google OAuth attempts and remote persistence when Supabase is offline to avoid confusing errors and failed requests.
- Improve UI messaging to reflect Supabase availability status.

### Description

- Add `isAvailable` state and a timeout around `supabase.auth.getSession()` to detect when Supabase auth is unresponsive and mark the service as unavailable.
- Implement a local fallback authentication flow that creates a local user object, stores it under `sota-local-auth-user` in `localStorage`, and exposes `isLocalAuth` from the auth context; `signInWithPassword` and `signUpWithPassword` return a local user when Supabase is unavailable.
- Clear local fallback data on `signOut`, and surface the fallback user as the context `user` when no remote session exists.
- Update `AuthModal` to adjust disabling logic, change error/info messages to reflect Supabase availability, and disable the Google button when Supabase is unavailable.
- Update `UserDataProvider` to skip persistence, migration, and remote data refresh when operating in local auth mode (`isLocalAuth`) to avoid attempts to persist to Supabase.

### Testing

- Ran TypeScript type check with `tsc --noEmit` and it succeeded.
- Ran the existing unit test suite with `npm test` and all tests passed.
- Ran automated linting with `npm run lint` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a137e8a5750832f8133843896435d12)